### PR TITLE
feat: 커뮤니티 화면 구성 및 라우트 분리

### DIFF
--- a/app/(tabs)/community.tsx
+++ b/app/(tabs)/community.tsx
@@ -1,9 +1,0 @@
-import { Text, View } from 'react-native';
-
-export default function CommunityScreen() {
-  return (
-    <View className="flex-1 items-center justify-center bg-fill-normal">
-      <Text className="typo-body-1-normal-regular text-label-normal">커뮤니티</Text>
-    </View>
-  );
-}

--- a/app/(tabs)/community/_layout.tsx
+++ b/app/(tabs)/community/_layout.tsx
@@ -1,0 +1,18 @@
+import { CommunityHeader } from "@/features/community/components/community-header";
+import { CommunityTabBar } from "@/features/community/components/community-tab-bar";
+import { Slot } from "expo-router";
+import React from "react";
+import { View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+export default function CommunityLayout(): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View className="flex-1 bg-fill-normal" style={{ paddingTop: insets.top }}>
+      <CommunityHeader />
+      <CommunityTabBar />
+      <Slot />
+    </View>
+  );
+}

--- a/app/(tabs)/community/free-board.tsx
+++ b/app/(tabs)/community/free-board.tsx
@@ -1,0 +1,6 @@
+import { FreeBoardScreen } from "@/features/community/components/free-board-screen";
+import React from "react";
+
+export default function FreeBoardPage(): React.JSX.Element {
+  return <FreeBoardScreen />;
+}

--- a/app/(tabs)/community/index.tsx
+++ b/app/(tabs)/community/index.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from "expo-router";
+
+export default function CommunityIndex() {
+  return <Redirect href="/community/record-share" />;
+}

--- a/app/(tabs)/community/record-share.tsx
+++ b/app/(tabs)/community/record-share.tsx
@@ -1,0 +1,6 @@
+import { RecordShareScreen } from "@/features/community/components/record-share-screen";
+import React from "react";
+
+export default function RecordSharePage(): React.JSX.Element {
+  return <RecordShareScreen />;
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,10 +1,9 @@
+import { useFonts } from "@expo-google-fonts/lexend";
 import {
   DarkTheme,
   DefaultTheme,
   ThemeProvider,
 } from "@react-navigation/native";
-import { useFonts } from "expo-font";
-import { Lexend_700Bold, useFonts } from "@expo-google-fonts/lexend";
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
@@ -34,7 +33,6 @@ export default function RootLayout() {
   }, [fontsLoaded]);
 
   if (!fontsLoaded) return null;
-  useFonts({ Lexend_700Bold });
 
   return (
     <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>

--- a/features/community/components/community-header.tsx
+++ b/features/community/components/community-header.tsx
@@ -1,0 +1,14 @@
+import { SearchIcon } from "@/components/icons/search-icon";
+import React from "react";
+import { Text, View } from "react-native";
+
+export function CommunityHeader(): React.JSX.Element {
+  return (
+    <View className="h-14 flex-row items-center justify-between bg-fill-normal px-5">
+      <Text className="flex-1 typo-headline-1-semi-bold text-label-normal">
+        커뮤니티
+      </Text>
+      <SearchIcon />
+    </View>
+  );
+}

--- a/features/community/components/community-tab-bar.tsx
+++ b/features/community/components/community-tab-bar.tsx
@@ -1,0 +1,38 @@
+import { Href, usePathname, useRouter } from "expo-router";
+import React from "react";
+import { Pressable, Text, View } from "react-native";
+
+const TABS = [
+  { path: "/community/record-share", label: "기록 공유" },
+  { path: "/community/free-board", label: "자유 게시판" },
+] as const;
+
+export function CommunityTabBar(): React.JSX.Element {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  return (
+    <View className="flex-row border-b border-line-subtle px-2">
+      {TABS.map(({ path, label }) => {
+        const isActive = pathname === path;
+        return (
+          <Pressable
+            key={path}
+            onPress={() => router.push(path as Href)}
+            className={`px-3 py-2 ${isActive ? "border-b-2 border-line-primary" : ""}`}
+          >
+            <Text
+              className={
+                isActive
+                  ? "typo-body-1-normal-semi-bold text-label-normal"
+                  : "typo-body-1-normal-regular text-label-subtler"
+              }
+            >
+              {label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}

--- a/features/community/components/community-tab-bar.tsx
+++ b/features/community/components/community-tab-bar.tsx
@@ -18,14 +18,14 @@ export function CommunityTabBar(): React.JSX.Element {
         return (
           <Pressable
             key={path}
-            onPress={() => router.push(path as Href)}
+            onPress={() => router.replace(path as Href)}
             className={`px-3 py-2 ${isActive ? "border-b-2 border-line-primary" : ""}`}
           >
             <Text
               className={
                 isActive
-                  ? "typo-body-1-normal-semi-bold text-label-normal"
-                  : "typo-body-1-normal-regular text-label-subtler"
+                  ? "text-label-normal typo-body-1-normal-semi-bold"
+                  : "text-label-subtler typo-body-1-normal-regular"
               }
             >
               {label}

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+export function FreeBoardScreen(): React.JSX.Element {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="typo-body-1-normal-regular text-label-subtler">
+        자유 게시판 준비 중
+      </Text>
+    </View>
+  );
+}

--- a/features/community/components/record-share-screen.tsx
+++ b/features/community/components/record-share-screen.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+export function RecordShareScreen(): React.JSX.Element {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text className="typo-body-1-normal-regular text-label-subtler">
+        기록 공유 준비 중
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

- `CommunityHeader`, `CommunityTabBar` 컴포넌트 구현
- `/community/record-share`, `/community/free-board` URL 기반 라우트 분리
- 커뮤니티 레이아웃에 safe area insets 처리 적용
- `_layout.tsx` 중복 import 제거

## ScreenShot

| 헤더 화면 |
| --- |
| <img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/1fbe95c6-c22f-4312-8e6e-d245ac981492" /> |


## Test plan

- [ ] 커뮤니티 탭 진입 시 `/community/record-share`로 리다이렉트 확인
- [ ] 탭 전환 시 URL이 `/community/free-board`로 변경되는지 확인
- [ ] iOS/Android 모두 헤더가 status bar를 침범하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)