### PR TITLE
feat: 커뮤니티 자유게시판 목록 화면 구현

### DIFF
--- a/components/icons/chat-icon.tsx
+++ b/components/icons/chat-icon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+export function ChatIcon({
+  size = 14,
+  color = "#73798c",
+}: {
+  size?: number;
+  color?: string;
+}) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 14 14" fill="none">
+      <Path
+        d="M12.25 6.708a5.292 5.292 0 0 1-.572 2.394A5.375 5.375 0 0 1 6.875 12a5.292 5.292 0 0 1-2.394-.572L1.75 12.25l.822-2.731A5.292 5.292 0 0 1 2 6.708 5.375 5.375 0 0 1 4.898 1.91 5.292 5.292 0 0 1 7.292 1.34H7.5a5.358 5.358 0 0 1 4.75 4.75v.618z"
+        stroke={color}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}

--- a/components/icons/eye-icon.tsx
+++ b/components/icons/eye-icon.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+export function EyeIcon({
+  size = 14,
+  color = "#73798c",
+}: {
+  size?: number;
+  color?: string;
+}) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 14 14" fill="none">
+      <Path
+        d="M1 7s2.25-4 6-4 6 4 6 4-2.25 4-6 4-6-4-6-4z"
+        stroke={color}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M7 8.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"
+        stroke={color}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}

--- a/components/icons/plus-icon.tsx
+++ b/components/icons/plus-icon.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+export function PlusIcon({
+  size = 24,
+  color = "#ffffff",
+}: {
+  size?: number;
+  color?: string;
+}) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M12 5v14M5 12h14"
+        stroke={color}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -1,12 +1,20 @@
+import { PlusIcon } from "@/components/icons/plus-icon";
+import { MOCK_POSTS } from "@/features/community/constants/mock-posts";
 import React from "react";
-import { Text, View } from "react-native";
+import { Pressable, ScrollView, View } from "react-native";
+import { PostItem } from "./post-item";
 
-export function FreeBoardScreen(): React.JSX.Element {
+export function FreeBoardScreen() {
   return (
-    <View className="flex-1 items-center justify-center">
-      <Text className="typo-body-1-normal-regular text-label-subtler">
-        자유 게시판 준비 중
-      </Text>
+    <View className="flex-1">
+      <ScrollView>
+        {MOCK_POSTS.map((post) => (
+          <PostItem key={post.id} post={post} />
+        ))}
+      </ScrollView>
+      <Pressable className="absolute bottom-6 right-5 size-14 rounded-full bg-primary-normal items-center justify-center">
+        <PlusIcon />
+      </Pressable>
     </View>
   );
 }

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -1,18 +1,18 @@
 import { PlusIcon } from "@/components/icons/plus-icon";
 import { MOCK_POSTS } from "@/features/community/constants/mock-posts";
 import React from "react";
-import { Pressable, ScrollView, View } from "react-native";
+import { FlatList, Pressable, View } from "react-native";
 import { PostItem } from "./post-item";
 
 export function FreeBoardScreen() {
   return (
     <View className="flex-1">
-      <ScrollView>
-        {MOCK_POSTS.map((post) => (
-          <PostItem key={post.id} post={post} />
-        ))}
-      </ScrollView>
-      <Pressable className="absolute bottom-6 right-5 size-14 rounded-full bg-primary-normal items-center justify-center">
+      <FlatList
+        data={MOCK_POSTS}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <PostItem post={item} />}
+      />
+      <Pressable className="absolute bottom-6 right-5 size-14 items-center justify-center rounded-full bg-primary-normal">
         <PlusIcon />
       </Pressable>
     </View>

--- a/features/community/components/post-item.tsx
+++ b/features/community/components/post-item.tsx
@@ -1,0 +1,48 @@
+import { ChatIcon } from "@/components/icons/chat-icon";
+import { EyeIcon } from "@/components/icons/eye-icon";
+import { HeartIcon } from "@/components/icons/heart-icon";
+import { Post } from "@/features/community/constants/mock-posts";
+import React from "react";
+import { Text, View } from "react-native";
+import { StatItem } from "./stat-item";
+import { Thumbnail } from "./thumbnail";
+
+export function PostItem({ post }: { post: Post }) {
+  const hasImage = !!post.imageCount && post.imageCount > 0;
+  return (
+    <View className="border-b border-line-subtle px-5 py-4">
+      <View className="gap-3">
+        <View className={`flex-row ${hasImage ? "gap-3" : ""}`}>
+          <View className="flex-1 gap-1">
+            <Text
+              className="typo-body-1-normal-semi-bold text-label-normal"
+              numberOfLines={1}
+            >
+              {post.title}
+            </Text>
+            <Text
+              className="typo-body-2-reading-regular text-label-subtle"
+              numberOfLines={2}
+            >
+              {post.body}
+            </Text>
+          </View>
+          {hasImage && <Thumbnail imageCount={post.imageCount!} />}
+        </View>
+        <View className="flex-row items-center justify-between">
+          <Text className="typo-caption-1-regular text-label-subtler">
+            {post.date}
+          </Text>
+          <View className="flex-row gap-3">
+            <StatItem icon={<EyeIcon />} count={post.views} />
+            <StatItem
+              icon={<HeartIcon size={14} color="#73798c" />}
+              count={post.likes}
+            />
+            <StatItem icon={<ChatIcon />} count={post.comments} />
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/features/community/components/post-item.tsx
+++ b/features/community/components/post-item.tsx
@@ -3,25 +3,30 @@ import { EyeIcon } from "@/components/icons/eye-icon";
 import { HeartIcon } from "@/components/icons/heart-icon";
 import { Post } from "@/features/community/constants/mock-posts";
 import React from "react";
-import { Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import { StatItem } from "./stat-item";
 import { Thumbnail } from "./thumbnail";
 
 export function PostItem({ post }: { post: Post }) {
   const hasImage = !!post.imageCount && post.imageCount > 0;
   return (
-    <View className="border-b border-line-subtle px-5 py-4">
+    <Pressable
+      onPress={() => {
+        // TODO : 게시글 상세페이지 이동 구현
+      }}
+      className="border-b border-line-subtle px-5 py-4"
+    >
       <View className="gap-3">
         <View className={`flex-row ${hasImage ? "gap-3" : ""}`}>
           <View className="flex-1 gap-1">
             <Text
-              className="typo-body-1-normal-semi-bold text-label-normal"
+              className="text-label-normal typo-body-1-normal-semi-bold"
               numberOfLines={1}
             >
               {post.title}
             </Text>
             <Text
-              className="typo-body-2-reading-regular text-label-subtle"
+              className="text-label-subtle typo-body-2-reading-regular"
               numberOfLines={2}
             >
               {post.body}
@@ -30,7 +35,7 @@ export function PostItem({ post }: { post: Post }) {
           {hasImage && <Thumbnail imageCount={post.imageCount!} />}
         </View>
         <View className="flex-row items-center justify-between">
-          <Text className="typo-caption-1-regular text-label-subtler">
+          <Text className="text-label-subtler typo-caption-1-regular">
             {post.date}
           </Text>
           <View className="flex-row gap-3">
@@ -43,6 +48,6 @@ export function PostItem({ post }: { post: Post }) {
           </View>
         </View>
       </View>
-    </View>
+    </Pressable>
   );
 }

--- a/features/community/components/stat-item.tsx
+++ b/features/community/components/stat-item.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+export function StatItem({
+  icon,
+  count,
+}: {
+  icon: React.ReactNode;
+  count: number;
+}) {
+  return (
+    <View className="flex-row items-center gap-1">
+      {icon}
+      <Text className="typo-caption-1-regular text-label-subtler">{count}</Text>
+    </View>
+  );
+}

--- a/features/community/components/thumbnail.tsx
+++ b/features/community/components/thumbnail.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Text, View } from "react-native";
+
+export function Thumbnail({ imageCount }: { imageCount: number }) {
+  const extraCount = imageCount - 1;
+  return (
+    <View className="size-[68px] rounded-[4px] bg-neutral-100 overflow-hidden">
+      {extraCount > 0 && (
+        <View className="absolute bottom-0 right-0 bg-black/70 rounded px-1 justify-center items-center">
+          <Text className="typo-caption-1-regular text-common-100">
+            +{extraCount}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/features/community/constants/mock-posts.ts
+++ b/features/community/constants/mock-posts.ts
@@ -1,0 +1,60 @@
+export type Post = {
+  id: string;
+  title: string;
+  body: string;
+  date: string;
+  views: number;
+  likes: number;
+  comments: number;
+  imageCount?: number;
+};
+
+export const MOCK_POSTS: Post[] = [
+  {
+    id: "1",
+    title: "등산할 때 신기 좋은 신발 추천 부탁드려요!",
+    body: "아치가 무너져서 오래 걷기 힘든데 이런 사람한테도 괜찮은 신발 있으면 알려주세요. 등산하고는 싶은 때 준비할 게 많아서 쉽지 않네요 ~",
+    date: "2026.04.27",
+    views: 234,
+    likes: 3,
+    comments: 8,
+  },
+  {
+    id: "2",
+    title: "등산할 때 신기 좋은 신발 추천 부탁드려요!",
+    body: "아치가 무너져서 오래 걷기 힘든데 이런 사람한테도 괜찮은 신발 있으면 알려주세요. 등산하고는 싶은 때 준비할 게 많아서 쉽지 않네요 ~",
+    date: "2026.04.27",
+    views: 234,
+    likes: 3,
+    comments: 8,
+    imageCount: 1,
+  },
+  {
+    id: "3",
+    title: "등산할 때 신기 좋은 신발 추천 부탁드려요!",
+    body: "아치가 무너져서 오래 걷기 힘든데 이런 사람한테도 괜찮은 신발 있으면 알려주세요. 등산하고는 싶은 때 준비할 게 많아서 쉽지 않네요 ~",
+    date: "2026.04.27",
+    views: 234,
+    likes: 3,
+    comments: 8,
+    imageCount: 2,
+  },
+  {
+    id: "4",
+    title: "등산할 때 신기 좋은 신발 추천 부탁드려요!",
+    body: "아치가 무너져서 오래 걷기 힘든데 이런 사람한테도 괜찮은 신발 있으면 알려주세요. 등산하고는 싶은 때 준비할 게 많아서 쉽지 않네요 ~",
+    date: "2026.04.27",
+    views: 234,
+    likes: 3,
+    comments: 8,
+  },
+  {
+    id: "5",
+    title: "등산할 때 신기 좋은 신발 추천 부탁드려요!",
+    body: "아치가 무너져서 오래 걷기 힘든데 이런 사람한테도 괜찮은 신발 있으면 알려주세요. 등산하고는 싶은 때 준비할 게 많아서 쉽지 않네요 ~",
+    date: "2026.04.27",
+    views: 234,
+    likes: 3,
+    comments: 8,
+  },
+];


### PR DESCRIPTION
## Summary
- 피그마 디자인 기반으로 자유게시판 목록 화면 퍼블리싱
- 게시글 아이템: 텍스트 전용 / 썸네일 1장 / 다중 이미지(+N 배지) 3가지 타입 지원
- 조회수·좋아요·댓글 수 통계 표시 및 글쓰기 FAB 버튼 추가
- `EyeIcon`, `ChatIcon`, `PlusIcon` SVG 아이콘 컴포넌트 추가
- 컴포넌트 파일 분리: `stat-item`, `thumbnail`, `post-item`
- Mock 데이터를 `features/community/constants/mock-posts.ts`로 분리

## ScreenShot

| 게시글리스트 |
| --- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/77331498-d6a0-4284-8586-becee1c58979" /> |


## Test plan
- [ ] 자유게시판 탭 진입 시 게시글 목록 렌더링 확인
- [ ] 이미지 없는 아이템 / 썸네일 1장 / +N 배지 아이템 레이아웃 확인
- [ ] 스크롤 동작 확인
- [ ] FAB 버튼 위치 및 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)