### PR TITLE
feat: Maze 유니버설 스니펫 웹 head에 주입

### DIFF
--- a/app/+html.tsx
+++ b/app/+html.tsx
@@ -1,0 +1,39 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from 'react';
+
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="ko">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+        <ScrollViewStyleReset />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function (m, a, z, e) {
+  var s, t, u, v;
+  try { t = m.sessionStorage.getItem('maze-us'); } catch (err) {}
+  if (!t) {
+    t = new Date().getTime();
+    try { m.sessionStorage.setItem('maze-us', t); } catch (err) {}
+  }
+  u = document.currentScript || (function () {
+    var w = document.getElementsByTagName('script');
+    return w[w.length - 1];
+  })();
+  v = u && u.nonce;
+  s = a.createElement('script');
+  s.src = z + '?apiKey=' + e;
+  s.async = true;
+  if (v) s.setAttribute('nonce', v);
+  a.getElementsByTagName('head')[0].appendChild(s);
+  m.mazeUniversalSnippetApiKey = e;
+})(window, document, 'https://snippet.maze.co/maze-universal-loader.js', '0df6d355-58c6-40fa-832e-f8b903cd8483');`,
+          }}
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- `app/+html.tsx` 추가 — Expo Router 웹 빌드 시 HTML 문서 템플릿으로 사용됨
- Maze 유니버설 스니펫을 `<head>` 내 `<script>`로 삽입
- 앱(iOS/Android) 빌드에는 영향 없음

## Test plan
- [ ] `npx expo export --platform web` 후 빌드 결과물 `index.html`에서 Maze 스크립트 확인
- [ ] 웹 배포 후 Maze 대시보드에서 세션 수집 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)