### PR TITLE
feat: 코스 상세 → 트래킹 연동 및 글로벌 카운트다운 오버레이 - UT대응

### DIFF
--- a/app/(tabs)/mountains.tsx
+++ b/app/(tabs)/mountains.tsx
@@ -11,6 +11,7 @@ import {
 import { FilterBottomSheet } from "@/features/mountains/components/filter-bottom-sheet";
 import { FilterChip } from "@/features/mountains/components/filter-chip";
 import {
+  Difficulty,
   MOCK_MOUNTAINS,
   MountainCard,
 } from "@/features/mountains/components/mountain-card";
@@ -57,6 +58,19 @@ export default function MountainsScreen() {
     setDurationRange([0, 7]);
     setRegionSelections([]);
   };
+
+  const DIFFICULTY_MAP: Record<DifficultyOption, Difficulty> = {
+    high: "상",
+    medium: "중",
+    low: "하",
+  };
+
+  const filteredMountains =
+    difficultyOptions.length === 0
+      ? MOCK_MOUNTAINS
+      : MOCK_MOUNTAINS.filter((m) =>
+          difficultyOptions.some((opt) => DIFFICULTY_MAP[opt] === m.difficulty)
+        );
 
   const hasActiveFilter =
     sortOption !== "popularity" ||
@@ -187,7 +201,7 @@ export default function MountainsScreen() {
       {/* Mountain list */}
       <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
         <View className="gap-5 px-5 py-3">
-          {MOCK_MOUNTAINS.map((mountain) => (
+          {filteredMountains.map((mountain) => (
             <TouchableOpacity
               key={mountain.id}
               onPress={() => router.push(`/mountains/${mountain.id}`)}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -5,7 +5,6 @@ import { SummitSheet } from '@/features/tracking/components/summit-sheet';
 import { StopConfirmModal } from '@/features/tracking/components/stop-confirm-modal';
 import { DifficultyRatingModal } from '@/features/tracking/components/difficulty-rating-modal';
 import { TrailAvatarMarker } from '@/features/tracking/components/trail-avatar-marker';
-import { CountdownOverlay } from '@/features/tracking/components/countdown-overlay';
 import { CourseSelectSheet } from '@/features/tracking/components/course-select-sheet';
 import { TrackingSheet } from '@/features/tracking/components/tracking-sheet';
 import {
@@ -27,15 +26,16 @@ import {
   TRAIL_BAR_LOCATIONS,
   TRAIL_BAR_WIDTH,
 } from '@/features/tracking/constants';
+import { useCountdownStore } from '@/store/countdown.store';
 import { LinearGradient } from 'expo-linear-gradient';
-import { Tabs } from 'expo-router';
+import { Tabs, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { LayoutChangeEvent, Text, TouchableOpacity, View } from 'react-native';
 
 export default function TrackingScreen() {
+  const { autoStart } = useLocalSearchParams<{ autoStart?: string }>();
   const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
   const [collapsed, setCollapsed] = useState(false);
-  const [countdown, setCountdown] = useState<number | null>(null);
   const [isTracking, setIsTracking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
@@ -53,19 +53,11 @@ export default function TrackingScreen() {
 
   const selectedCourse = MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
 
-  const startCountdown = () => setCountdown(3);
+  const startCountdown = () => useCountdownStore.getState().start(() => setIsTracking(true));
 
-  // 카운트다운 → 0이 되면 트래킹 시작
   useEffect(() => {
-    if (countdown === null) return;
-    if (countdown === 0) {
-      setIsTracking(true);
-      setCountdown(null);
-      return;
-    }
-    const timer = setTimeout(() => setCountdown((c) => (c !== null ? c - 1 : null)), 1000);
-    return () => clearTimeout(timer);
-  }, [countdown]);
+    if (autoStart === '1') setIsTracking(true);
+  }, [autoStart]);
 
   // 트래킹 중 경과 시간 카운트업 (일시정지 시 멈춤)
   useEffect(() => {
@@ -214,14 +206,6 @@ export default function TrackingScreen() {
             />
           )}
         </View>
-      )}
-
-      {/* 카운트다운 오버레이 */}
-      {countdown !== null && countdown > 0 && (
-        <CountdownOverlay
-          countdown={countdown}
-          onClose={() => setCountdown(null)}
-        />
       )}
 
       {/* 기록 종료 확인 모달 */}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -7,12 +7,14 @@ import {
 import { Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import "react-native-reanimated";
 import "../global.css";
 
 import Toast from "@/components/toast/toast";
+import { CountdownOverlay } from "@/features/tracking/components/countdown-overlay";
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { useCountdownStore } from "@/store/countdown.store";
 
 SplashScreen.preventAutoHideAsync();
 
@@ -20,17 +22,24 @@ export const unstable_settings = {
   anchor: "(tabs)",
 };
 
-export default function RootLayout() {
+export default function RootLayout(): React.JSX.Element | null {
   const colorScheme = useColorScheme();
   const [fontsLoaded] = useFonts({
     "Lexend-SemiBold": require("../assets/fonts/Lexend-SemiBold.ttf"),
   });
+  const { countdown, dismiss } = useCountdownStore();
 
   useEffect(() => {
     if (fontsLoaded) {
       SplashScreen.hideAsync();
     }
   }, [fontsLoaded]);
+
+  useEffect(() => {
+    if (countdown === null) return;
+    const timer = setTimeout(() => useCountdownStore.getState().tick(), 1000);
+    return () => clearTimeout(timer);
+  }, [countdown]);
 
   if (!fontsLoaded) return null;
 
@@ -46,6 +55,9 @@ export default function RootLayout() {
       </Stack>
       <Toast />
       <StatusBar style="auto" />
+      {countdown !== null && countdown > 0 && (
+        <CountdownOverlay countdown={countdown} onClose={dismiss} />
+      )}
     </ThemeProvider>
   );
 }

--- a/app/mountains/[id].tsx
+++ b/app/mountains/[id].tsx
@@ -29,7 +29,7 @@ import { buildWeatherDays } from "@/features/mountains/modules/weather";
 import { LinearGradient } from "expo-linear-gradient";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React, { useState } from "react";
-import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Image, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type TabKey = "코스" | "교통" | "편의" | "맛집" | "리뷰";
@@ -70,7 +70,11 @@ function CourseCard({ course }: { course: Course }) {
       activeOpacity={0.7}
       onPress={() => router.push(`/mountains/courses/${course.id}`)}
     >
-      <View className="h-[72px] w-16 rounded-[10px] bg-fill-stronger" />
+      <Image
+        source={{ uri: course.imageUrl }}
+        className="h-[72px] w-16 rounded-[10px] bg-fill-stronger"
+        resizeMode="cover"
+      />
       <View className="gap-1.5">
         <View className="flex-row items-center gap-1.5">
           <CourseBadge difficulty={course.difficulty} />

--- a/app/mountains/courses/[id].tsx
+++ b/app/mountains/courses/[id].tsx
@@ -7,6 +7,7 @@ import {
   MOCK_REVIEWS,
   type CourseDifficulty,
 } from "@/features/mountains/constants/mountain-detail";
+import { useCountdownStore } from "@/store/countdown.store";
 import { Stack, useRouter } from "expo-router";
 import React from "react";
 import { Image, ScrollView, Text, TouchableOpacity, View } from "react-native";
@@ -209,7 +210,12 @@ export default function CourseDetailScreen(): React.JSX.Element {
         >
           <TouchableOpacity
             onPress={() => {
-              /** TODO : 트래킹 페이지 연동 */
+              useCountdownStore.getState().start(() => {
+                router.push({
+                  pathname: '/(tabs)/tracking',
+                  params: { autoStart: '1' },
+                });
+              });
             }}
             className="flex-row items-center gap-2 rounded-full bg-primary-normal px-5 py-3"
           >

--- a/app/mountains/courses/[id].tsx
+++ b/app/mountains/courses/[id].tsx
@@ -4,56 +4,49 @@ import { RouteIcon } from "@/components/icons/route-icon";
 import { UserIcon } from "@/components/icons/user-icon";
 import { CourseBadge } from "@/features/mountains/components/course-badge";
 import {
+  MOCK_COURSES,
   MOCK_REVIEWS,
-  type CourseDifficulty,
 } from "@/features/mountains/constants/mountain-detail";
 import { useCountdownStore } from "@/store/countdown.store";
-import { Stack, useRouter } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import React from "react";
 import { Image, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-const MOCK_COURSE: {
-  name: string;
-  difficulty: CourseDifficulty;
-  start: string;
-  end: string;
-  distanceKm: number;
-  altitude: string;
-  uphillM: number;
-  downhillM: number;
-  durationHours: number;
-  imageUrl?: string;
-} = {
-  name: "관악산 코스 1",
-  difficulty: "초급",
-  start: "서울시 관악구 신림동",
-  end: "서울시 관악구 신림동",
-  distanceKm: 13.95,
-  altitude: "2.43m",
-  uphillM: 1436,
-  downhillM: 1354,
-  durationHours: 4,
-  imageUrl:
-    "https://private-user-images.githubusercontent.com/92029332/589569538-fa311796-0fc8-42d4-9822-3df84e9f158b.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzgyNDcwOTQsIm5iZiI6MTc3ODI0Njc5NCwicGF0aCI6Ii85MjAyOTMzMi81ODk1Njk1MzgtZmEzMTE3OTYtMGZjOC00MmQ0LTk4MjItM2RmODRlOWYxNThiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTA4VDEzMjYzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQ1YTNiZjg2YWE2ZTk2YmI0NjZiMmQ3YjRlMDc5MjM4ODk0Y2M4ODU2MWQxMTI3MDBkMGQ3OGI2M2FlOWMxY2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.5FPoKd8-AmZWqFiCqNRcaburL7zvrtB1Ls0_UQBJjsw",
-};
-
-const STAT_ROWS = [
-  [
-    { label: "거리", value: `${MOCK_COURSE.distanceKm}km` },
-    { label: "난이도", value: MOCK_COURSE.difficulty },
-    { label: "소요시간", value: `${MOCK_COURSE.durationHours}시간` },
-  ],
-  [
-    { label: "고도", value: MOCK_COURSE.altitude },
-    { label: "오르막길", value: `${MOCK_COURSE.uphillM}m` },
-    { label: "내리막길", value: `${MOCK_COURSE.downhillM}m` },
-  ],
-];
-
 export default function CourseDetailScreen(): React.JSX.Element {
+  const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
   const insets = useSafeAreaInsets();
+
+  const course = MOCK_COURSES.find((c) => String(c.id) === id);
+
+  const statRows = course
+    ? [
+        [
+          { label: "거리", value: `${course.distanceKm}km` },
+          { label: "난이도", value: course.difficulty },
+          { label: "소요시간", value: `${course.durationHours}시간` },
+        ],
+        [
+          { label: "고도", value: "-" },
+          { label: "오르막길", value: "-" },
+          { label: "내리막길", value: "-" },
+        ],
+      ]
+    : [];
+
+  if (!course) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View className="flex-1 items-center justify-center bg-fill-normal">
+          <Text className="text-label-subtle typo-body-2-normal-regular">
+            코스를 찾을 수 없습니다.
+          </Text>
+        </View>
+      </>
+    );
+  }
 
   return (
     <>
@@ -69,7 +62,7 @@ export default function CourseDetailScreen(): React.JSX.Element {
 
           {/* Map */}
           <Image
-            source={{ uri: MOCK_COURSE.imageUrl }}
+            source={{ uri: course.imageUrl }}
             className="mx-5 h-[200px] overflow-hidden rounded-[20px] bg-fill-stronger"
             resizeMode="cover"
           />
@@ -78,41 +71,20 @@ export default function CourseDetailScreen(): React.JSX.Element {
           <View className="gap-[10px] px-5 pt-5">
             <View className="flex-row items-center justify-between">
               <View className="flex-row items-center gap-[10px]">
-                <CourseBadge difficulty={MOCK_COURSE.difficulty} />
+                <CourseBadge difficulty={course.difficulty} />
                 <Text className="text-label-normal typo-heading-1-semi-bold">
-                  {MOCK_COURSE.name}
+                  {course.title}
                 </Text>
               </View>
               <TouchableOpacity hitSlop={8}>
                 <HeartIcon />
               </TouchableOpacity>
             </View>
-
-            <View className="gap-1">
-              <View className="flex-row items-center gap-2">
-                <View className="size-[10px] rounded-full bg-blue-500" />
-                <Text className="text-label-subtle typo-body-2-normal-semi-bold">
-                  출발
-                </Text>
-                <Text className="text-label-subtler typo-body-2-normal-regular">
-                  {MOCK_COURSE.start}
-                </Text>
-              </View>
-              <View className="flex-row items-center gap-2">
-                <View className="size-[10px] rounded-full bg-red-500" />
-                <Text className="text-label-subtle typo-body-2-normal-semi-bold">
-                  도착
-                </Text>
-                <Text className="text-label-subtler typo-body-2-normal-regular">
-                  {MOCK_COURSE.end}
-                </Text>
-              </View>
-            </View>
           </View>
 
           {/* Stats grid */}
           <View className="mt-6 gap-[6px]">
-            {STAT_ROWS.map((row, rowIdx) => (
+            {statRows.map((row, rowIdx) => (
               <View key={rowIdx} className="flex-row justify-center gap-1">
                 {row.map(({ label, value }) => (
                   <View

--- a/app/mountains/courses/[id].tsx
+++ b/app/mountains/courses/[id].tsx
@@ -9,19 +9,32 @@ import {
 } from "@/features/mountains/constants/mountain-detail";
 import { Stack, useRouter } from "expo-router";
 import React from "react";
-import { ScrollView, Text, TouchableOpacity, View } from "react-native";
+import { Image, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-const MOCK_COURSE = {
-  name: "과천향교출발3코스",
-  difficulty: "초급" as CourseDifficulty,
-  start: "서울시 관악구 00동",
-  end: "서울시 관악구 00동",
+const MOCK_COURSE: {
+  name: string;
+  difficulty: CourseDifficulty;
+  start: string;
+  end: string;
+  distanceKm: number;
+  altitude: string;
+  uphillM: number;
+  downhillM: number;
+  durationHours: number;
+  imageUrl?: string;
+} = {
+  name: "관악산 코스 1",
+  difficulty: "초급",
+  start: "서울시 관악구 신림동",
+  end: "서울시 관악구 신림동",
   distanceKm: 13.95,
   altitude: "2.43m",
   uphillM: 1436,
   downhillM: 1354,
   durationHours: 4,
+  imageUrl:
+    "https://private-user-images.githubusercontent.com/92029332/589569538-fa311796-0fc8-42d4-9822-3df84e9f158b.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzgyNDcwOTQsIm5iZiI6MTc3ODI0Njc5NCwicGF0aCI6Ii85MjAyOTMzMi81ODk1Njk1MzgtZmEzMTE3OTYtMGZjOC00MmQ0LTk4MjItM2RmODRlOWYxNThiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTA4VDEzMjYzNFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQ1YTNiZjg2YWE2ZTk2YmI0NjZiMmQ3YjRlMDc5MjM4ODk0Y2M4ODU2MWQxMTI3MDBkMGQ3OGI2M2FlOWMxY2ImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.5FPoKd8-AmZWqFiCqNRcaburL7zvrtB1Ls0_UQBJjsw",
 };
 
 const STAT_ROWS = [
@@ -54,7 +67,11 @@ export default function CourseDetailScreen(): React.JSX.Element {
           <View style={{ height: insets.top + 56 + 8 }} />
 
           {/* Map */}
-          <View className="mx-5 h-[200px] overflow-hidden rounded-[20px] bg-fill-stronger" />
+          <Image
+            source={{ uri: MOCK_COURSE.imageUrl }}
+            className="mx-5 h-[200px] overflow-hidden rounded-[20px] bg-fill-stronger"
+            resizeMode="cover"
+          />
 
           {/* Course info */}
           <View className="gap-[10px] px-5 pt-5">

--- a/features/mountains/components/mountain-card.tsx
+++ b/features/mountains/components/mountain-card.tsx
@@ -1,6 +1,6 @@
 import { COURSE_BADGE } from "@/features/mountains/constants/course-badge";
 import React from "react";
-import { Text, View } from "react-native";
+import { Image, Text, View } from "react-native";
 
 export type Difficulty = "하" | "중" | "상";
 
@@ -10,17 +10,368 @@ export type Mountain = {
   location: string;
   altitude: number;
   difficulty: Difficulty;
+  imageUrl?: string;
 };
 
 export const MOCK_MOUNTAINS: Mountain[] = [
-  { id: 1, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "중" },
-  { id: 2, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "상" },
-  { id: 3, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "하" },
-  { id: 4, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "중" },
-  { id: 5, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "상" },
-  { id: 6, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "하" },
-  { id: 7, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "중" },
-  { id: 8, name: "관악산", location: "경기 과천시 중앙동", altitude: 632, difficulty: "상" },
+  {
+    id: 1,
+    name: "북한산",
+    location: "서울 도봉구 도봉동",
+    altitude: 837,
+    difficulty: "상",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Insoo_peak.jpg/330px-Insoo_peak.jpg",
+  },
+  {
+    id: 2,
+    name: "도봉산",
+    location: "서울 도봉구 도봉동",
+    altitude: 740,
+    difficulty: "상",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/ko/thumb/b/be/Dobongsan.jpg/330px-Dobongsan.jpg",
+  },
+  {
+    id: 3,
+    name: "수락산",
+    location: "서울 노원구 상계동",
+    altitude: 638,
+    difficulty: "중",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Suraksan.JPG/330px-Suraksan.JPG",
+  },
+  {
+    id: 4,
+    name: "관악산",
+    location: "서울 관악구 신림동",
+    altitude: 632,
+    difficulty: "상",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Gwanaksan_Seoul_KR.jpg/330px-Gwanaksan_Seoul_KR.jpg",
+  },
+  {
+    id: 5,
+    name: "청계산",
+    location: "서울 서초구 원지동",
+    altitude: 618,
+    difficulty: "중",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Maebawi_of_Cheong_gye_Mt_Seoul.JPG/330px-Maebawi_of_Cheong_gye_Mt_Seoul.JPG",
+  },
+  {
+    id: 6,
+    name: "불암산",
+    location: "서울 노원구 중계동",
+    altitude: 508,
+    difficulty: "중",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Buram_Mountain_Peak.JPG/330px-Buram_Mountain_Peak.JPG",
+  },
+  {
+    id: 7,
+    name: "삼성산",
+    location: "서울 관악구 남현동",
+    altitude: 481,
+    difficulty: "중",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Samsungsan.jpg/330px-Samsungsan.jpg",
+  },
+  {
+    id: 8,
+    name: "남한산",
+    location: "서울 송파구 마천동",
+    altitude: 522,
+    difficulty: "중",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Korea-Namhansanseong-10.jpg/330px-Korea-Namhansanseong-10.jpg",
+  },
+  {
+    id: 9,
+    name: "용마산",
+    location: "서울 광진구 중곡동",
+    altitude: 348,
+    difficulty: "중",
+    imageUrl: "http://www.mhtimes.kr/data/newsThumb/1695002162ADD_thumb580.jpg",
+  },
+  {
+    id: 10,
+    name: "북악산",
+    location: "서울 종로구 청운동",
+    altitude: 342,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg/330px-Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg",
+  },
+  {
+    id: 11,
+    name: "인왕산",
+    location: "서울 서대문구 홍제동",
+    altitude: 338,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Mount_Inwang.jpg/330px-Mount_Inwang.jpg",
+  },
+  {
+    id: 12,
+    name: "인릉산",
+    location: "서울 서초구 내곡동",
+    altitude: 326,
+    difficulty: "중",
+    imageUrl:
+      "http://pnuac.com/files/attach/images/103/029/093/be8dcdf5dc58aa679606712d76dd4b77.jpg",
+  },
+  {
+    id: 13,
+    name: "구룡산",
+    location: "서울 서초구 염곡동",
+    altitude: 306,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg/330px-%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg",
+  },
+  {
+    id: 14,
+    name: "아차산",
+    location: "서울 광진구 광장동",
+    altitude: 287,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/AchasanPost.jpg/330px-AchasanPost.jpg",
+  },
+  {
+    id: 15,
+    name: "대모산",
+    location: "서울 강남구 개포동",
+    altitude: 293,
+    difficulty: "하",
+    imageUrl:
+      "https://www.gangnam.go.kr/assets/images/contents/01/011102_img01.jpg",
+  },
+  {
+    id: 16,
+    name: "우면산",
+    location: "서울 서초구 우면동",
+    altitude: 293,
+    difficulty: "하",
+    imageUrl:
+      "https://i.namu.wiki/i/2HANF35TPXMhUJEL1cgmbVCVDnWKJN5XjjRIrxv7-bvtMNlkTiSVRJxbxftR7w81HfKa9jKVC0thDTIShjKmUdUKYQCEtWX_2diBaL9TSiBFPvEQequMfLZxfVFwYZldWIC-lQKYjRPeDNcA_5pang.webp",
+  },
+  {
+    id: 17,
+    name: "안산",
+    location: "서울 서대문구 홍제동",
+    altitude: 296,
+    difficulty: "하",
+    imageUrl:
+      "https://cdn.tongilnews.com/news/photo/201609/118264_53108_311.jpg",
+  },
+  {
+    id: 18,
+    name: "남산",
+    location: "서울 중구 예장동",
+    altitude: 262,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Seoul_Aerial_Shot_13.jpg/330px-Seoul_Aerial_Shot_13.jpg",
+  },
+  {
+    id: 19,
+    name: "백련산",
+    location: "서울 은평구 응암동",
+    altitude: 216,
+    difficulty: "하",
+    imageUrl:
+      "https://mediahub.seoul.go.kr/uploads/mediahub/2023/03/aTlfPNPKiehfQLdIqHZbmsMMAHdnYPwP.jpg",
+  },
+  {
+    id: 20,
+    name: "매봉산",
+    location: "서울 용산구 도원동",
+    altitude: 236,
+    difficulty: "하",
+    imageUrl:
+      "https://devin.aks.ac.kr/image/73580ef3-202e-4751-b698-b8243dd88c30?preset=orig",
+  },
+  {
+    id: 21,
+    name: "봉제산",
+    location: "서울 강서구 화곡동",
+    altitude: 193,
+    difficulty: "하",
+    imageUrl:
+      "https://mediahub.seoul.go.kr/uploads/mediahub/2021/06/TrnaQAqGHDbpptaXkVAwDxeVqENxzgMR.JPG",
+  },
+  {
+    id: 22,
+    name: "일자산",
+    location: "서울 강동구 고덕동",
+    altitude: 150,
+    difficulty: "하",
+    imageUrl:
+      "https://i.namu.wiki/i/ISw7R1DE7MhtMQebkEbjxM5vT0MZyzkO9hHuKXjP4W9DBsTmUJV_ZqlFEvvoXwJEJuCZFk4NUVikxMPOnYALKmehIDEIGifsjZECxr6S-1h9uhuSHTszscAkgcsee-7y12A51VI613SiP6WJmuOEYw.webp",
+  },
+  {
+    id: 23,
+    name: "굴봉산",
+    location: "서울 구로구 오류동",
+    altitude: 145,
+    difficulty: "하",
+    imageUrl: "https://cdn.chunsa.kr/news/photo/202309/56164_23471_637.jpg",
+  },
+  {
+    id: 24,
+    name: "개화산",
+    location: "서울 강서구 개화동",
+    altitude: 132,
+    difficulty: "하",
+    imageUrl:
+      "https://mediahub.seoul.go.kr/uploads/mediahub/2023/11/HmtMDrIbPHjbXZUqZSQqvQmXFdlfEWvv.jpg",
+  },
+  {
+    id: 25,
+    name: "개운산",
+    location: "서울 성북구 안암동",
+    altitude: 134,
+    difficulty: "하",
+    imageUrl:
+      "https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdna%2FcxhhG3%2FbtsJ3IVw37N%2FAAAAAAAAAAAAAAAAAAAAAGvxOSB-T3VwQR7N6iAV6F9oDm6-XrRMZnyKu7FPo6mg%2Fimg.jpg%3Fcredential%3DyqXZFxpELC7KVnFOS48ylbz2pIh7yKj8%26expires%3D1780239599%26allow_ip%3D%26allow_referer%3D%26signature%3D4XDTHKydHxng%252F%252BrcCExHnCWdZjs%253D",
+  },
+  {
+    id: 26,
+    name: "금호산",
+    location: "서울 성동구 금호동",
+    altitude: 140,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg/330px-Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg",
+  },
+  {
+    id: 27,
+    name: "벽오산",
+    location: "서울 강북구 번동",
+    altitude: 135,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Bukhansan_Spring_in_Korea.jpg/330px-Bukhansan_Spring_in_Korea.jpg",
+  },
+  {
+    id: 28,
+    name: "봉화산",
+    location: "서울 중랑구 신내동",
+    altitude: 138,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Bukhansan_landscape_and_azalia.jpg/330px-Bukhansan_landscape_and_azalia.jpg",
+  },
+  {
+    id: 29,
+    name: "오패산",
+    location: "서울 성북구 월곡동",
+    altitude: 123,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Mount_Inwang.jpg/330px-Mount_Inwang.jpg",
+  },
+  {
+    id: 30,
+    name: "대현산",
+    location: "서울 성동구 옥수동",
+    altitude: 123,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Gwanaksan_Seoul_KR.jpg/330px-Gwanaksan_Seoul_KR.jpg",
+  },
+  {
+    id: 31,
+    name: "낙산",
+    location: "서울 종로구 동숭동",
+    altitude: 125,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Seoul_Aerial_Shot_13.jpg/330px-Seoul_Aerial_Shot_13.jpg",
+  },
+  {
+    id: 32,
+    name: "개웅산",
+    location: "서울 구로구 개봉동",
+    altitude: 125,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Suraksan.JPG/330px-Suraksan.JPG",
+  },
+  {
+    id: 33,
+    name: "응봉산",
+    location: "서울 성동구 응봉동",
+    altitude: 81,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg/330px-Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg",
+  },
+  {
+    id: 34,
+    name: "와우산",
+    location: "서울 마포구 창전동",
+    altitude: 79,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Maebawi_of_Cheong_gye_Mt_Seoul.JPG/330px-Maebawi_of_Cheong_gye_Mt_Seoul.JPG",
+  },
+  {
+    id: 35,
+    name: "우장산",
+    location: "서울 강서구 화곡동",
+    altitude: 99,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Samsungsan.jpg/330px-Samsungsan.jpg",
+  },
+  {
+    id: 36,
+    name: "용왕산",
+    location: "서울 양천구 신월동",
+    altitude: 78,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/AchasanPost.jpg/330px-AchasanPost.jpg",
+  },
+  {
+    id: 37,
+    name: "배봉산",
+    location: "서울 동대문구 전농동",
+    altitude: 106,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg/330px-Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg",
+  },
+  {
+    id: 38,
+    name: "노고산",
+    location: "서울 마포구 노고산동",
+    altitude: 106,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Insoo_peak.jpg/330px-Insoo_peak.jpg",
+  },
+  {
+    id: 39,
+    name: "성산",
+    location: "서울 마포구 성산동",
+    altitude: 66,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Buram_Mountain_Peak.JPG/330px-Buram_Mountain_Peak.JPG",
+  },
+  {
+    id: 40,
+    name: "매봉산",
+    location: "서울 강남구 도곡동",
+    altitude: 95,
+    difficulty: "하",
+    imageUrl:
+      "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg/330px-%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg",
+  },
 ];
 
 export const DIFFICULTY_STYLE: Record<Difficulty, string> = {
@@ -29,10 +380,18 @@ export const DIFFICULTY_STYLE: Record<Difficulty, string> = {
   상: COURSE_BADGE.상급.text,
 };
 
-export function MountainCard({ mountain }: { mountain: Mountain }): React.JSX.Element {
+export function MountainCard({
+  mountain,
+}: {
+  mountain: Mountain;
+}): React.JSX.Element {
   return (
     <View className="flex-row items-center gap-4">
-      <View className="h-[72px] w-[86px] rounded-[10px] bg-fill-stronger" />
+      <Image
+        source={{ uri: mountain.imageUrl }}
+        className="h-[72px] w-[86px] rounded-[10px] bg-fill-stronger"
+        resizeMode="cover"
+      />
       <View className="flex-col gap-1.5">
         <View className="flex-row items-end gap-[9px]">
           <Text className="text-label-normal typo-headline-1-semi-bold">
@@ -47,7 +406,9 @@ export function MountainCard({ mountain }: { mountain: Mountain }): React.JSX.El
             고도 {mountain.altitude}m
           </Text>
           <View className="h-0.5 w-0.5 rounded-full bg-label-subtler" />
-          <Text className={`typo-body-3-semi-bold ${DIFFICULTY_STYLE[mountain.difficulty]}`}>
+          <Text
+            className={`typo-body-3-semi-bold ${DIFFICULTY_STYLE[mountain.difficulty]}`}
+          >
             난이도 {mountain.difficulty}
           </Text>
         </View>

--- a/features/mountains/components/mountain-card.tsx
+++ b/features/mountains/components/mountain-card.tsx
@@ -28,7 +28,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "도봉산",
     location: "서울 도봉구 도봉동",
     altitude: 740,
-    difficulty: "상",
+    difficulty: "중",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/ko/thumb/b/be/Dobongsan.jpg/330px-Dobongsan.jpg",
   },
@@ -37,7 +37,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "수락산",
     location: "서울 노원구 상계동",
     altitude: 638,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Suraksan.JPG/330px-Suraksan.JPG",
   },
@@ -64,7 +64,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "불암산",
     location: "서울 노원구 중계동",
     altitude: 508,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Buram_Mountain_Peak.JPG/330px-Buram_Mountain_Peak.JPG",
   },
@@ -73,7 +73,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "삼성산",
     location: "서울 관악구 남현동",
     altitude: 481,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Samsungsan.jpg/330px-Samsungsan.jpg",
   },
@@ -82,7 +82,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "남한산",
     location: "서울 송파구 마천동",
     altitude: 522,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Korea-Namhansanseong-10.jpg/330px-Korea-Namhansanseong-10.jpg",
   },
@@ -91,7 +91,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "용마산",
     location: "서울 광진구 중곡동",
     altitude: 348,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl: "http://www.mhtimes.kr/data/newsThumb/1695002162ADD_thumb580.jpg",
   },
   {
@@ -99,7 +99,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "북악산",
     location: "서울 종로구 청운동",
     altitude: 342,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg/330px-Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg",
   },
@@ -108,7 +108,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "인왕산",
     location: "서울 서대문구 홍제동",
     altitude: 338,
-    difficulty: "하",
+    difficulty: "중",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Mount_Inwang.jpg/330px-Mount_Inwang.jpg",
   },
@@ -117,7 +117,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "인릉산",
     location: "서울 서초구 내곡동",
     altitude: 326,
-    difficulty: "중",
+    difficulty: "상",
     imageUrl:
       "http://pnuac.com/files/attach/images/103/029/093/be8dcdf5dc58aa679606712d76dd4b77.jpg",
   },
@@ -126,7 +126,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "구룡산",
     location: "서울 서초구 염곡동",
     altitude: 306,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg/330px-%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg",
   },
@@ -135,7 +135,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "아차산",
     location: "서울 광진구 광장동",
     altitude: 287,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/AchasanPost.jpg/330px-AchasanPost.jpg",
   },
@@ -144,7 +144,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "대모산",
     location: "서울 강남구 개포동",
     altitude: 293,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://www.gangnam.go.kr/assets/images/contents/01/011102_img01.jpg",
   },
@@ -153,7 +153,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "우면산",
     location: "서울 서초구 우면동",
     altitude: 293,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://i.namu.wiki/i/2HANF35TPXMhUJEL1cgmbVCVDnWKJN5XjjRIrxv7-bvtMNlkTiSVRJxbxftR7w81HfKa9jKVC0thDTIShjKmUdUKYQCEtWX_2diBaL9TSiBFPvEQequMfLZxfVFwYZldWIC-lQKYjRPeDNcA_5pang.webp",
   },
@@ -162,7 +162,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "안산",
     location: "서울 서대문구 홍제동",
     altitude: 296,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://cdn.tongilnews.com/news/photo/201609/118264_53108_311.jpg",
   },
@@ -171,7 +171,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "남산",
     location: "서울 중구 예장동",
     altitude: 262,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Seoul_Aerial_Shot_13.jpg/330px-Seoul_Aerial_Shot_13.jpg",
   },
@@ -180,7 +180,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "백련산",
     location: "서울 은평구 응암동",
     altitude: 216,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://mediahub.seoul.go.kr/uploads/mediahub/2023/03/aTlfPNPKiehfQLdIqHZbmsMMAHdnYPwP.jpg",
   },
@@ -189,7 +189,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "매봉산",
     location: "서울 용산구 도원동",
     altitude: 236,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://devin.aks.ac.kr/image/73580ef3-202e-4751-b698-b8243dd88c30?preset=orig",
   },
@@ -198,7 +198,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "봉제산",
     location: "서울 강서구 화곡동",
     altitude: 193,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://mediahub.seoul.go.kr/uploads/mediahub/2021/06/TrnaQAqGHDbpptaXkVAwDxeVqENxzgMR.JPG",
   },
@@ -207,7 +207,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "일자산",
     location: "서울 강동구 고덕동",
     altitude: 150,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://i.namu.wiki/i/ISw7R1DE7MhtMQebkEbjxM5vT0MZyzkO9hHuKXjP4W9DBsTmUJV_ZqlFEvvoXwJEJuCZFk4NUVikxMPOnYALKmehIDEIGifsjZECxr6S-1h9uhuSHTszscAkgcsee-7y12A51VI613SiP6WJmuOEYw.webp",
   },
@@ -216,7 +216,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "굴봉산",
     location: "서울 구로구 오류동",
     altitude: 145,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl: "https://cdn.chunsa.kr/news/photo/202309/56164_23471_637.jpg",
   },
   {
@@ -224,7 +224,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "개화산",
     location: "서울 강서구 개화동",
     altitude: 132,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://mediahub.seoul.go.kr/uploads/mediahub/2023/11/HmtMDrIbPHjbXZUqZSQqvQmXFdlfEWvv.jpg",
   },
@@ -233,7 +233,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "개운산",
     location: "서울 성북구 안암동",
     altitude: 134,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdna%2FcxhhG3%2FbtsJ3IVw37N%2FAAAAAAAAAAAAAAAAAAAAAGvxOSB-T3VwQR7N6iAV6F9oDm6-XrRMZnyKu7FPo6mg%2Fimg.jpg%3Fcredential%3DyqXZFxpELC7KVnFOS48ylbz2pIh7yKj8%26expires%3D1780239599%26allow_ip%3D%26allow_referer%3D%26signature%3D4XDTHKydHxng%252F%252BrcCExHnCWdZjs%253D",
   },
@@ -242,7 +242,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "금호산",
     location: "서울 성동구 금호동",
     altitude: 140,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg/330px-Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg",
   },
@@ -251,7 +251,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "벽오산",
     location: "서울 강북구 번동",
     altitude: 135,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/7/79/Bukhansan_Spring_in_Korea.jpg/330px-Bukhansan_Spring_in_Korea.jpg",
   },
@@ -260,7 +260,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "봉화산",
     location: "서울 중랑구 신내동",
     altitude: 138,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Bukhansan_landscape_and_azalia.jpg/330px-Bukhansan_landscape_and_azalia.jpg",
   },
@@ -269,7 +269,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "오패산",
     location: "서울 성북구 월곡동",
     altitude: 123,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Mount_Inwang.jpg/330px-Mount_Inwang.jpg",
   },
@@ -278,7 +278,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "대현산",
     location: "서울 성동구 옥수동",
     altitude: 123,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Gwanaksan_Seoul_KR.jpg/330px-Gwanaksan_Seoul_KR.jpg",
   },
@@ -287,7 +287,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "낙산",
     location: "서울 종로구 동숭동",
     altitude: 125,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Seoul_Aerial_Shot_13.jpg/330px-Seoul_Aerial_Shot_13.jpg",
   },
@@ -296,7 +296,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "개웅산",
     location: "서울 구로구 개봉동",
     altitude: 125,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3c/Suraksan.JPG/330px-Suraksan.JPG",
   },
@@ -305,7 +305,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "응봉산",
     location: "서울 성동구 응봉동",
     altitude: 81,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg/330px-Eungbongsan_Mountain_Spring_01_%2825558972543%29.jpg",
   },
@@ -314,7 +314,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "와우산",
     location: "서울 마포구 창전동",
     altitude: 79,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Maebawi_of_Cheong_gye_Mt_Seoul.JPG/330px-Maebawi_of_Cheong_gye_Mt_Seoul.JPG",
   },
@@ -323,7 +323,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "우장산",
     location: "서울 강서구 화곡동",
     altitude: 99,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Samsungsan.jpg/330px-Samsungsan.jpg",
   },
@@ -332,7 +332,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "용왕산",
     location: "서울 양천구 신월동",
     altitude: 78,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/AchasanPost.jpg/330px-AchasanPost.jpg",
   },
@@ -341,7 +341,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "배봉산",
     location: "서울 동대문구 전농동",
     altitude: 106,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg/330px-Seoul_Gyeongbokgung_Blue_House_Bukhansan.jpg",
   },
@@ -350,7 +350,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "노고산",
     location: "서울 마포구 노고산동",
     altitude: 106,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/6/60/Insoo_peak.jpg/330px-Insoo_peak.jpg",
   },
@@ -359,7 +359,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "성산",
     location: "서울 마포구 성산동",
     altitude: 66,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/4/41/Buram_Mountain_Peak.JPG/330px-Buram_Mountain_Peak.JPG",
   },
@@ -368,7 +368,7 @@ export const MOCK_MOUNTAINS: Mountain[] = [
     name: "매봉산",
     location: "서울 강남구 도곡동",
     altitude: 95,
-    difficulty: "하",
+    difficulty: "상",
     imageUrl:
       "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg/330px-%EA%B5%AC%EB%A3%A1%EC%82%B0.jpg",
   },

--- a/features/mountains/constants/mountain-detail.ts
+++ b/features/mountains/constants/mountain-detail.ts
@@ -6,6 +6,7 @@ export type Course = {
   difficulty: CourseDifficulty;
   distanceKm: number;
   durationHours: number;
+  imageUrl?: string;
 };
 
 export const MOCK_COURSES: Course[] = [
@@ -15,6 +16,8 @@ export const MOCK_COURSES: Course[] = [
     difficulty: "초급",
     distanceKm: 10,
     durationHours: 3,
+    imageUrl:
+      "https://github-production-user-asset-6210df.s3.amazonaws.com/92029332/589566263-44c884d0-f20f-48b5-84a4-e1308e924c39.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260508%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260508T132116Z&X-Amz-Expires=300&X-Amz-Signature=9dc14ad9355f4d2ec5685a136ecd3486816d5d3a4686677a8ef3174e1628d551&X-Amz-SignedHeaders=host&response-content-type=image%2Fpng",
   },
   {
     id: 2,
@@ -22,6 +25,8 @@ export const MOCK_COURSES: Course[] = [
     difficulty: "중급",
     distanceKm: 10,
     durationHours: 3,
+    imageUrl:
+      "https://private-user-images.githubusercontent.com/92029332/589567487-cd5026ab-a0c0-497d-b9ed-7677036f9183.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzgyNDY4OTAsIm5iZiI6MTc3ODI0NjU5MCwicGF0aCI6Ii85MjAyOTMzMi81ODk1Njc0ODctY2Q1MDI2YWItYTBjMC00OTdkLWI5ZWQtNzY3NzAzNmY5MTgzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTA4VDEzMjMxMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBjZTA4MzY4NTMzMTIwNGI4NzBhOGVjZDBjMDg1MGY4YzhjN2QzNDY2NDFhNDQ2MmMwNDUxYTdhYzYyZTY4YzQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.E_2ZCDx-VGAhMQ5kCi0_gTfPOOvkhn5BhfOVUOKQ3jY",
   },
   {
     id: 3,
@@ -29,6 +34,8 @@ export const MOCK_COURSES: Course[] = [
     difficulty: "상급",
     distanceKm: 10,
     durationHours: 3,
+    imageUrl:
+      "https://private-user-images.githubusercontent.com/92029332/589568080-428d31c1-428a-4aac-a81f-d524181eca34.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzgyNDY5NDcsIm5iZiI6MTc3ODI0NjY0NywicGF0aCI6Ii85MjAyOTMzMi81ODk1NjgwODAtNDI4ZDMxYzEtNDI4YS00YWFjLWE4MWYtZDUyNDE4MWVjYTM0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTA4VDEzMjQwN1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWMwZmRjMTJmZTljZmRmZGNjMWUyYWM3NjIwNDQ3OGVmNjczOTA3NDdjZDVkOTAzZDc5YzA2NDI4ZmU4NDg0ZDcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.PMUGvrvlSWAMzHqlrIMewohUh48_4CXnbnjH6uJppUw",
   },
   {
     id: 4,
@@ -36,6 +43,8 @@ export const MOCK_COURSES: Course[] = [
     difficulty: "상급",
     distanceKm: 10,
     durationHours: 3,
+    imageUrl:
+      "https://private-user-images.githubusercontent.com/92029332/589567487-cd5026ab-a0c0-497d-b9ed-7677036f9183.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzgyNDY4OTAsIm5iZiI6MTc3ODI0NjU5MCwicGF0aCI6Ii85MjAyOTMzMi81ODk1Njc0ODctY2Q1MDI2YWItYTBjMC00OTdkLWI5ZWQtNzY3NzAzNmY5MTgzLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTA4VDEzMjMxMFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTBjZTA4MzY4NTMzMTIwNGI4NzBhOGVjZDBjMDg1MGY4YzhjN2QzNDY2NDFhNDQ2MmMwNDUxYTdhYzYyZTY4YzQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.E_2ZCDx-VGAhMQ5kCi0_gTfPOOvkhn5BhfOVUOKQ3jY",
   },
   {
     id: 5,
@@ -43,6 +52,8 @@ export const MOCK_COURSES: Course[] = [
     difficulty: "초급",
     distanceKm: 10,
     durationHours: 3,
+    imageUrl:
+      "https://github-production-user-asset-6210df.s3.amazonaws.com/92029332/589566263-44c884d0-f20f-48b5-84a4-e1308e924c39.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20260508%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260508T132116Z&X-Amz-Expires=300&X-Amz-Signature=9dc14ad9355f4d2ec5685a136ecd3486816d5d3a4686677a8ef3174e1628d551&X-Amz-SignedHeaders=host&response-content-type=image%2Fpng",
   },
 ];
 

--- a/store/countdown.store.ts
+++ b/store/countdown.store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+type CountdownStore = {
+  countdown: number | null;
+  onComplete: (() => void) | null;
+  start: (onComplete?: () => void) => void;
+  dismiss: () => void;
+  tick: () => void;
+};
+
+export const useCountdownStore = create<CountdownStore>((set, get) => ({
+  countdown: null,
+  onComplete: null,
+  start: (onComplete) => set({ countdown: 3, onComplete: onComplete ?? null }),
+  dismiss: () => set({ countdown: null, onComplete: null }),
+  tick: () => {
+    const { countdown, onComplete } = get();
+    if (countdown === null) return;
+    if (countdown <= 1) {
+      set({ countdown: null, onComplete: null });
+      onComplete?.();
+    } else {
+      set({ countdown: countdown - 1 });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

- `countdown.store.ts` (Zustand) 추가 — 앱 어디서든 3,2,1 카운트다운 트리거 가능
- `_layout.tsx`에 `CountdownOverlay` 글로벌 렌더링 — 어느 화면 위에서도 표시
- `tracking.tsx` 로컬 카운트다운 상태 제거 → 글로벌 스토어로 교체
- 코스 상세(`/courses/[id]`) "코스 따라가기" 버튼: 카운트다운 완료 후 `autoStart=1` 파라미터로 트래킹 탭 이동 및 자동 시작
- 코스 상세 페이지 `id` 파라미터 기반 동적 데이터 연동 (`MOCK_COURSES` 조회)

## Test plan

- [ ] 코스 목록에서 코스 카드 탭 → 상세 페이지 진입, 코스 정보(이름·난이도·거리·소요시간·이미지)가 id에 맞게 표시되는지 확인
- [ ] 상세 페이지 "코스 따라가기" → 3,2,1 오버레이가 현재 화면 위에 뜨는지 확인
- [ ] 카운트다운 완료 → 트래킹 탭으로 이동하고 트래킹이 즉시 시작되는지 확인
- [ ] 트래킹 탭 내 "코스 따라가기"도 기존과 동일하게 동작하는지 확인
- [ ] 잘못된 id로 진입 시 "코스를 찾을 수 없습니다" 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)