### PR TITLE
[Feat] 클라이브 화면 개발 - UT용 완료

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Image as ExpoImage } from 'expo-image';
 import {
@@ -15,6 +15,8 @@ import Clive2Svg from '@/assets/clive2.svg';
 import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon';
 import { DotsThreeIcon } from '@/components/icons/dots-three-icon';
 import { DownloadSimpleIcon } from '@/components/icons/download-simple-icon';
+import { GlobeSimpleIcon } from '@/components/icons/globe-simple-icon';
+import { LinkSimpleIcon } from '@/components/icons/link-simple-icon';
 import { LockIcon } from '@/components/icons/lock-icon';
 import { ShareIcon } from '@/components/icons/share-icon';
 import { XIcon } from '@/components/icons/x-icon';
@@ -26,6 +28,41 @@ export default function RecordScreen() {
   const router = useRouter();
   const { top } = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<RecordTab>('클라이브');
+  const [toastMessage, setToastMessage] = useState<'save' | 'public' | null>(null);
+  const [showPublicDialog, setShowPublicDialog] = useState(false);
+  const [showMoreSheet, setShowMoreSheet] = useState(false);
+  const [isClivePublic, setIsClivePublic] = useState(false);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleSavePress = () => {
+    setToastMessage('save');
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+    }
+    toastTimerRef.current = setTimeout(() => {
+      setToastMessage(null);
+    }, 1800);
+  };
+
+  const handleConfirmPublic = () => {
+    setShowPublicDialog(false);
+    setIsClivePublic(true);
+    setToastMessage('public');
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+    }
+    toastTimerRef.current = setTimeout(() => {
+      setToastMessage(null);
+    }, 1800);
+  };
 
   return (
     <View className="flex-1 bg-fill-normal">
@@ -128,15 +165,40 @@ export default function RecordScreen() {
               ) : (
                 <Clive2Svg width="100%" height="100%" />
               )}
+              {toastMessage && (
+                <View style={styles.savedToast}>
+                  <View style={styles.savedToastCheckCircle}>
+                    <Text style={styles.savedToastCheck}>✓</Text>
+                  </View>
+                  <Text style={styles.savedToastText}>
+                    {toastMessage === 'public' ? '세모피드에 공개' : '사진에 저장 완료'}
+                  </Text>
+                </View>
+              )}
             </View>
             <View style={styles.bottomIconRow}>
-              <TouchableOpacity style={styles.roundIconButton} hitSlop={8}>
-                <LockIcon size={24} />
+              <TouchableOpacity
+                style={[
+                  styles.roundIconButton,
+                  isClivePublic && styles.roundIconButtonActive,
+                ]}
+                hitSlop={8}
+                onPress={() => {
+                  if (!isClivePublic) {
+                    setShowPublicDialog(true);
+                  }
+                }}
+              >
+                {isClivePublic ? <GlobeSimpleIcon size={24} color="#FFFFFF" /> : <LockIcon size={24} />}
               </TouchableOpacity>
-              <TouchableOpacity style={styles.roundIconButton} hitSlop={8}>
+              <TouchableOpacity style={styles.roundIconButton} hitSlop={8} onPress={handleSavePress}>
                 <DownloadSimpleIcon size={24} />
               </TouchableOpacity>
-              <TouchableOpacity style={styles.roundIconButton} hitSlop={8}>
+              <TouchableOpacity
+                style={styles.roundIconButton}
+                hitSlop={8}
+                onPress={() => setShowMoreSheet(true)}
+              >
                 <DotsThreeIcon size={24} />
               </TouchableOpacity>
             </View>
@@ -149,6 +211,60 @@ export default function RecordScreen() {
           </View>
         )}
       </ScrollView>
+
+      {showMoreSheet && (
+        <View style={styles.moreSheetBackdrop}>
+          <TouchableOpacity
+            style={StyleSheet.absoluteFillObject}
+            activeOpacity={1}
+            onPress={() => setShowMoreSheet(false)}
+          />
+          <View style={styles.moreSheetContainer}>
+            <View style={styles.moreSheetBody}>
+              <TouchableOpacity style={styles.moreSheetItemRow} onPress={() => setShowMoreSheet(false)}>
+                <LinkSimpleIcon size={20} />
+                <Text style={styles.moreSheetItemText}>세모피드에서 보기</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.moreSheetItemRowLast}
+                onPress={() => {
+                  setShowMoreSheet(false);
+                  handleSavePress();
+                }}
+              >
+                <DownloadSimpleIcon size={20} />
+                <Text style={styles.moreSheetItemText}>원본 사진 저장하기</Text>
+              </TouchableOpacity>
+            </View>
+            <View style={styles.moreSheetCancelWrap}>
+              <TouchableOpacity style={styles.moreSheetCancelButton} onPress={() => setShowMoreSheet(false)}>
+                <Text style={styles.moreSheetCancelText}>취소</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      )}
+
+      {showPublicDialog && (
+        <View style={styles.dialogBackdrop}>
+          <TouchableOpacity
+            style={StyleSheet.absoluteFillObject}
+            activeOpacity={1}
+            onPress={() => setShowPublicDialog(false)}
+          />
+          <View style={styles.dialogCard}>
+            <Text style={styles.dialogTitle}>세모피드에 클라이브를 공개할까요?</Text>
+            <View style={styles.dialogButtonRow}>
+              <TouchableOpacity style={styles.dialogCancelButton} onPress={() => setShowPublicDialog(false)}>
+                <Text style={styles.dialogCancelText}>취소</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.dialogConfirmButton} onPress={handleConfirmPublic}>
+                <Text style={styles.dialogConfirmText}>확인</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      )}
     </View>
   );
 }
@@ -208,6 +324,41 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
+  savedToast: {
+    position: 'absolute',
+    left: '50%',
+    bottom: 16,
+    transform: [{ translateX: -72 }],
+    height: 48,
+    borderRadius: 12,
+    backgroundColor: '#2F323A',
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  savedToastCheckCircle: {
+    width: 20,
+    height: 20,
+    borderRadius: 999,
+    borderWidth: 1.5,
+    borderColor: '#FFFFFF',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  savedToastCheck: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '700',
+    lineHeight: 12,
+  },
+  savedToastText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 21,
+    letterSpacing: -0.14,
+  },
   statItem: {
     flex: 1,
     alignItems: 'center',
@@ -252,6 +403,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  roundIconButtonActive: {
+    backgroundColor: '#1A1B1F',
+    borderColor: '#1A1B1F',
+  },
   shareIconButton: {
     width: 48,
     height: 48,
@@ -270,5 +425,128 @@ const styles = StyleSheet.create({
     gap: 12,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  dialogBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 10,
+  },
+  dialogCard: {
+    width: 320,
+    borderRadius: 16,
+    backgroundColor: '#FFFFFF',
+    paddingTop: 20,
+  },
+  dialogTitle: {
+    paddingHorizontal: 20,
+    color: 'rgba(0,12,30,0.8)',
+    fontSize: 20,
+    fontWeight: '600',
+    lineHeight: 26,
+    letterSpacing: -0.4,
+  },
+  dialogButtonRow: {
+    height: 84,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 20,
+    paddingBottom: 16,
+  },
+  dialogCancelButton: {
+    flex: 1,
+    minHeight: 48,
+    maxHeight: 48,
+    borderRadius: 10,
+    backgroundColor: '#F0F2F4',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dialogCancelText: {
+    color: '#464A57',
+    fontSize: 17,
+    fontWeight: '600',
+    lineHeight: 26,
+    letterSpacing: -0.255,
+  },
+  dialogConfirmButton: {
+    flex: 1,
+    minHeight: 48,
+    maxHeight: 48,
+    borderRadius: 10,
+    backgroundColor: '#1A1B1F',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  dialogConfirmText: {
+    color: '#FFFFFF',
+    fontSize: 17,
+    fontWeight: '600',
+    lineHeight: 26,
+    letterSpacing: -0.255,
+  },
+  moreSheetBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    justifyContent: 'flex-end',
+  },
+  moreSheetContainer: {
+    backgroundColor: '#FFFFFF',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    overflow: 'hidden',
+  },
+  moreSheetBody: {
+    paddingTop: 20,
+    paddingHorizontal: 20,
+    backgroundColor: '#FFFFFF',
+  },
+  moreSheetItemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingBottom: 16,
+    marginBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  moreSheetItemRowLast: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingBottom: 16,
+  },
+  moreSheetItemText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#1A1B1F',
+    lineHeight: 24,
+    letterSpacing: -0.16,
+  },
+  moreSheetCancelWrap: {
+    height: 84,
+    paddingTop: 20,
+    paddingBottom: 16,
+    paddingHorizontal: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  moreSheetCancelButton: {
+    flex: 1,
+    borderRadius: 10,
+    minHeight: 48,
+    maxHeight: 48,
+    backgroundColor: 'rgba(26,27,31,0.05)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  moreSheetCancelText: {
+    color: '#1A1B1F',
+    fontSize: 17,
+    fontWeight: '600',
+    lineHeight: 26,
+    letterSpacing: -0.255,
   },
 });

--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -166,22 +166,23 @@ export default function RecordScreen() {
                 <Clive2Svg width="100%" height="100%" />
               )}
               {toastMessage && (
-                <View style={styles.savedToast}>
-                  <View style={styles.savedToastCheckCircle}>
-                    <Text style={styles.savedToastCheck}>✓</Text>
+                <View className="absolute bottom-4 self-center h-12 rounded-xl bg-fill-heavy flex-row items-center px-4 gap-2">
+                  <View className="w-5 h-5 rounded-full border-[1.5px] border-fill-normal items-center justify-center">
+                    <Text className="text-fill-normal text-[12px] font-bold leading-3">✓</Text>
                   </View>
-                  <Text style={styles.savedToastText}>
+                  <Text className="typo-body-2-normal-medium text-label-normal-inverse">
                     {toastMessage === 'public' ? '세모피드에 공개' : '사진에 저장 완료'}
                   </Text>
                 </View>
               )}
             </View>
-            <View style={styles.bottomIconRow}>
+            <View className="mt-3 flex-row gap-3 items-center justify-center">
               <TouchableOpacity
-                style={[
-                  styles.roundIconButton,
-                  isClivePublic && styles.roundIconButtonActive,
-                ]}
+                className={`w-12 h-12 rounded-full border items-center justify-center ${
+                  isClivePublic
+                    ? 'bg-primary-normal border-primary-normal'
+                    : 'bg-fill-normal border-line-normal'
+                }`}
                 hitSlop={8}
                 onPress={() => {
                   if (!isClivePublic) {
@@ -191,11 +192,15 @@ export default function RecordScreen() {
               >
                 {isClivePublic ? <GlobeSimpleIcon size={24} color="#FFFFFF" /> : <LockIcon size={24} />}
               </TouchableOpacity>
-              <TouchableOpacity style={styles.roundIconButton} hitSlop={8} onPress={handleSavePress}>
+              <TouchableOpacity
+                className="w-12 h-12 rounded-full border border-line-normal bg-fill-normal items-center justify-center"
+                hitSlop={8}
+                onPress={handleSavePress}
+              >
                 <DownloadSimpleIcon size={24} />
               </TouchableOpacity>
               <TouchableOpacity
-                style={styles.roundIconButton}
+                className="w-12 h-12 rounded-full border border-line-normal bg-fill-normal items-center justify-center"
                 hitSlop={8}
                 onPress={() => setShowMoreSheet(true)}
               >
@@ -213,32 +218,38 @@ export default function RecordScreen() {
       </ScrollView>
 
       {showMoreSheet && (
-        <View style={styles.moreSheetBackdrop}>
+        <View className="absolute inset-0 bg-[rgba(0,0,0,0.3)] justify-end">
           <TouchableOpacity
-            style={StyleSheet.absoluteFillObject}
+            style={{ ...StyleSheet.absoluteFillObject }}
             activeOpacity={1}
             onPress={() => setShowMoreSheet(false)}
           />
-          <View style={styles.moreSheetContainer}>
-            <View style={styles.moreSheetBody}>
-              <TouchableOpacity style={styles.moreSheetItemRow} onPress={() => setShowMoreSheet(false)}>
+          <View className="bg-fill-normal rounded-t-[20px] overflow-hidden">
+            <View className="pt-5 px-5 bg-fill-normal">
+              <TouchableOpacity
+                className="flex-row items-center gap-3 pb-4 mb-4 border-b border-line-subtle"
+                onPress={() => setShowMoreSheet(false)}
+              >
                 <LinkSimpleIcon size={20} />
-                <Text style={styles.moreSheetItemText}>세모피드에서 보기</Text>
+                <Text className="typo-body-1-normal-medium text-label-normal">세모피드에서 보기</Text>
               </TouchableOpacity>
               <TouchableOpacity
-                style={styles.moreSheetItemRowLast}
+                className="flex-row items-center gap-3 pb-4"
                 onPress={() => {
                   setShowMoreSheet(false);
                   handleSavePress();
                 }}
               >
                 <DownloadSimpleIcon size={20} />
-                <Text style={styles.moreSheetItemText}>원본 사진 저장하기</Text>
+                <Text className="typo-body-1-normal-medium text-label-normal">원본 사진 저장하기</Text>
               </TouchableOpacity>
             </View>
-            <View style={styles.moreSheetCancelWrap}>
-              <TouchableOpacity style={styles.moreSheetCancelButton} onPress={() => setShowMoreSheet(false)}>
-                <Text style={styles.moreSheetCancelText}>취소</Text>
+            <View className="h-[84px] pt-5 pb-4 px-4 bg-fill-normal">
+              <TouchableOpacity
+                className="flex-1 min-h-12 max-h-12 rounded-[10px] bg-[rgba(26,27,31,0.05)] items-center justify-center"
+                onPress={() => setShowMoreSheet(false)}
+              >
+                <Text className="text-[17px] font-semibold text-label-normal leading-[26px]">취소</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -246,20 +257,28 @@ export default function RecordScreen() {
       )}
 
       {showPublicDialog && (
-        <View style={styles.dialogBackdrop}>
+        <View className="absolute inset-0 bg-[rgba(0,0,0,0.3)] items-center justify-center px-[10px]">
           <TouchableOpacity
-            style={StyleSheet.absoluteFillObject}
+            style={{ ...StyleSheet.absoluteFillObject }}
             activeOpacity={1}
             onPress={() => setShowPublicDialog(false)}
           />
-          <View style={styles.dialogCard}>
-            <Text style={styles.dialogTitle}>세모피드에 클라이브를 공개할까요?</Text>
-            <View style={styles.dialogButtonRow}>
-              <TouchableOpacity style={styles.dialogCancelButton} onPress={() => setShowPublicDialog(false)}>
-                <Text style={styles.dialogCancelText}>취소</Text>
+          <View className="w-[320px] rounded-2xl bg-fill-normal pt-5">
+            <Text className="px-5 text-[20px] font-semibold leading-[26px] tracking-[-0.4px] text-[rgba(0,12,30,0.8)]">
+              세모피드에 클라이브를 공개할까요?
+            </Text>
+            <View className="h-[84px] flex-row items-center gap-2 px-4 pt-5 pb-4">
+              <TouchableOpacity
+                className="flex-1 min-h-12 max-h-12 rounded-[10px] bg-fill-stronger items-center justify-center"
+                onPress={() => setShowPublicDialog(false)}
+              >
+                <Text className="text-[17px] font-semibold text-label-subtle leading-[26px]">취소</Text>
               </TouchableOpacity>
-              <TouchableOpacity style={styles.dialogConfirmButton} onPress={handleConfirmPublic}>
-                <Text style={styles.dialogConfirmText}>확인</Text>
+              <TouchableOpacity
+                className="flex-1 min-h-12 max-h-12 rounded-[10px] bg-primary-normal items-center justify-center"
+                onPress={handleConfirmPublic}
+              >
+                <Text className="text-[17px] font-semibold text-label-normal-inverse leading-[26px]">확인</Text>
               </TouchableOpacity>
             </View>
           </View>
@@ -324,41 +343,6 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
-  savedToast: {
-    position: 'absolute',
-    left: '50%',
-    bottom: 16,
-    transform: [{ translateX: -72 }],
-    height: 48,
-    borderRadius: 12,
-    backgroundColor: '#2F323A',
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    gap: 8,
-  },
-  savedToastCheckCircle: {
-    width: 20,
-    height: 20,
-    borderRadius: 999,
-    borderWidth: 1.5,
-    borderColor: '#FFFFFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  savedToastCheck: {
-    color: '#FFFFFF',
-    fontSize: 12,
-    fontWeight: '700',
-    lineHeight: 12,
-  },
-  savedToastText: {
-    color: '#FFFFFF',
-    fontSize: 14,
-    fontWeight: '500',
-    lineHeight: 21,
-    letterSpacing: -0.14,
-  },
   statItem: {
     flex: 1,
     alignItems: 'center',
@@ -393,20 +377,6 @@ const styles = StyleSheet.create({
   tabInactive: {
     color: '#BFC4D1',
   },
-  roundIconButton: {
-    width: 48,
-    height: 48,
-    borderRadius: 999,
-    borderWidth: 1,
-    borderColor: '#D1D5DB',
-    backgroundColor: '#FFFFFF',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  roundIconButtonActive: {
-    backgroundColor: '#1A1B1F',
-    borderColor: '#1A1B1F',
-  },
   shareIconButton: {
     width: 48,
     height: 48,
@@ -418,135 +388,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 16,
     paddingVertical: 13,
-  },
-  bottomIconRow: {
-    marginTop: 12,
-    flexDirection: 'row',
-    gap: 12,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  dialogBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 10,
-  },
-  dialogCard: {
-    width: 320,
-    borderRadius: 16,
-    backgroundColor: '#FFFFFF',
-    paddingTop: 20,
-  },
-  dialogTitle: {
-    paddingHorizontal: 20,
-    color: 'rgba(0,12,30,0.8)',
-    fontSize: 20,
-    fontWeight: '600',
-    lineHeight: 26,
-    letterSpacing: -0.4,
-  },
-  dialogButtonRow: {
-    height: 84,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    paddingHorizontal: 16,
-    paddingTop: 20,
-    paddingBottom: 16,
-  },
-  dialogCancelButton: {
-    flex: 1,
-    minHeight: 48,
-    maxHeight: 48,
-    borderRadius: 10,
-    backgroundColor: '#F0F2F4',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  dialogCancelText: {
-    color: '#464A57',
-    fontSize: 17,
-    fontWeight: '600',
-    lineHeight: 26,
-    letterSpacing: -0.255,
-  },
-  dialogConfirmButton: {
-    flex: 1,
-    minHeight: 48,
-    maxHeight: 48,
-    borderRadius: 10,
-    backgroundColor: '#1A1B1F',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  dialogConfirmText: {
-    color: '#FFFFFF',
-    fontSize: 17,
-    fontWeight: '600',
-    lineHeight: 26,
-    letterSpacing: -0.255,
-  },
-  moreSheetBackdrop: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: 'rgba(0,0,0,0.3)',
-    justifyContent: 'flex-end',
-  },
-  moreSheetContainer: {
-    backgroundColor: '#FFFFFF',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    overflow: 'hidden',
-  },
-  moreSheetBody: {
-    paddingTop: 20,
-    paddingHorizontal: 20,
-    backgroundColor: '#FFFFFF',
-  },
-  moreSheetItemRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingBottom: 16,
-    marginBottom: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
-  },
-  moreSheetItemRowLast: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    paddingBottom: 16,
-  },
-  moreSheetItemText: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: '#1A1B1F',
-    lineHeight: 24,
-    letterSpacing: -0.16,
-  },
-  moreSheetCancelWrap: {
-    height: 84,
-    paddingTop: 20,
-    paddingBottom: 16,
-    paddingHorizontal: 16,
-    backgroundColor: '#FFFFFF',
-  },
-  moreSheetCancelButton: {
-    flex: 1,
-    borderRadius: 10,
-    minHeight: 48,
-    maxHeight: 48,
-    backgroundColor: 'rgba(26,27,31,0.05)',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  moreSheetCancelText: {
-    color: '#1A1B1F',
-    fontSize: 17,
-    fontWeight: '600',
-    lineHeight: 26,
-    letterSpacing: -0.255,
   },
 });

--- a/components/icons/globe-simple-icon.tsx
+++ b/components/icons/globe-simple-icon.tsx
@@ -1,0 +1,27 @@
+import Svg, { Circle, Path } from 'react-native-svg';
+
+type GlobeSimpleIconProps = {
+  size?: number;
+  color?: string;
+};
+
+export function GlobeSimpleIcon({ size = 24, color = '#FFFFFF' }: GlobeSimpleIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Circle cx={12} cy={12} r={9} stroke={color} strokeWidth={1.8} />
+      <Path d="M3.5 12H20.5" stroke={color} strokeWidth={1.8} strokeLinecap="round" />
+      <Path
+        d="M12 3.2C14.2 5.4 15.5 8.6 15.5 12C15.5 15.4 14.2 18.6 12 20.8"
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+      <Path
+        d="M12 3.2C9.8 5.4 8.5 8.6 8.5 12C8.5 15.4 9.8 18.6 12 20.8"
+        stroke={color}
+        strokeWidth={1.8}
+        strokeLinecap="round"
+      />
+    </Svg>
+  );
+}

--- a/components/icons/link-simple-icon.tsx
+++ b/components/icons/link-simple-icon.tsx
@@ -1,0 +1,24 @@
+import { Path, Svg } from 'react-native-svg';
+
+type Props = { size?: number; color?: string };
+
+export function LinkSimpleIcon({ size = 20, color = '#1A1B1F' }: Props) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 20 20" fill="none">
+      <Path
+        d="M5.8 2.8H12.4C14.75 2.8 16.2 4.25 16.2 6.6V13.2C16.2 15.55 14.75 17 12.4 17H5.8C3.45 17 2 15.55 2 13.2V6.6C2 4.25 3.45 2.8 5.8 2.8Z"
+        stroke={color}
+        strokeWidth={1.7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M11.4 17V13.6C11.4 12.5 12 11.9 13.1 11.9H16.2"
+        stroke={color}
+        strokeWidth={1.7}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  );
+}


### PR DESCRIPTION
## **Summary**
클라이브 화면의 하단 액션 UX를 Figma 기준으로 확장해, 공개 전환/저장/더보기 플로우를 완성했습니다.
자물쇠 버튼 공개 전환 상태와 토스트 피드백, 점 세 개 버튼 기반 하단 바텀시트까지 연결해 사용자 액션 흐름을 일관되게 정리했습니다.

## **Changes**
- `app/record/[id].tsx`
→ 클라이브 하단 액션 상태 관리 추가 (public 전환, 토스트, 더보기 시트)
→ 자물쇠 버튼 클릭 시 공개 확인 다이얼로그 노출 (취소/확인)
→ 공개 확인 시 세모피드에 공개 토스트 노출 + 자물쇠 버튼을 퍼블릭 아이콘(검정 배경)으로 전환
→ 다운로드 버튼 클릭 시 사진에 저장 완료 토스트 노출
→ 점 세 개 더보기 버튼 클릭 시 Figma 가이드 기반 하단 바텀시트 노출
→ 바텀시트 액션 구성: 세모피드에서 보기, 원본 사진 저장하기, 취소, 딤 영역 탭 닫기

- `components/icons/globe-simple-icon.tsx`
→ 퍼블릭 상태용 지구본 아이콘 컴포넌트 추가

- `components/icons/link-simple-icon.tsx`
→ 더보기 바텀시트의 세모피드에서 보기 아이콘을 피그마 형태로 반영