### PR TITLE
fix(temp): 웹 바텀시트 렌더링 및 네비바 z-index 수정 [UT대응 임시]

### DIFF
--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -40,7 +40,7 @@ export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarPro
   return (
     <View
       className="bg-fill-normal border-t border-line-subtle flex-row items-center justify-between px-5"
-      style={{ paddingBottom: Math.max(insets.bottom, 4), paddingTop: 4 }}
+      style={{ paddingBottom: Math.max(insets.bottom, 4), paddingTop: 4, zIndex: -100 }}
     >
       {state.routes.map((route, index) => {
         const item = TAB_ITEMS[index];

--- a/features/mountains/components/filter-bottom-sheet.tsx
+++ b/features/mountains/components/filter-bottom-sheet.tsx
@@ -2,6 +2,7 @@ import { ReactNode, useEffect, useState } from "react";
 import {
   Keyboard,
   Modal,
+  Platform,
   Pressable,
   Text,
   TouchableWithoutFeedback,
@@ -108,6 +109,63 @@ export function FilterBottomSheet({
     opacity: backdropOpacity.value,
   }));
 
+  const backdrop = (
+    <Animated.View
+      className="absolute inset-0"
+      style={[{ backgroundColor: "rgba(0,0,0,0.2)" }, backdropStyle]}
+    >
+      <Pressable className="absolute inset-0" onPress={handleDismiss} />
+    </Animated.View>
+  );
+
+  const sheet = (
+    <Animated.View
+      className="absolute bottom-0 left-0 right-0 overflow-hidden rounded-tl-[20px] rounded-tr-[20px] bg-fill-normal"
+      style={[{ paddingBottom: insets.bottom }, sheetStyle]}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <View>
+          {/* Drag handle */}
+          <View className="items-center pb-2" />
+
+          {/* Title */}
+          <View className="px-5 pb-1 pt-3">
+            <Text className="text-label-subtle typo-body-2-normal-medium">
+              {title}
+            </Text>
+          </View>
+
+          {children}
+        </View>
+      </TouchableWithoutFeedback>
+    </Animated.View>
+  );
+
+  if (Platform.OS === 'web') {
+    if (!modalVisible) return null;
+    return (
+      <View style={{ position: 'fixed' as any, top: 0, left: 0, right: 0, bottom: 0, zIndex: 99999 }}>
+        <Pressable
+          className="absolute inset-0"
+          style={{ backgroundColor: 'rgba(0,0,0,0.2)' }}
+          onPress={handleDismiss}
+        />
+        <View
+          className="absolute bottom-0 left-0 right-0 rounded-tl-[20px] rounded-tr-[20px] bg-fill-normal"
+          style={{ paddingBottom: insets.bottom }}
+        >
+          <View className="items-center pb-2" />
+          <View className="px-5 pb-1 pt-3">
+            <Text className="text-label-subtle typo-body-2-normal-medium">
+              {title}
+            </Text>
+          </View>
+          {children}
+        </View>
+      </View>
+    );
+  }
+
   return (
     <Modal
       visible={modalVisible}
@@ -117,41 +175,11 @@ export function FilterBottomSheet({
       presentationStyle="overFullScreen"
       statusBarTranslucent
     >
-      {/* Modal은 별도 네이티브 뷰 계층에 렌더링되므로 GestureHandlerRootView를 직접 감싸야 함 */}
+      {/* 네이티브: Modal은 별도 뷰 계층이므로 GestureHandlerRootView 필요 */}
       <GestureHandlerRootView className="flex-1">
-        {/* Backdrop */}
-        <Animated.View
-          className="absolute inset-0"
-          style={[{ backgroundColor: "rgba(0,0,0,0.2)" }, backdropStyle]}
-        >
-          <Pressable className="absolute inset-0" onPress={handleDismiss} />
-        </Animated.View>
-
-        {/* Sheet */}
+        {backdrop}
         <GestureDetector gesture={panGesture}>
-          <Animated.View
-            className="absolute bottom-0 left-0 right-0 overflow-hidden rounded-tl-[20px] rounded-tr-[20px] bg-fill-normal"
-            style={[{ paddingBottom: insets.bottom }, sheetStyle]}
-          >
-            <TouchableWithoutFeedback
-              onPress={Keyboard.dismiss}
-              accessible={false}
-            >
-              <View>
-                {/* Drag handle */}
-                <View className="items-center pb-2" />
-
-                {/* Title */}
-                <View className="px-5 pb-1 pt-3">
-                  <Text className="text-label-subtle typo-body-2-normal-medium">
-                    {title}
-                  </Text>
-                </View>
-
-                {children}
-              </View>
-            </TouchableWithoutFeedback>
-          </Animated.View>
+          {sheet}
         </GestureDetector>
       </GestureHandlerRootView>
     </Modal>


### PR DESCRIPTION
## Summary

> ⚠️ UT 대응용 임시 PR — 이후 롤백 예정

- `FilterBottomSheet` 웹 환경에서 `Modal` + `react-native-gesture-handler` 대신 `position: fixed` View로 렌더링 교체 (Modal이 웹 포털 환경에서 깨지는 문제 해결)
- `BottomTabBar`에 `zIndex: -100` 임시 적용 (바텀시트에 네비바가 가려지는 현상 해결)

## Test plan

- [ ] 웹에서 필터 바텀시트 정상 오픈 확인
- [ ] 바텀시트가 네비바 위에 표시되는지 확인
- [ ] 네이티브에서 기존 동작(슬라이드 애니메이션, 스와이프 닫기) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)