### PR TITLE
fix(course): 코스 상세에서 트래킹 진입 시 collapse 파라미터 전달

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,14 @@ Figma 재내보내기 후 반드시 실행하세요. `tokens.cjs`, `typography-p
 
 ---
 
+## 코드 스타일
+
+### Prettier
+
+`.prettierrc`에 `singleQuote` 설정이 없으므로 Prettier 기본값인 **double quotes (`"`)** 를 사용한다. single quote (`'`) 사용 금지.
+
+---
+
 ## 스타일링 규칙
 
 ### 1. NativeWind의 `className`을 항상 사용할 것

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1,40 +1,44 @@
-import { LocationIcon } from '@/components/icons/location-icon';
-import { TrackingCourseCard } from '@/features/tracking/components/tracking-course-card';
-import { CollapsedCourseCard } from '@/features/tracking/components/collapsed-course-card';
-import { SummitSheet } from '@/features/tracking/components/summit-sheet';
-import { StopConfirmModal } from '@/features/tracking/components/stop-confirm-modal';
-import { DifficultyRatingModal } from '@/features/tracking/components/difficulty-rating-modal';
-import { TrailAvatarMarker } from '@/features/tracking/components/trail-avatar-marker';
-import { CourseSelectSheet } from '@/features/tracking/components/course-select-sheet';
-import { TrackingSheet } from '@/features/tracking/components/tracking-sheet';
+import { LocationIcon } from "@/components/icons/location-icon";
+import { CollapsedCourseCard } from "@/features/tracking/components/collapsed-course-card";
+import { CountdownOverlay } from "@/features/tracking/components/countdown-overlay";
+import { CourseSelectSheet } from "@/features/tracking/components/course-select-sheet";
+import { DifficultyRatingModal } from "@/features/tracking/components/difficulty-rating-modal";
+import { StopConfirmModal } from "@/features/tracking/components/stop-confirm-modal";
+import { SummitSheet } from "@/features/tracking/components/summit-sheet";
+import { TrackingCourseCard } from "@/features/tracking/components/tracking-course-card";
+import { TrackingSheet } from "@/features/tracking/components/tracking-sheet";
+import { TrailAvatarMarker } from "@/features/tracking/components/trail-avatar-marker";
 import {
-  CARD_SHADOW,
   COLLAPSED_PEEK_HEIGHT,
-  DIFFICULTY_BG,
-  DIFFICULTY_TEXT_COLOR,
   FLOATING_CARD_GAP,
+  LOCATION_BUTTON_GAP,
   MOCK_COURSES,
   SHADOW,
-  TRAIL_BAR_COLORS,
-  LOCATION_BUTTON_GAP,
   TRACKING_COURSE_CARD_HEIGHT,
   TRACKING_COURSE_CARD_TOP,
   TRACKING_SHEET_HEIGHT,
+  TRAIL_BAR_COLORS,
   TRAIL_BAR_GAP,
   TRAIL_BAR_LEFT,
-  TRAIL_MARKER_LEFT,
   TRAIL_BAR_LOCATIONS,
   TRAIL_BAR_WIDTH,
-} from '@/features/tracking/constants';
-import { CountdownOverlay } from '@/features/tracking/components/countdown-overlay';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Tabs } from 'expo-router';
-import { useEffect, useState } from 'react';
-import { LayoutChangeEvent, Text, TouchableOpacity, View } from 'react-native';
+  TRAIL_MARKER_LEFT,
+} from "@/features/tracking/constants";
+import { LinearGradient } from "expo-linear-gradient";
+import { Tabs, useLocalSearchParams } from "expo-router";
+import { useEffect, useState } from "react";
+import { LayoutChangeEvent, Text, TouchableOpacity, View } from "react-native";
 
 export default function TrackingScreen() {
-  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(false);
+  const { collapse: collapseParameter, courseId: courseIdParameter } =
+    useLocalSearchParams<{
+      collapse?: string;
+      courseId?: string;
+    }>();
+  const [selectedCourseId, setSelectedCourseId] = useState<string | null>(
+    courseIdParameter ?? null,
+  );
+  const [collapsed, setCollapsed] = useState(collapseParameter === "true");
   const [countdown, setCountdown] = useState<number | null>(null);
   const [isTracking, setIsTracking] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
@@ -43,15 +47,21 @@ export default function TrackingScreen() {
   // TODO: 실제 구현 시 GPS 좌표 기반으로 정상 도달 여부 판단
   const [isAtSummit, setIsAtSummit] = useState(true); // 목 값
   const [showSummitSheet, setShowSummitSheet] = useState(false);
-  const [trackingSheetHeight, setTrackingSheetHeight] = useState(TRACKING_SHEET_HEIGHT);
+  const [trackingSheetHeight, setTrackingSheetHeight] = useState(
+    TRACKING_SHEET_HEIGHT,
+  );
   const [showStopModal, setShowStopModal] = useState(false);
   const [showDifficultyRating, setShowDifficultyRating] = useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
-  const [barLayout, setBarLayout] = useState<{ top: number; height: number } | null>(null);
+  const [barLayout, setBarLayout] = useState<{
+    top: number;
+    height: number;
+  } | null>(null);
   // 마커 Y 비율: 0.0(바 상단/최고도) ~ 1.0(바 하단/최저도), 추후 실제 고도로 대체
   const markerRatio = 0.8;
 
-  const selectedCourse = MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
+  const selectedCourse =
+    MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
 
   const startCountdown = () => setCountdown(3);
 
@@ -62,7 +72,10 @@ export default function TrackingScreen() {
       setCountdown(null);
       return;
     }
-    const timer = setTimeout(() => setCountdown((c) => (c !== null ? c - 1 : null)), 1000);
+    const timer = setTimeout(
+      () => setCountdown((c) => (c !== null ? c - 1 : null)),
+      1000,
+    );
     return () => clearTimeout(timer);
   }, [countdown]);
 
@@ -107,15 +120,19 @@ export default function TrackingScreen() {
   return (
     <View className="flex-1 bg-fill-stronger">
       {/* 트래킹 중 탭바 숨기기 */}
-      <Tabs.Screen options={{ tabBarStyle: isTracking ? { display: 'none' } : undefined }} />
+      <Tabs.Screen
+        options={{ tabBarStyle: isTracking ? { display: "none" } : undefined }}
+      />
 
       {/* 지도 영역 */}
       <TouchableOpacity
         activeOpacity={1}
-        className="flex-1 bg-fill-stronger items-center justify-center"
+        className="flex-1 items-center justify-center bg-fill-stronger"
         onPress={() => !isTracking && setCollapsed(true)}
       >
-        <Text className="typo-body-2-normal-medium text-label-disabled">지도 영역</Text>
+        <Text className="text-label-disabled typo-body-2-normal-medium">
+          지도 영역
+        </Text>
 
         {/* 트래킹 중 — 고도 그라데이션 바 + 아바타 마커 */}
         {isTracking && (
@@ -130,9 +147,12 @@ export default function TrackingScreen() {
                 setBarLayout({ top: y, height });
               }}
               style={{
-                position: 'absolute',
+                position: "absolute",
                 left: TRAIL_BAR_LEFT,
-                top: TRACKING_COURSE_CARD_TOP + TRACKING_COURSE_CARD_HEIGHT + TRAIL_BAR_GAP,
+                top:
+                  TRACKING_COURSE_CARD_TOP +
+                  TRACKING_COURSE_CARD_HEIGHT +
+                  TRAIL_BAR_GAP,
                 bottom: TRAIL_BAR_GAP,
                 width: TRAIL_BAR_WIDTH,
                 borderRadius: 999,
@@ -158,7 +178,7 @@ export default function TrackingScreen() {
 
       {/* 위치 버튼 */}
       <TouchableOpacity
-        className="absolute right-4 bg-fill-normal rounded-full w-12 h-12 items-center justify-center"
+        className="absolute right-4 h-12 w-12 items-center justify-center rounded-full bg-fill-normal"
         style={{
           bottom: isTracking
             ? trackingSheetHeight + LOCATION_BUTTON_GAP
@@ -192,7 +212,11 @@ export default function TrackingScreen() {
 
       {/* 트래킹 중 바텀시트 */}
       {isTracking && (
-        <View onLayout={(e: LayoutChangeEvent) => setTrackingSheetHeight(e.nativeEvent.layout.height)}>
+        <View
+          onLayout={(e: LayoutChangeEvent) =>
+            setTrackingSheetHeight(e.nativeEvent.layout.height)
+          }
+        >
           {showSummitSheet ? (
             <SummitSheet
               onCertify={() => setShowDifficultyRating(true)}

--- a/app/mountains/courses/[id].tsx
+++ b/app/mountains/courses/[id].tsx
@@ -182,7 +182,9 @@ export default function CourseDetailScreen(): React.JSX.Element {
           pointerEvents="box-none"
         >
           <TouchableOpacity
-            onPress={() => router.push("/(tabs)/tracking?collapse=true")}
+            onPress={() =>
+              router.push(`/(tabs)/tracking?collapse=true&courseId=${id}`)
+            }
             className="flex-row items-center gap-2 rounded-full bg-primary-normal px-5 py-3"
           >
             <RouteIcon />

--- a/app/mountains/courses/[id].tsx
+++ b/app/mountains/courses/[id].tsx
@@ -63,7 +63,7 @@ export default function CourseDetailScreen(): React.JSX.Element {
           <View className="mx-5 h-[200px] overflow-hidden rounded-[20px] bg-fill-stronger">
             <Image
               source={course.imageSource ?? { uri: course.imageUrl }}
-              style={{ width: '100%', height: '100%' }}
+              style={{ width: "100%", height: "100%" }}
               resizeMode="stretch"
             />
           </View>
@@ -182,7 +182,7 @@ export default function CourseDetailScreen(): React.JSX.Element {
           pointerEvents="box-none"
         >
           <TouchableOpacity
-            onPress={() => router.push('/(tabs)/tracking')}
+            onPress={() => router.push("/(tabs)/tracking?collapse=true")}
             className="flex-row items-center gap-2 rounded-full bg-primary-normal px-5 py-3"
           >
             <RouteIcon />

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -1,14 +1,14 @@
-import { type BottomTabBarProps } from '@react-navigation/bottom-tabs';
-import { ReactNode } from 'react';
-import { Pressable, Text, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { type BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { ReactNode } from "react";
+import { Pressable, Text, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-import { CommunityIcon } from '@/components/icons/community-icon';
-import { HomeIcon } from '@/components/icons/home-icon';
-import { MountainIcon } from '@/components/icons/mountain-icon';
-import { MyIcon } from '@/components/icons/my-icon';
-import { NavigationIcon } from '@/components/icons/navigation-icon';
-import { useHomeStateContext } from '@/contexts/home-state-context';
+import { CommunityIcon } from "@/components/icons/community-icon";
+import { HomeIcon } from "@/components/icons/home-icon";
+import { MountainIcon } from "@/components/icons/mountain-icon";
+import { MyIcon } from "@/components/icons/my-icon";
+import { NavigationIcon } from "@/components/icons/navigation-icon";
+import { useHomeStateContext } from "@/contexts/home-state-context";
 
 type TabItem = {
   name: string;
@@ -17,31 +17,56 @@ type TabItem = {
   isCenter?: boolean;
 };
 
-const ACTIVE_COLOR = '#1a1b1f';
-const INACTIVE_COLOR = '#d1d5db';
+const ACTIVE_COLOR = "#1a1b1f";
+const INACTIVE_COLOR = "#d1d5db";
 
 const TAB_ITEMS: TabItem[] = [
-  { name: 'index', label: '홈', renderIcon: (color) => <HomeIcon size={24} color={color} /> },
-  { name: 'mountains', label: '산목록', renderIcon: (color) => <MountainIcon size={24} color={color} /> },
-  { name: 'tracking', label: null, renderIcon: (color) => <NavigationIcon size={24} color={color} />, isCenter: true },
-  { name: 'community', label: '커뮤니티', renderIcon: (color) => <CommunityIcon size={24} color={color} /> },
-  { name: 'mypage', label: 'MY', renderIcon: (color) => <MyIcon size={24} color={color} /> },
+  {
+    name: "index",
+    label: "홈",
+    renderIcon: (color) => <HomeIcon size={24} color={color} />,
+  },
+  {
+    name: "mountains",
+    label: "산목록",
+    renderIcon: (color) => <MountainIcon size={24} color={color} />,
+  },
+  {
+    name: "tracking",
+    label: null,
+    renderIcon: (color) => <NavigationIcon size={24} color={color} />,
+    isCenter: true,
+  },
+  {
+    name: "community",
+    label: "커뮤니티",
+    renderIcon: (color) => <CommunityIcon size={24} color={color} />,
+  },
+  {
+    name: "mypage",
+    label: "MY",
+    renderIcon: (color) => <MyIcon size={24} color={color} />,
+  },
 ];
 
-export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+export function BottomTabBar({
+  state,
+  descriptors,
+  navigation,
+}: BottomTabBarProps) {
   const insets = useSafeAreaInsets();
   const { hasRecords, toggleHasRecords } = useHomeStateContext();
 
   // 현재 활성 라우트의 tabBarStyle이 hidden이면 탭바 숨기기
   const currentRoute = state.routes[state.index];
   const { tabBarStyle } = descriptors[currentRoute.key].options;
-  if (tabBarStyle && (tabBarStyle as { display?: string }).display === 'none') {
+  if (tabBarStyle && (tabBarStyle as { display?: string }).display === "none") {
     return null;
   }
 
   return (
     <View
-      className="bg-fill-normal border-t border-line-subtle flex-row items-center justify-between px-5"
+      className="flex-row items-center justify-between border-t border-line-subtle bg-fill-normal px-5"
       style={{ paddingBottom: Math.max(insets.bottom, 4), paddingTop: 4 }}
     >
       {state.routes.map((route, index) => {
@@ -52,7 +77,7 @@ export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarPro
 
         const onPress = () => {
           const event = navigation.emit({
-            type: 'tabPress',
+            type: "tabPress",
             target: route.key,
             canPreventDefault: true,
           });
@@ -68,10 +93,10 @@ export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarPro
               onPress={onPress}
               onLongPress={toggleHasRecords}
               delayLongPress={500}
-              className="bg-primary-normal items-center justify-center rounded-full"
+              className="items-center justify-center rounded-full bg-primary-normal"
               style={{ width: 68, height: 42 }}
             >
-              {item.renderIcon('#ffffff')}
+              {item.renderIcon("#ffffff")}
             </Pressable>
           );
         }
@@ -80,12 +105,12 @@ export function BottomTabBar({ state, descriptors, navigation }: BottomTabBarPro
           <Pressable
             key={route.key}
             onPress={onPress}
-            className="items-center justify-center rounded gap-0.5"
+            className="items-center justify-center gap-0.5 rounded"
             style={{ width: 48, height: 48 }}
           >
             {item.renderIcon(isFocused ? ACTIVE_COLOR : INACTIVE_COLOR)}
             <Text
-              className={`typo-caption-1-medium text-center ${isFocused ? 'text-label-normal' : 'text-neutral-100'}`}
+              className={`text-center typo-caption-1-medium ${isFocused ? "text-label-normal" : "text-neutral-100"}`}
             >
               {item.label}
             </Text>


### PR DESCRIPTION
## Summary

- 코스 상세(`courses/[id].tsx`)에서 코스 따라가기 버튼 클릭 시 `collapse=true` 쿼리 파라미터를 포함하여 트래킹 화면으로 라우팅
- 트래킹 화면(`tracking.tsx`)에서 `useLocalSearchParams`로 `collapse`, `courseId` 초기값을 수신해 상태 초기화
- 전체 파일 single quote → double quote (Prettier 기본값 준수)

## Test plan

- [ ] 코스 상세 페이지 → 코스 따라가기 버튼 클릭 시 트래킹 화면이 collapsed 상태로 진입하는지 확인
- [ ] 트래킹 화면 직접 진입 시 기존 동작(collapsed 아님) 유지되는지 확인
- [ ] 탭바 및 트래킹 화면 UI 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)