### PR TITLE
feat(community): 자유게시판 게시글 작성 화면 구현

### DIFF
--- a/app/(tabs)/community/_layout.tsx
+++ b/app/(tabs)/community/_layout.tsx
@@ -1,5 +1,4 @@
 import { CommunityHeader } from "@/features/community/components/community-header";
-import { CommunityTabBar } from "@/features/community/components/community-tab-bar";
 import { Slot } from "expo-router";
 import React from "react";
 import { View } from "react-native";
@@ -11,7 +10,6 @@ export default function CommunityLayout(): React.JSX.Element {
   return (
     <View className="flex-1 bg-fill-normal" style={{ paddingTop: insets.top }}>
       <CommunityHeader />
-      <CommunityTabBar />
       <Slot />
     </View>
   );

--- a/app/(tabs)/community/index.tsx
+++ b/app/(tabs)/community/index.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from "expo-router";
 
 export default function CommunityIndex() {
-  return <Redirect href="/community/record-share" />;
+  return <Redirect href="/community/free-board" />;
 }

--- a/app/community/free-board/write.tsx
+++ b/app/community/free-board/write.tsx
@@ -1,0 +1,11 @@
+import { WriteScreen } from "@/features/community/write/components/write-screen";
+import { Stack } from "expo-router";
+
+export default function FreeBoardWritePage() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <WriteScreen />
+    </>
+  );
+}

--- a/components/icons/arrow-down-to-line-icon.tsx
+++ b/components/icons/arrow-down-to-line-icon.tsx
@@ -1,0 +1,32 @@
+import { Line, Path, Svg } from "react-native-svg";
+
+type Props = { size?: number; color?: string };
+
+export function ArrowDownToLineIcon({ size = 24, color = "#1A1B1F" }: Props) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M12 3L12 17"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+      <Path
+        d="M6 11L12 17L18 11"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Line
+        x1="5"
+        y1="21"
+        x2="19"
+        y2="21"
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    </Svg>
+  );
+}

--- a/components/icons/camera-icon.tsx
+++ b/components/icons/camera-icon.tsx
@@ -1,8 +1,12 @@
-import { Path, Svg } from 'react-native-svg';
+import { Path, Svg } from "react-native-svg";
 
 type Props = { width?: number; height?: number; color?: string };
 
-export function CameraIcon({ width = 20, height = 18, color = '#1A1B1F' }: Props) {
+export function CameraIcon({
+  width = 16,
+  height = 14,
+  color = "#1A1B1F",
+}: Props) {
   return (
     <Svg width={width} height={height} viewBox="0 0 20 18" fill="none">
       <Path

--- a/components/ios-keyboard-accessory-toolbar.tsx
+++ b/components/ios-keyboard-accessory-toolbar.tsx
@@ -2,29 +2,17 @@ import { ArrowDownToLineIcon } from "@/components/icons/arrow-down-to-line-icon"
 import {
   InputAccessoryView,
   Keyboard,
-  Platform,
   TouchableOpacity,
   View,
 } from "react-native";
 
-type SupportedPlatform = "ios" | "android" | "all";
-
 type Props = {
   nativeID: string;
-  platform?: SupportedPlatform;
 };
 
-export function KeyboardAccessoryToolbar({
+export function IOSKeyboardAccessoryToolbar({
   nativeID,
-  platform = "ios",
-}: Props) {
-  const shouldRender =
-    platform === "all" ||
-    (platform === "ios" && Platform.OS === "ios") ||
-    (platform === "android" && Platform.OS === "android");
-
-  if (!shouldRender) return null;
-
+}: Props): React.ReactElement | null {
   return (
     <InputAccessoryView nativeID={nativeID}>
       <View className="flex-row items-center justify-end border-t border-line-subtle bg-fill-normal px-4 py-2">

--- a/components/keyboard-accessory-toolbar.tsx
+++ b/components/keyboard-accessory-toolbar.tsx
@@ -1,0 +1,37 @@
+import { ArrowDownToLineIcon } from "@/components/icons/arrow-down-to-line-icon";
+import {
+  InputAccessoryView,
+  Keyboard,
+  Platform,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+type SupportedPlatform = "ios" | "android" | "all";
+
+type Props = {
+  nativeID: string;
+  platform?: SupportedPlatform;
+};
+
+export function KeyboardAccessoryToolbar({
+  nativeID,
+  platform = "ios",
+}: Props) {
+  const shouldRender =
+    platform === "all" ||
+    (platform === "ios" && Platform.OS === "ios") ||
+    (platform === "android" && Platform.OS === "android");
+
+  if (!shouldRender) return null;
+
+  return (
+    <InputAccessoryView nativeID={nativeID}>
+      <View className="flex-row items-center justify-end border-t border-line-subtle bg-fill-normal px-4 py-2">
+        <TouchableOpacity onPress={() => Keyboard.dismiss()} hitSlop={8}>
+          <ArrowDownToLineIcon size={20} color="#73798c" />
+        </TouchableOpacity>
+      </View>
+    </InputAccessoryView>
+  );
+}

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -1,10 +1,12 @@
 import { PlusIcon } from "@/components/icons/plus-icon";
 import { MOCK_POSTS } from "@/features/community/constants/mock-posts";
+import { useRouter } from "expo-router";
 import React from "react";
-import { FlatList, Pressable, View } from "react-native";
+import { FlatList, TouchableOpacity, View } from "react-native";
 import { PostItem } from "./post-item";
 
 export function FreeBoardScreen() {
+  const router = useRouter();
   return (
     <View className="flex-1">
       <FlatList
@@ -12,9 +14,12 @@ export function FreeBoardScreen() {
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => <PostItem post={item} />}
       />
-      <Pressable className="absolute bottom-6 right-5 size-14 items-center justify-center rounded-full bg-primary-normal">
+      <TouchableOpacity
+        onPress={() => router.push("/community/free-board/write")}
+        className="absolute bottom-6 right-5 size-14 items-center justify-center rounded-full bg-primary-normal"
+      >
         <PlusIcon />
-      </Pressable>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -2,7 +2,7 @@ import { PlusIcon } from "@/components/icons/plus-icon";
 import { MOCK_POSTS } from "@/features/community/constants/mock-posts";
 import { useRouter } from "expo-router";
 import React from "react";
-import { FlatList, TouchableOpacity, View } from "react-native";
+import { FlatList, Pressable, View } from "react-native";
 import { PostItem } from "./post-item";
 
 export function FreeBoardScreen() {
@@ -14,12 +14,12 @@ export function FreeBoardScreen() {
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => <PostItem post={item} />}
       />
-      <TouchableOpacity
+      <Pressable
         onPress={() => router.push("/community/free-board/write")}
         className="absolute bottom-6 right-5 size-14 items-center justify-center rounded-full bg-primary-normal"
       >
         <PlusIcon />
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 }

--- a/features/community/write/components/image-upload-button.tsx
+++ b/features/community/write/components/image-upload-button.tsx
@@ -1,0 +1,16 @@
+import { CameraIcon } from "@/components/icons/camera-icon";
+import { Pressable, Text } from "react-native";
+
+export function ImageUploadButton() {
+  return (
+    <Pressable
+      onPress={() => {}}
+      className="h-16 w-16 items-center justify-center gap-1 rounded-lg border border-line-subtle bg-fill-normal"
+    >
+      <CameraIcon color="#73798c" />
+      <Text className="text-label-subtler typo-body-2-normal-medium">
+        업로드
+      </Text>
+    </Pressable>
+  );
+}

--- a/features/community/write/components/image-upload-button.tsx
+++ b/features/community/write/components/image-upload-button.tsx
@@ -4,7 +4,9 @@ import { Pressable, Text } from "react-native";
 export function ImageUploadButton() {
   return (
     <Pressable
-      onPress={() => {}}
+      onPress={() => {
+        // TODO : 이미지업로드 기능 구현
+      }}
       className="h-16 w-16 items-center justify-center gap-1 rounded-lg border border-line-subtle bg-fill-normal"
     >
       <CameraIcon color="#73798c" />

--- a/features/community/write/components/write-header.tsx
+++ b/features/community/write/components/write-header.tsx
@@ -1,0 +1,18 @@
+import { CaretLeftIcon } from "@/components/icons/caret-left-icon";
+import { useRouter } from "expo-router";
+import { Pressable, Text, View } from "react-native";
+
+export function WriteHeader() {
+  const router = useRouter();
+  return (
+    <View className="h-14 flex-row items-center justify-between bg-fill-normal px-5">
+      <Pressable onPress={() => router.back()} hitSlop={8} className="flex-1">
+        <CaretLeftIcon />
+      </Pressable>
+      <Text className="flex-1 text-center text-label-normal typo-headline-1-semi-bold">
+        게시글 작성하기
+      </Text>
+      <View className="flex-1" />
+    </View>
+  );
+}

--- a/features/community/write/components/write-screen.tsx
+++ b/features/community/write/components/write-screen.tsx
@@ -1,0 +1,85 @@
+import { useRouter } from "expo-router";
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useWriteForm } from "../hooks/use-write-form";
+import { ImageUploadButton } from "./image-upload-button";
+import { WriteHeader } from "./write-header";
+
+export function WriteScreen() {
+  const router = useRouter();
+  const { top, bottom } = useSafeAreaInsets();
+  const { title, setTitle, body, setBody, isSubmittable } = useWriteForm();
+
+  return (
+    <KeyboardAvoidingView
+      className="flex-1 bg-fill-normal"
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <View style={{ paddingTop: top }}>
+        <WriteHeader />
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: 100 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="px-5">
+          <TextInput
+            value={title}
+            onChangeText={setTitle}
+            placeholder="제목"
+            placeholderTextColor="#73798c"
+            className="border-b border-line-subtle py-4 text-label-normal typo-body-1-normal-semi-bold"
+            style={{ lineHeight: undefined }}
+          />
+          <TextInput
+            value={body}
+            onChangeText={setBody}
+            placeholder="글을 작성해주세요."
+            placeholderTextColor="#73798c"
+            multiline
+            textAlignVertical="top"
+            className="min-h-[200px] py-4 text-label-normal typo-body-2-reading-regular"
+          />
+        </View>
+
+        <View className="h-[6px] bg-fill-strong" />
+
+        <View className="px-5 py-4">
+          <ImageUploadButton />
+        </View>
+      </ScrollView>
+
+      <View
+        className="absolute bottom-0 left-0 right-0 bg-fill-normal px-5 pt-4"
+        style={{ paddingBottom: Math.max(bottom, 20) }}
+      >
+        <Pressable
+          disabled={!isSubmittable}
+          onPress={() => router.back()}
+          className={`h-14 items-center justify-center rounded-xl ${
+            isSubmittable ? "bg-primary-normal" : "bg-fill-disabled"
+          }`}
+        >
+          <Text
+            className={`typo-label-large ${
+              isSubmittable ? "text-common-100" : "text-label-disabled"
+            }`}
+          >
+            완료
+          </Text>
+        </Pressable>
+      </View>
+    </KeyboardAvoidingView>
+  );
+}

--- a/features/community/write/components/write-screen.tsx
+++ b/features/community/write/components/write-screen.tsx
@@ -39,6 +39,8 @@ export function WriteScreen() {
             onChangeText={setTitle}
             placeholder="제목"
             placeholderTextColor="#73798c"
+            autoCorrect={false}
+            spellCheck={false}
             className="border-b border-line-subtle py-4 text-label-normal typo-body-1-normal-semi-bold"
             style={{ lineHeight: undefined }}
           />
@@ -47,6 +49,8 @@ export function WriteScreen() {
             onChangeText={setBody}
             placeholder="글을 작성해주세요."
             placeholderTextColor="#73798c"
+            autoCorrect={false}
+            spellCheck={false}
             multiline
             textAlignVertical="top"
             className="min-h-[200px] py-4 text-label-normal typo-body-2-reading-regular"

--- a/features/community/write/components/write-screen.tsx
+++ b/features/community/write/components/write-screen.tsx
@@ -1,4 +1,4 @@
-import { KeyboardAccessoryToolbar } from "@/components/keyboard-accessory-toolbar";
+import { IOSKeyboardAccessoryToolbar } from "@/components/ios-keyboard-accessory-toolbar";
 import { useRouter } from "expo-router";
 import {
   KeyboardAvoidingView,
@@ -91,8 +91,12 @@ export function WriteScreen() {
         </Pressable>
       </View>
 
-      <KeyboardAccessoryToolbar nativeID={TITLE_TOOLBAR_ID} />
-      <KeyboardAccessoryToolbar nativeID={BODY_TOOLBAR_ID} />
+      {Platform.OS === "ios" && (
+        <IOSKeyboardAccessoryToolbar nativeID={TITLE_TOOLBAR_ID} />
+      )}
+      {Platform.OS === "ios" && (
+        <IOSKeyboardAccessoryToolbar nativeID={BODY_TOOLBAR_ID} />
+      )}
     </KeyboardAvoidingView>
   );
 }

--- a/features/community/write/components/write-screen.tsx
+++ b/features/community/write/components/write-screen.tsx
@@ -1,3 +1,4 @@
+import { KeyboardAccessoryToolbar } from "@/components/keyboard-accessory-toolbar";
 import { useRouter } from "expo-router";
 import {
   KeyboardAvoidingView,
@@ -12,6 +13,9 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useWriteForm } from "../hooks/use-write-form";
 import { ImageUploadButton } from "./image-upload-button";
 import { WriteHeader } from "./write-header";
+
+const TITLE_TOOLBAR_ID = "write-title-toolbar";
+const BODY_TOOLBAR_ID = "write-body-toolbar";
 
 export function WriteScreen() {
   const router = useRouter();
@@ -41,6 +45,7 @@ export function WriteScreen() {
             placeholderTextColor="#73798c"
             autoCorrect={false}
             spellCheck={false}
+            inputAccessoryViewID={TITLE_TOOLBAR_ID}
             className="border-b border-line-subtle py-4 text-label-normal typo-body-1-normal-semi-bold"
             style={{ lineHeight: undefined }}
           />
@@ -51,6 +56,7 @@ export function WriteScreen() {
             placeholderTextColor="#73798c"
             autoCorrect={false}
             spellCheck={false}
+            inputAccessoryViewID={BODY_TOOLBAR_ID}
             multiline
             textAlignVertical="top"
             className="min-h-[200px] py-4 text-label-normal typo-body-2-reading-regular"
@@ -84,6 +90,9 @@ export function WriteScreen() {
           </Text>
         </Pressable>
       </View>
+
+      <KeyboardAccessoryToolbar nativeID={TITLE_TOOLBAR_ID} />
+      <KeyboardAccessoryToolbar nativeID={BODY_TOOLBAR_ID} />
     </KeyboardAvoidingView>
   );
 }

--- a/features/community/write/hooks/use-write-form.ts
+++ b/features/community/write/hooks/use-write-form.ts
@@ -1,0 +1,10 @@
+import { useState } from "react";
+
+export function useWriteForm() {
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+
+  const isSubmittable = title.trim().length > 0;
+
+  return { title, setTitle, body, setBody, isSubmittable };
+}


### PR DESCRIPTION
## Summary

- `/community/free-board/write` 라우트 및 `WriteScreen` 구현
- 제목/본문 입력, 이미지 업로드 버튼, 완료 버튼 (제목 입력 시 활성화)
- 자동완성·맞춤법 제안 비활성화 (`autoCorrect`, `spellCheck`)
- `KeyboardAccessoryToolbar` 공통 컴포넌트 추가 — `nativeID`, `platform` props로 재사용 가능
- FAB `+` 버튼 → 작성 화면 연결 (`TouchableOpacity` 적용)

## ScreenShot

| 키보드 열기 전 | 키보드 열기 후 |
| --- | --- |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/8007460b-4dc4-4587-b4fd-8cb0311009c5" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/00b59808-c1e6-4cd8-8b1a-590273f05270" /> |



## Test plan

- [x] FAB 버튼 클릭 시 게시글 작성 화면 진입 확인
- [x] 제목 입력 전 완료 버튼 비활성화, 입력 후 활성화 확인
- [x] 제목/본문 포커스 시 키보드 위 toolbar 및 닫기 버튼 노출 확인
- [x] 이미지 업로드 버튼 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)