### PR TITLE
feat: 마이페이지 저장한 산 목록, 권한 관리, 이용 약관

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -12,7 +12,7 @@ export default function MyPageScreen() {
   const router = useRouter();
 
   const activityItems = [
-    { label: '저장한 산 목록', onPress: () => {} },
+    { label: '저장한 산 목록', onPress: () => router.push('/mypage/saved-mountains') },
     { label: '내 게시글', onPress: () => {} },
     { label: '내 반응', onPress: () => {} },
     { label: '차단 목록', onPress: () => {} },

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -21,8 +21,8 @@ export default function MyPageScreen() {
   const serviceItems = [
     { label: '공지사항', onPress: () => {} },
     { label: '1:1 문의하기', onPress: () => {} },
-    { label: '권한 관리', onPress: () => {} },
-    { label: '이용약관', onPress: () => {} },
+    { label: '권한 관리', onPress: () => router.push('/mypage/permissions') },
+    { label: '이용약관', onPress: () => router.push('/mypage/terms') },
     { label: '버전 정보', value: `v ${APP_VERSION}`, onPress: () => {} },
   ];
 

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -48,6 +48,8 @@ export default function RootLayout(): React.JSX.Element | null {
           <Stack.Screen name="community/post-complete" options={{ headerShown: false }} />
           <Stack.Screen name="mypage/info" options={{ headerShown: false }} />
           <Stack.Screen name="mypage/saved-mountains" options={{ headerShown: false }} />
+          <Stack.Screen name="mypage/permissions" options={{ headerShown: false }} />
+          <Stack.Screen name="mypage/terms" options={{ headerShown: false }} />
           <Stack.Screen
             name="modal"
             options={{ presentation: "modal", title: "Modal" }}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -47,6 +47,7 @@ export default function RootLayout(): React.JSX.Element | null {
           <Stack.Screen name="community/write" options={{ headerShown: false }} />
           <Stack.Screen name="community/post-complete" options={{ headerShown: false }} />
           <Stack.Screen name="mypage/info" options={{ headerShown: false }} />
+          <Stack.Screen name="mypage/saved-mountains" options={{ headerShown: false }} />
           <Stack.Screen
             name="modal"
             options={{ presentation: "modal", title: "Modal" }}

--- a/app/mypage/permissions.tsx
+++ b/app/mypage/permissions.tsx
@@ -1,0 +1,179 @@
+import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon';
+import { toast } from '@/store/toast.store';
+import { useRouter } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import { Animated, Linking, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// 토큰 기반 상수
+const TRACK_WIDTH = 44;
+const TRACK_HEIGHT = 24;
+const THUMB_SIZE = 20;
+const THUMB_PADDING = 2;
+const THUMB_TRAVEL = TRACK_WIDTH - THUMB_SIZE - THUMB_PADDING * 2; // 20
+
+const COLOR_ON = '#2F323A';   // fill-heavy
+const COLOR_OFF = '#F0F2F4';  // fill-stronger
+const COLOR_THUMB = '#FFFFFF'; // fill-normal
+
+function ToggleSwitch({ value, onValueChange }: { value: boolean; onValueChange: (v: boolean) => void }) {
+  const anim = useRef(new Animated.Value(value ? 1 : 0)).current;
+
+  useEffect(() => {
+    Animated.timing(anim, {
+      toValue: value ? 1 : 0,
+      duration: 200,
+      useNativeDriver: false,
+    }).start();
+  }, [value]);
+
+  const thumbLeft = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [THUMB_PADDING, THUMB_PADDING + THUMB_TRAVEL],
+  });
+
+  const trackColor = anim.interpolate({
+    inputRange: [0, 1],
+    outputRange: [COLOR_OFF, COLOR_ON],
+  });
+
+  return (
+    <TouchableOpacity activeOpacity={0.8} onPress={() => onValueChange(!value)}>
+      <Animated.View
+        style={{
+          width: TRACK_WIDTH,
+          height: TRACK_HEIGHT,
+          borderRadius: 9999,
+          backgroundColor: trackColor,
+          justifyContent: 'center',
+        }}
+      >
+        <Animated.View
+          style={{
+            position: 'absolute',
+            left: thumbLeft,
+            width: THUMB_SIZE,
+            height: THUMB_SIZE,
+            borderRadius: 9999,
+            backgroundColor: COLOR_THUMB,
+            shadowColor: '#000',
+            shadowOffset: { width: 0, height: 4 },
+            shadowOpacity: 0.1,
+            shadowRadius: 6,
+            elevation: 4,
+          }}
+        />
+      </Animated.View>
+    </TouchableOpacity>
+  );
+}
+
+type NotificationKey = 'push' | 'liveActivity' | 'voice';
+
+const NOTIFICATION_ITEMS: { key: NotificationKey; label: string; toastMessage: string }[] = [
+  { key: 'push', label: '푸시 알림', toastMessage: '푸시 알림을 활성화했어요' },
+  { key: 'liveActivity', label: '라이브 액티비티', toastMessage: '라이브 액티비티를 활성화했어요' },
+  { key: 'voice', label: '음성 안내', toastMessage: '음성 안내를 활성화했어요' },
+];
+
+const DEVICE_PERMISSION_ITEMS = [
+  { label: '위치 서비스' },
+  { label: '카메라' },
+];
+
+export default function PermissionsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  const [notifications, setNotifications] = useState<Record<NotificationKey, boolean>>({
+    push: true,
+    liveActivity: false,
+    voice: false,
+  });
+
+  const handleToggle = (key: NotificationKey, value: boolean) => {
+    setNotifications((prev) => ({ ...prev, [key]: value }));
+    if (value) {
+      const item = NOTIFICATION_ITEMS.find((i) => i.key === key);
+      if (item) toast.show(item.toastMessage);
+    }
+  };
+
+  return (
+    <View className="flex-1 bg-fill-normal">
+      {/* 헤더 */}
+      <View
+        className="flex-row items-center bg-fill-normal"
+        style={{ height: 56, paddingHorizontal: 20, gap: 8, marginTop: insets.top }}
+      >
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.6}>
+          <ChevronLeftIcon size={24} color="#1a1b1f" />
+        </TouchableOpacity>
+        <Text className="typo-headline-1-semi-bold text-label-normal">권한 관리</Text>
+      </View>
+
+      <ScrollView showsVerticalScrollIndicator={false}>
+        {/* 알림 설정 */}
+        <View style={{ paddingTop: 12, paddingBottom: 6, paddingHorizontal: 20, gap: 10, alignSelf: 'stretch' }}>
+          <Text className="typo-body-2-normal-semi-bold text-label-subtler" style={{ letterSpacing: -0.14 }}>
+            알림 설정
+          </Text>
+        </View>
+
+        <View className="bg-fill-normal">
+          {NOTIFICATION_ITEMS.map((item) => (
+            <View
+              key={item.key}
+              className="flex-row items-center justify-between"
+              style={{ paddingHorizontal: 20, paddingVertical: 16 }}
+            >
+              <Text className="typo-body-1-normal-regular text-label-normal" style={{ letterSpacing: -0.16 }}>
+                {item.label}
+              </Text>
+              <ToggleSwitch
+                value={notifications[item.key]}
+                onValueChange={(v) => handleToggle(item.key, v)}
+              />
+            </View>
+          ))}
+        </View>
+
+        {/* 섹션 구분선 */}
+        <View className="bg-fill-strong" style={{ height: 6 }} />
+
+        {/* 기기 권한 */}
+        <View style={{ paddingTop: 12, paddingBottom: 6, paddingHorizontal: 20, gap: 10, alignSelf: 'stretch' }}>
+          <Text className="typo-body-2-normal-semi-bold text-label-subtler" style={{ letterSpacing: -0.14 }}>
+            기기 권한
+          </Text>
+        </View>
+
+        <View className="bg-fill-normal">
+          {DEVICE_PERMISSION_ITEMS.map((item) => (
+            <TouchableOpacity
+              key={item.label}
+              className="flex-row items-center justify-between"
+              style={{ paddingHorizontal: 20, paddingVertical: 16 }}
+              activeOpacity={0.6}
+              onPress={() => Linking.openSettings()}
+            >
+              <Text className="typo-body-1-normal-regular text-label-normal" style={{ letterSpacing: -0.16 }}>
+                {item.label}
+              </Text>
+              <View className="flex-row items-center" style={{ gap: 4 }}>
+                <Text className="typo-body-1-normal-regular text-label-alternative" style={{ letterSpacing: -0.16 }}>
+                  허용됨
+                </Text>
+                <View style={{ transform: [{ rotate: '180deg' }] }}>
+                  <ChevronLeftIcon size={16} color="#9CA3AF" />
+                </View>
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={{ height: insets.bottom + 16 }} />
+      </ScrollView>
+    </View>
+  );
+}

--- a/app/mypage/saved-mountains.tsx
+++ b/app/mypage/saved-mountains.tsx
@@ -1,0 +1,113 @@
+import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon';
+import {
+  DIFFICULTY_STYLE,
+  MOCK_MOUNTAINS,
+  type Mountain,
+} from '@/features/mountains/components/mountain-card';
+import { useRouter } from 'expo-router';
+
+import { FlatList, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Path, Svg } from 'react-native-svg';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+// 목 데이터: 저장된 산 목록 (MOCK_MOUNTAINS 전체를 저장된 상태로 사용)
+const MOCK_SAVED_MOUNTAINS: Mountain[] = MOCK_MOUNTAINS;
+
+function BookmarkIcon() {
+  return (
+    <Svg width={14} height={19} viewBox="0 0 14 19" fill="none">
+      <Path
+        d="M12 0H1.5C1.10218 0 0.720644 0.158035 0.43934 0.43934C0.158035 0.720644 0 1.10218 0 1.5V18C6.65975e-05 18.1338 0.0359509 18.2652 0.103929 18.3805C0.171907 18.4958 0.269503 18.5908 0.386587 18.6557C0.503672 18.7206 0.635979 18.7529 0.76978 18.7494C0.90358 18.7458 1.034 18.7066 1.1475 18.6356L6.75 15.1341L12.3534 18.6356C12.4669 18.7063 12.5972 18.7454 12.7309 18.7488C12.8646 18.7522 12.9967 18.7198 13.1136 18.655C13.2306 18.5902 13.3281 18.4953 13.396 18.3801C13.4639 18.2649 13.4998 18.1337 13.5 18V1.5C13.5 1.10218 13.342 0.720644 13.0607 0.43934C12.7794 0.158035 12.3978 0 12 0Z"
+        fill="#73798C"
+      />
+    </Svg>
+  );
+}
+
+function SavedMountainItem({ mountain }: { mountain: Mountain }) {
+  const router = useRouter();
+  return (
+    <TouchableOpacity
+      className="flex-row items-center bg-fill-normal"
+      style={{ paddingHorizontal: 20, paddingVertical: 16, gap: 12 }}
+      activeOpacity={0.7}
+      onPress={() => router.push(`/mountains/${mountain.id}`)}
+    >
+      {/* 썸네일 */}
+      <Image
+        source={mountain.imageUrl ? { uri: mountain.imageUrl } : undefined}
+        className="bg-fill-stronger"
+        style={{ width: 72, height: 72, borderRadius: 10 }}
+        resizeMode="cover"
+      />
+
+      {/* 정보 */}
+      <View style={{ flex: 1, gap: 6 }}>
+        <View className="flex-row items-end" style={{ gap: 8 }}>
+          <Text className="typo-headline-1-semi-bold text-label-normal">
+            {mountain.name}
+          </Text>
+          <Text
+            className="typo-body-3-medium text-label-subtler"
+            style={{ paddingBottom: 2 }}
+          >
+            {mountain.location}
+          </Text>
+        </View>
+        <View className="flex-row items-center" style={{ gap: 6 }}>
+          <Text className="typo-body-3-medium text-label-subtle">
+            고도 {mountain.altitude}m
+          </Text>
+          <View
+            className="bg-label-subtler rounded-full"
+            style={{ width: 2, height: 2 }}
+          />
+          <Text
+            className={`typo-body-3-semi-bold ${DIFFICULTY_STYLE[mountain.difficulty]}`}
+          >
+            난이도 {mountain.difficulty}
+          </Text>
+        </View>
+      </View>
+
+      {/* 북마크 버튼 */}
+      <TouchableOpacity
+        onPress={() => setSaved((prev) => !prev)}
+        activeOpacity={0.7}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <BookmarkIcon />
+      </TouchableOpacity>
+    </TouchableOpacity>
+  );
+}
+
+export default function SavedMountainsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View className="flex-1 bg-fill-normal">
+      {/* 헤더 */}
+      <View
+        className="flex-row items-center bg-fill-normal"
+        style={{ height: 56, paddingHorizontal: 20, gap: 8, marginTop: insets.top }}
+      >
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.6}>
+          <ChevronLeftIcon size={24} color="#1a1b1f" />
+        </TouchableOpacity>
+        <Text className="typo-headline-1-semi-bold text-label-normal">
+          저장한 산 목록
+        </Text>
+      </View>
+
+      <FlatList
+        data={MOCK_SAVED_MOUNTAINS}
+        keyExtractor={(item) => String(item.id)}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
+        renderItem={({ item }) => <SavedMountainItem mountain={item} />}
+      />
+    </View>
+  );
+}

--- a/app/mypage/terms.tsx
+++ b/app/mypage/terms.tsx
@@ -1,0 +1,40 @@
+import { ChevronLeftIcon } from '@/components/icons/chevron-left-icon';
+import { MenuRow } from '@/features/mypage/components/menu-row';
+import { useRouter } from 'expo-router';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const TERMS_ITEMS = [
+  { label: '위치 기반 서비스 이용약관', onPress: () => {} },
+  { label: '개인정보 처리방침', onPress: () => {} },
+  { label: '커뮤니티 이용약관', onPress: () => {} },
+];
+
+export default function TermsScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View className="flex-1 bg-fill-normal">
+      {/* 헤더 */}
+      <View
+        className="flex-row items-center bg-fill-normal"
+        style={{ height: 56, paddingHorizontal: 20, gap: 8, marginTop: insets.top }}
+      >
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.6}>
+          <ChevronLeftIcon size={24} color="#1a1b1f" />
+        </TouchableOpacity>
+        <Text className="typo-headline-1-semi-bold text-label-normal">이용약관</Text>
+      </View>
+
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <View className="bg-fill-normal">
+          {TERMS_ITEMS.map((item) => (
+            <MenuRow key={item.label} label={item.label} onPress={item.onPress} />
+          ))}
+        </View>
+        <View style={{ height: insets.bottom + 16 }} />
+      </ScrollView>
+    </View>
+  );
+}

--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -1,10 +1,33 @@
 import { useToastStore } from "@/store/toast.store";
 import React, { useEffect, useRef } from "react";
 import { Animated, Easing, Text, View } from "react-native";
+import { Path, Svg } from "react-native-svg";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 const ENTER_MS = 200;
 const EXIT_MS = 160;
+
+// 토스트 레이아웃 상수
+const TOAST_HEIGHT = 48;
+const TOAST_PADDING_V = 10;
+const TOAST_PADDING_H = 16;
+const TOAST_GAP = 8;
+const TOAST_BORDER_RADIUS = 12; // radius-xl
+const TOAST_LEFT = 70;
+const TOAST_BOTTOM = 54;
+const TOAST_BG = '#2F323A';       // fill-heavy
+const TOAST_TEXT_COLOR = '#FFFFFF'; // label-normal-inverse
+
+function CheckCircleIcon() {
+  return (
+    <Svg width={20} height={20} viewBox="0 0 20 20" fill="none">
+      <Path
+        d="M13.5672 7.68281C13.6253 7.74086 13.6714 7.80979 13.7029 7.88566C13.7343 7.96154 13.7505 8.04287 13.7505 8.125C13.7505 8.20713 13.7343 8.28846 13.7029 8.36434C13.6714 8.44021 13.6253 8.50914 13.5672 8.56719L9.19219 12.9422C9.13415 13.0003 9.06522 13.0464 8.98934 13.0779C8.91347 13.1093 8.83214 13.1255 8.75 13.1255C8.66787 13.1255 8.58654 13.1093 8.51067 13.0779C8.43479 13.0464 8.36586 13.0003 8.30782 12.9422L6.43282 11.0672C6.31554 10.9499 6.24966 10.7909 6.24966 10.625C6.24966 10.4591 6.31554 10.3001 6.43282 10.1828C6.55009 10.0655 6.70915 9.99965 6.875 9.99965C7.04086 9.99965 7.19992 10.0655 7.31719 10.1828L8.75 11.6164L12.6828 7.68281C12.7409 7.6247 12.8098 7.5786 12.8857 7.54715C12.9615 7.5157 13.0429 7.49951 13.125 7.49951C13.2071 7.49951 13.2885 7.5157 13.3643 7.54715C13.4402 7.5786 13.5091 7.6247 13.5672 7.68281ZM18.125 10C18.125 11.607 17.6485 13.1779 16.7557 14.514C15.8629 15.8502 14.594 16.8916 13.1093 17.5065C11.6247 18.1215 9.99099 18.2824 8.41489 17.9689C6.8388 17.6554 5.39106 16.8815 4.25476 15.7452C3.11846 14.6089 2.34463 13.1612 2.03112 11.5851C1.71762 10.009 1.87852 8.37535 2.49348 6.8907C3.10844 5.40605 4.14985 4.1371 5.486 3.24431C6.82214 2.35152 8.39303 1.875 10 1.875C12.1542 1.87727 14.2195 2.73403 15.7427 4.25727C17.266 5.78051 18.1227 7.84581 18.125 10ZM16.875 10C16.875 8.64025 16.4718 7.31104 15.7164 6.18045C14.9609 5.04987 13.8872 4.16868 12.631 3.64833C11.3747 3.12798 9.99238 2.99183 8.65876 3.2571C7.32514 3.52237 6.10013 4.17715 5.13864 5.13864C4.17716 6.10013 3.52238 7.32513 3.2571 8.65875C2.99183 9.99237 3.12798 11.3747 3.64833 12.6309C4.16868 13.8872 5.04987 14.9609 6.18046 15.7164C7.31105 16.4718 8.64026 16.875 10 16.875C11.8227 16.8729 13.5702 16.1479 14.8591 14.8591C16.1479 13.5702 16.8729 11.8227 16.875 10Z"
+        fill="white"
+      />
+    </Svg>
+  );
+}
 
 type Props = {
   containerClassName?: string;
@@ -77,21 +100,39 @@ export default function Toast({ containerClassName, gap = 8 }: Props) {
 
   return (
     <View
-      pointerEvents="box-none"
-      className={`absolute bottom-[100px] left-0 right-0 z-[9999] items-center ${containerClassName ? ` ${containerClassName}` : ""}`}
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: TOAST_LEFT,
+        bottom: insets.bottom + TOAST_BOTTOM,
+        zIndex: 9999,
+      }}
     >
       <Animated.View
-        className="mx-5 self-stretch"
         style={{
           opacity,
           transform: [{ translateY }],
-          marginTop: insets.top + gap,
-          marginBottom: gap,
         }}
       >
-        {/* TODO : 토스트 디자인 나오면 변경 필요. */}
-        <View className="rounded-xl bg-white px-4 py-3 shadow-md shadow-black/20">
-          <Text className="text-black">{current.message}</Text>
+        <View
+          style={{
+            height: TOAST_HEIGHT,
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: TOAST_GAP,
+            paddingVertical: TOAST_PADDING_V,
+            paddingHorizontal: TOAST_PADDING_H,
+            borderRadius: TOAST_BORDER_RADIUS,
+            backgroundColor: TOAST_BG,
+          }}
+        >
+          <CheckCircleIcon />
+          <Text
+            style={{ color: TOAST_TEXT_COLOR, letterSpacing: -0.16 }}
+            className="typo-body-1-normal-regular"
+          >
+            {current.message}
+          </Text>
         </View>
       </Animated.View>
     </View>


### PR DESCRIPTION
## Summary

마이페이지 - 저장한 산 목록 / 권한 관리 / 이용약관 페이지 구현

- `app/mypage/saved-mountains.tsx` — 저장한 산 목록 페이지 (산 리스트, 북마크 아이콘)
- `app/mypage/permissions.tsx` — 권한 관리 페이지 (알림 설정 토글, 기기 권한)
- `app/mypage/terms.tsx` — 이용약관 페이지 (위치 기반 서비스 이용약관 / 개인정보 처리방침 / 커뮤니티 이용약관)
- `app/_layout.tsx` — 신규 페이지 Stack 등록 (headerShown: false)
- `app/(tabs)/mypage.tsx` — 각 항목 라우팅 연결
- `components/toast/toast.tsx` — 토스트 디자인 업데이트 (fill-heavy 배경, 체크 아이콘, 위치/크기 스펙 반영)

## Screenshots

| 저장한 산 목록 | 권한 관리 | 이용약관 |
|--------------|---------|---------|
|<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/a0bdc0ae-e498-4d8f-88e6-6341f87e0401" />|<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/b7c0a9c9-c3d6-42f5-b706-60d3bba5544a" />|<img width="1179" height="2556" alt="image" src="https://github.com/user-attachments/assets/00549b28-ed54-48e0-b87c-a5e2772b0520" />|

## Test plan

- [x] 마이페이지 → 저장한 산 목록 탭 시 페이지 이동 확인
- [x] 저장한 산 목록: 산 카드(썸네일, 이름, 위치, 고도, 난이도) 정상 렌더링 확인
- [x] 저장한 산 목록: 산 카드 탭 시 산 상세 페이지 이동 확인
- [x] 저장한 산 목록: 북마크 아이콘 정상 노출 확인
- [x] 마이페이지 → 권한 관리 탭 시 페이지 이동 확인
- [x] 권한 관리: 토글 ON/OFF 동작 및 애니메이션 확인
- [x] 권한 관리: 토글 ON 시 토스트 메시지 정상 노출 확인 ("~을 활성화했어요")
- [x] 권한 관리: 위치 서비스 / 카메라 탭 시 시스템 설정 이동 확인
- [x] 마이페이지 → 이용약관 탭 시 페이지 이동 확인
- [x] 이용약관: 3개 항목 정상 렌더링 확인
- [x] 각 페이지 뒤로가기 버튼 동작 확인
- [x] 기본 Stack 헤더 미노출 확인 (커스텀 헤더만 표시)