### PR TITLE
chore: EAS 빌드 설정 추가 및 번들 ID 수정

### DIFF
--- a/GoogleService-Info.plist
+++ b/GoogleService-Info.plist
@@ -9,7 +9,7 @@
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
-	<string>com.tastyhiking.semosan</string>
+	<string>com.tastyhiking.semosanapp</string>
 	<key>PROJECT_ID</key>
 	<string>semosan-b2593</string>
 	<key>STORAGE_BUCKET</key>

--- a/app.config.js
+++ b/app.config.js
@@ -76,6 +76,11 @@ const config = {
     typedRoutes: true,
     reactCompiler: true,
   },
+  extra: {
+    eas: {
+      projectId: "df38234e-8a6e-42ca-8c16-21eed97912bc",
+    },
+  },
 };
 
 export default config;

--- a/app.config.js
+++ b/app.config.js
@@ -12,7 +12,7 @@ const config = {
   newArchEnabled: true,
   ios: {
     supportsTablet: true,
-    bundleIdentifier: "com.tastyhiking.semosan",
+    bundleIdentifier: "com.tastyhiking.semosanapp",
     usesAppleSignIn: true,
     infoPlist: {
       CFBundleAllowMixedLocalizations: true,
@@ -31,7 +31,7 @@ const config = {
     edgeToEdgeEnabled: true,
     predictiveBackGestureEnabled: false,
     permissions: [],
-    package: "com.tastyhiking.semosan",
+    package: "com.tastyhiking.semosanapp",
   },
   web: {
     output: "static",

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,21 @@
+{
+  "cli": {
+    "version": ">= 18.12.3",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/google-services.json
+++ b/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:923659199755:android:aa09b7ad81f1813d39ae0e",
         "android_client_info": {
-          "package_name": "com.tastyhiking.semosan"
+          "package_name": "com.tastyhiking.semosanapp"
         }
       },
       "oauth_client": [],


### PR DESCRIPTION
## Summary

- `eas.json` 추가 — development/preview/production 빌드 프로파일 설정
- `app.config.js`에 EAS `projectId` 추가
- 번들 ID `com.tastyhiking.semosan` → `com.tastyhiking.semosanapp` 통일 (iOS/Android/Firebase)

## Test plan

- [ ] `eas build --profile development` 정상 실행 확인
- [ ] iOS 번들 ID, Android 패키지명 일치 여부 확인
- [ ] Firebase Google 서비스 파일 패키지명 일치 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)