### PR TITLE
feat: 앱 출시 준비 — 산 목록/상세 API 연동 및 미구현 항목 정리

### DIFF
--- a/components/permission-bottom-sheet.tsx
+++ b/components/permission-bottom-sheet.tsx
@@ -1,11 +1,11 @@
-import { Text, TouchableOpacity, View } from "react-native";
-import { ModalSheet } from "@/components/modal-sheet";
 import {
   PermissionBellIcon,
   PermissionCameraIcon,
   PermissionImageIcon,
   PermissionLocationIcon,
 } from "@/components/icons/permission-icons";
+import { ModalSheet } from "@/components/modal-sheet";
+import { Text, TouchableOpacity, View } from "react-native";
 
 type Props = {
   visible: boolean;
@@ -47,33 +47,40 @@ const OPTIONAL: PermissionItem[] = [
 export function PermissionBottomSheet({ visible, onConfirm }: Props) {
   return (
     <ModalSheet visible={visible} onDismiss={onConfirm}>
-      <View className="px-5 pt-3 gap-6">
-        <Text className="typo-heading-1-semi-bold text-label-normal">
+      <View className="gap-6 px-5 pt-3">
+        <Text className="text-label-normal typo-heading-1-semi-bold">
           {"원활한 SEMOSAN 사용을 위해\n아래 권한을 허용해주세요."}
         </Text>
 
         <View className="gap-4">
-          <Text className="typo-body-1-normal-semi-bold text-label-subtle">필수 접근 권한</Text>
+          <Text className="text-label-subtle typo-body-1-normal-semi-bold">
+            필수 접근 권한
+          </Text>
           {REQUIRED.map((item) => (
             <PermissionRow key={item.title} item={item} />
           ))}
         </View>
 
-        <View className="gap-4">
-          <Text className="typo-body-1-normal-semi-bold text-label-subtle">선택적 접근 권한</Text>
+        {/* TODO : 아직은 필요하지 않은 권한이므로 주석처리 */}
+        {/* <View className="gap-4">
+          <Text className="text-label-subtle typo-body-1-normal-semi-bold">
+            선택적 접근 권한
+          </Text>
           {OPTIONAL.map((item) => (
             <PermissionRow key={item.title} item={item} />
           ))}
-        </View>
+        </View> */}
       </View>
 
       <View className="px-5 pt-8">
         <TouchableOpacity
-          className="h-12 bg-label-normal rounded-[10px] items-center justify-center"
+          className="h-12 items-center justify-center rounded-[10px] bg-label-normal"
           onPress={onConfirm}
           activeOpacity={0.8}
         >
-          <Text className="typo-label-large text-label-normal-inverse">확인</Text>
+          <Text className="text-label-normal-inverse typo-label-large">
+            확인
+          </Text>
         </TouchableOpacity>
       </View>
     </ModalSheet>
@@ -85,8 +92,12 @@ function PermissionRow({ item }: { item: PermissionItem }) {
     <View className="flex-row items-center gap-3">
       {item.icon}
       <View className="flex-1 gap-0.5">
-        <Text className="typo-body-2-normal-semi-bold text-label-normal">{item.title}</Text>
-        <Text className="typo-caption-1-regular text-label-subtler">{item.description}</Text>
+        <Text className="text-label-normal typo-body-2-normal-semi-bold">
+          {item.title}
+        </Text>
+        <Text className="text-label-subtler typo-caption-1-regular">
+          {item.description}
+        </Text>
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary

- 앱 실행 오류 수정 (LiveActivity 플러그인 제거)
- 홈 지도 마커 `useMountains` API 연동 (MOCK 데이터 제거)
- 산 상세 이미지 캐러셀 구현 (imageUrls 배열 기반, dot indicator)
- `WeatherAccordion` 컴포넌트 분리 + SunCalc 기반 일출/일몰 계산
- 산 상세 위도/경도 목록 API에서 임시 조회
- 산 상세 헤더 깜빡임 수정 (`_layout.tsx` 사전 선언)
- 트래킹·커뮤니티 탭 출시 전 비활성화
- 권한 바텀시트 선택 권한 임시 비활성화

## Test plan

- [ ] 앱 정상 실행 확인 (iOS 시뮬레이터)
- [ ] 홈 지도 API 마커 표시 확인
- [ ] 산 상세 진입 시 헤더 깜빡임 없음 확인
- [ ] 산 상세 이미지 캐러셀 및 dot indicator 동작 확인
- [ ] 일출/일몰 아코디언 정상 동작 확인
- [ ] 권한 바텀시트 필수 권한만 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)