### PR TITLE
fix: 앱 로고 추가

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -1,6 +1,7 @@
 import "dotenv/config";
 
-const isLiveActivityEnabled = process.env.EXPO_PUBLIC_LIVE_ACTIVITY_ENABLED === "true";
+const isLiveActivityEnabled =
+  process.env.EXPO_PUBLIC_LIVE_ACTIVITY_ENABLED === "true";
 
 /** @type {import('expo/config').ExpoConfig} */
 const config = {
@@ -8,7 +9,7 @@ const config = {
   slug: "semosan",
   version: "1.0.0",
   orientation: "portrait",
-  icon: "./assets/images/icon.png",
+  icon: "./assets/logo.png",
   scheme: "semosan",
   userInterfaceStyle: "automatic",
   newArchEnabled: true,
@@ -42,7 +43,7 @@ const config = {
   },
   web: {
     output: "static",
-    favicon: "./assets/images/favicon.png",
+    favicon: "./assets/logo.png",
     bundler: "metro",
   },
   plugins: [
@@ -51,7 +52,7 @@ const config = {
     [
       "expo-notifications",
       {
-        icon: "./assets/images/icon.png",
+        icon: "./assets/logo.png",
         color: "#ffffff",
         googleServicesFile: "./google-services.json",
       },


### PR DESCRIPTION
## Summary
- `assets/images/icon.png` (존재하지 않는 경로) → `assets/logo.png`으로 아이콘 경로 수정
- iOS 앱 아이콘, 웹 파비콘, 푸시 알림 아이콘 경로 일괄 변경

## Test plan
- [x] EAS 빌드 후 앱 아이콘 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)