### PR TITLE
fix: 카카오 로그인 API 연동

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -10,7 +10,7 @@ const config = {
   orientation: "portrait",
   icon: "./assets/images/icon.png",
   scheme: "semosan",
-  userInterfaceStyle: "automatic",
+  userInterfaceStyle: "light",
   newArchEnabled: true,
   ios: {
     supportsTablet: true,

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -11,7 +11,11 @@ export function useKakaoLogin() {
       const { accessToken } = await login();
 
       const deviceType =
-        Platform.OS === "ios" ? "IOS" : Platform.OS === "android" ? "ANDROID" : null;
+        Platform.OS === "ios"
+          ? "IOS"
+          : Platform.OS === "android"
+            ? "ANDROID"
+            : null;
 
       const { data } = await api.post<OAuthLoginResponse>({
         path: ENDPOINTS.OAUTH_KAKAO_LOGIN,

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -1,15 +1,24 @@
+import { api } from "@/lib/api";
 import { tokenStorage } from "@/lib/auth/tokenStorage";
-import { OAuthLoginResponse } from "@/types/api.generated";
+import { ENDPOINTS, OAuthLoginResponse } from "@/types/api.generated";
 import { login } from "@react-native-kakao/user";
 import { useMutation } from "@tanstack/react-query";
+import { Platform } from "react-native";
 
 export function useKakaoLogin() {
   return useMutation({
-    mutationFn: async (): Promise<OAuthLoginResponse> => {
-      // login() 내부적으로 POST /api/oauth/kakao/login 를 호출함.
-      const token = await login();
+    mutationFn: async () => {
+      const { accessToken } = await login();
 
-      return token;
+      const deviceType =
+        Platform.OS === "ios" ? "IOS" : Platform.OS === "android" ? "ANDROID" : null;
+
+      const { data } = await api.post<OAuthLoginResponse>({
+        path: ENDPOINTS.OAUTH_KAKAO_LOGIN,
+        body: { code: accessToken, deviceType },
+      });
+
+      return data;
     },
     onSuccess: async ({ accessToken, refreshToken }) => {
       if (accessToken && refreshToken) {

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -19,7 +19,7 @@ export function useKakaoLogin() {
 
       const { data } = await api.post<OAuthLoginResponse>({
         path: ENDPOINTS.OAUTH_KAKAO_LOGIN,
-        body: { code: accessToken, deviceType },
+        body: { accessToken, deviceType },
       });
 
       return data;

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -7,15 +7,10 @@ import { Platform } from "react-native";
 
 export function useKakaoLogin() {
   return useMutation({
-    mutationFn: async () => {
+    mutationFn: async (): Promise<OAuthLoginResponse> => {
       const { accessToken } = await login();
 
-      const deviceType =
-        Platform.OS === "ios"
-          ? "IOS"
-          : Platform.OS === "android"
-            ? "ANDROID"
-            : null;
+      const deviceType = Platform.OS.toUpperCase() as "IOS" | "ANDROID";
 
       const { data } = await api.post<OAuthLoginResponse>({
         path: ENDPOINTS.OAUTH_KAKAO_LOGIN,


### PR DESCRIPTION
## Summary
- 카카오 로그인 후 서버 API(`OAUTH_KAKAO_LOGIN`)에 accessToken과 deviceType을 전송하도록 연동
- `Platform.OS` 기반으로 deviceType을 `"IOS"` / `"ANDROID"` 로 동적 처리


🤖 Generated with [Claude Code](https://claude.com/claude-code)