### PR TITLE
fix: 저장한 산목록 캐시 문제 해결

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -16,6 +16,8 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 export default function MyPageScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
+
+
   const { data: profile } = useProfile();
   const { mutate: logout } = useLogout();
   const { mutate: withdraw } = useWithdraw();

--- a/app/mountains/[id].tsx
+++ b/app/mountains/[id].tsx
@@ -139,7 +139,10 @@ export default function MountainDetailScreen() {
                     {data.mountain?.address}
                   </Text>
                 </View>
-                <MountainBookmarkButton mountainId={Number(id)} />
+                <MountainBookmarkButton
+                  mountainId={Number(id)}
+                  mountainData={data.mountain ?? undefined}
+                />
               </View>
 
               <View className="flex-row items-center gap-2">

--- a/app/mypage/saved-mountains.tsx
+++ b/app/mypage/saved-mountains.tsx
@@ -4,7 +4,8 @@ import { DIFFICULTY_LABEL } from '@/features/mountains/components/mountain-card'
 import { COURSE_BADGE } from '@/features/mountains/constants/course-badge';
 import { useSavedMountains } from '@/features/mountains/hooks/use-saved-mountains';
 import { LikedMountainResponse } from '@/types/api.generated';
-import { useRouter } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { useCallback } from 'react';
 import { FlatList, Image, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -57,7 +58,7 @@ function SavedMountainItem({ mountain }: { mountain: LikedMountainResponse }) {
 
       {/* 북마크 버튼 */}
       {mountain.mountainId != null && (
-        <MountainBookmarkButton mountainId={mountain.mountainId} />
+        <MountainBookmarkButton mountainId={mountain.mountainId} mountainData={mountain} />
       )}
     </TouchableOpacity>
   );
@@ -79,9 +80,17 @@ function EmptyState() {
 export default function SavedMountainsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { data, isLoading } = useSavedMountains();
+  const { data, isLoading, refetch } = useSavedMountains();
 
-  const mountains = data?.content ?? [];
+  // 화면 포커스될 때마다 최신 데이터 동기화
+  useFocusEffect(
+    useCallback(() => {
+      refetch();
+    }, [refetch])
+  );
+
+  // 낙관적 업데이트로 임시 추가된 불완전한 항목(name 없는 항목) 필터링
+  const mountains = (data?.content ?? []).filter((m) => !!m.name);
 
   return (
     <View className="flex-1 bg-fill-normal">

--- a/features/mountains/components/mountain-bookmark-button.tsx
+++ b/features/mountains/components/mountain-bookmark-button.tsx
@@ -1,13 +1,15 @@
 import { BookmarkIcon } from "@/components/icons/bookmark-icon";
 import { useMountainBookmark } from "@/features/mountains/hooks/use-mountain-bookmark";
+import { LikedMountainResponse } from "@/types/api.generated";
 import { Pressable } from "react-native";
 
 type Props = {
   mountainId: number;
+  mountainData?: LikedMountainResponse;
 };
 
-export function MountainBookmarkButton({ mountainId }: Props) {
-  const { isBookmarked, isPending, toggle } = useMountainBookmark(mountainId);
+export function MountainBookmarkButton({ mountainId, mountainData }: Props) {
+  const { isBookmarked, isPending, toggle } = useMountainBookmark(mountainId, mountainData);
 
   return (
     <Pressable hitSlop={8} onPress={toggle} disabled={isPending}>

--- a/features/mountains/hooks/use-mountain-bookmark.ts
+++ b/features/mountains/hooks/use-mountain-bookmark.ts
@@ -1,6 +1,7 @@
 import { api } from "@/lib/api";
 import {
   ENDPOINTS,
+  LikedMountainResponse,
   PageResponseLikedMountainResponse,
 } from "@/types/api.generated";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -14,7 +15,10 @@ export async function getLikedMountains(): Promise<PageResponseLikedMountainResp
   return res.data;
 }
 
-export function useMountainBookmark(mountainId: number) {
+export function useMountainBookmark(
+  mountainId: number,
+  mountainData?: LikedMountainResponse,
+) {
   const queryClient = useQueryClient();
 
   const { data: likedMountains } = useQuery({
@@ -32,17 +36,24 @@ export function useMountainBookmark(mountainId: number) {
       await queryClient.cancelQueries({ queryKey: LIKES_KEY });
       const previous =
         queryClient.getQueryData<PageResponseLikedMountainResponse>(LIKES_KEY);
-      queryClient.setQueryData<PageResponseLikedMountainResponse>(
-        LIKES_KEY,
-        (old) => ({
-          ...old,
-          content: [...(old?.content ?? []), { mountainId }],
-        }),
-      );
+
+      // name이 있는 완전한 데이터일 때만 즉시 캐시 업데이트
+      if (mountainData?.name) {
+        queryClient.setQueryData<PageResponseLikedMountainResponse>(
+          LIKES_KEY,
+          (old) => ({
+            ...old,
+            content: [...(old?.content ?? []), mountainData],
+          }),
+        );
+      }
       return { previous };
     },
     onError: (_err, _vars, context) => {
       queryClient.setQueryData(LIKES_KEY, context?.previous);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: LIKES_KEY });
     },
   });
 


### PR DESCRIPTION
## 📌 작업 내용

### 저장한 산 목록 구현

- `GET /api/mountains/likes` API 연동
- `useSavedMountains` 훅 분리
- 저장한 산 없을 때 빈 상태(empty state) 표시
- `useFocusEffect`로 화면 포커스 시마다 최신 데이터 동기화
- 마이페이지에서 저장한 산 목록 메뉴 복원

### 북마크 낙관적 업데이트 데이터 문제 수정

- 기존: 북마크 시 `{ mountainId }` 만 캐시에 추가 → 이름·주소·고도 없는 빈 항목 노출
- 수정: `MountainBookmarkButton`에 `mountainData` prop 추가하여 부모에서 전체 데이터 직접 전달
- `name` 없는 불완전한 데이터는 캐시에 추가하지 않도록 방어 처리

---

## 📁 변경 파일

- `app/mypage/saved-mountains.tsx` — 저장한 산 목록 화면 API 연동
- `app/(tabs)/mypage.tsx` — 저장한 산 목록 메뉴 복원
- `app/mountains/[id].tsx` — `MountainBookmarkButton`에 mountain 데이터 전달
- `features/mountains/hooks/use-saved-mountains.ts` — 저장한 산 목록 전용 훅
- `features/mountains/hooks/use-mountain-bookmark.ts` — 낙관적 업데이트 데이터 문제 수정
- `features/mountains/components/mountain-bookmark-button.tsx` — `mountainData` prop 추가

---

## ✅ 체크리스트

- [x] 저장한 산 목록 API 정상 조회
- [x] 북마크 시 저장한 산 목록에 빈 항목 노출되지 않음
- [x] 저장한 산 없을 때 빈 상태 표시
- [x] 마이페이지 → 저장한 산 목록 진입 시 최신 데이터 반영