### PR TITLE
feat :  트래킹 세션 시작 및 기록 관련 API

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,7 +13,7 @@ export default function TabLayout() {
       >
         <Tabs.Screen name="index" options={{ title: "홈" }} />
         <Tabs.Screen name="mountains" options={{ title: "산목록" }} />
-        {/* <Tabs.Screen name="tracking" options={{ title: '기록' }} /> */}
+        <Tabs.Screen name="tracking" options={{ title: '기록' }} />
         {/* <Tabs.Screen name="community" options={{ title: '커뮤니티' }} /> */}
         <Tabs.Screen name="mypage" options={{ title: "MY" }} />
       </Tabs>

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -29,6 +29,7 @@ import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain
 import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tracking-session";
 import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
 import { useResumeTrackingSession } from "@/features/tracking/hooks/use-resume-tracking-session";
+import { useCompleteTrackingSession } from "@/features/tracking/hooks/use-complete-tracking-session";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -72,6 +73,7 @@ export default function TrackingScreen() {
   const [showStopModal, setShowStopModal] = useState(false);
   const [showDifficultyRating, setShowDifficultyRating] = useState(false);
   const [sessionId, setSessionId] = useState<number | null>(null);
+  const [hasSummited, setHasSummited] = useState(false);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
   const [barLayout, setBarLayout] = useState<{
@@ -114,6 +116,7 @@ export default function TrackingScreen() {
   const { mutate: startSession } = useStartTrackingSession();
   const { mutate: pauseSession } = usePauseTrackingSession();
   const { mutate: resumeSession } = useResumeTrackingSession();
+  const { mutate: completeSession } = useCompleteTrackingSession();
 
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
@@ -256,6 +259,8 @@ export default function TrackingScreen() {
     setElapsedSeconds(0);
     setShowTooltip(true);
     setShowSummitSheet(false);
+    setHasSummited(false);
+    setSessionId(null);
     setCollapsed(false);
   };
 
@@ -417,7 +422,23 @@ export default function TrackingScreen() {
         >
           {showSummitSheet ? (
             <SummitSheet
-              onCertify={() => setShowDifficultyRating(true)}
+              onCertify={() => {
+                const proceedToDescentSheet = () => {
+                  setHasSummited(true);
+                  setShowSummitSheet(false);
+                };
+                if (sessionId != null) {
+                  completeSession(sessionId, {
+                    onSuccess: proceedToDescentSheet,
+                    onError: (err) => {
+                      console.warn('[Tracking] 세션 종료 실패:', err);
+                      proceedToDescentSheet(); // 실패해도 하산 시트로 진행
+                    },
+                  });
+                } else {
+                  proceedToDescentSheet();
+                }
+              }}
               onNotYet={() => setShowSummitSheet(false)}
             />
           ) : (
@@ -425,7 +446,7 @@ export default function TrackingScreen() {
               elapsedSeconds={elapsedSeconds}
               isPaused={isPaused}
               showTooltip={showTooltip}
-              hasSummited={false}
+              hasSummited={hasSummited}
               timeToTarget="04:00"
               distanceToTarget="500m"
               onDismissTooltip={() => setShowTooltip(false)}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -30,6 +30,7 @@ import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tra
 import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
 import { useResumeTrackingSession } from "@/features/tracking/hooks/use-resume-tracking-session";
 import { useCompleteTrackingSession } from "@/features/tracking/hooks/use-complete-tracking-session";
+import { useActiveTrackingSession } from "@/features/tracking/hooks/use-active-tracking-session";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -40,7 +41,8 @@ import {
 import { LinearGradient } from "expo-linear-gradient";
 import * as Location from "expo-location";
 import { Tabs, useLocalSearchParams } from "expo-router";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { useFocusEffect } from "@react-navigation/native";
 import {
   LayoutChangeEvent,
   StyleSheet,
@@ -117,6 +119,36 @@ export default function TrackingScreen() {
   const { mutate: pauseSession } = usePauseTrackingSession();
   const { mutate: resumeSession } = useResumeTrackingSession();
   const { mutate: completeSession } = useCompleteTrackingSession();
+  const { data: activeSession, refetch: refetchActiveSession } = useActiveTrackingSession();
+
+  // 앱 재진입 시 진행 중인 세션 복원
+  useFocusEffect(
+    useCallback(() => {
+      // 이미 트래킹 중이면 재조회 불필요
+      if (isTracking) return;
+      refetchActiveSession();
+    }, [isTracking, refetchActiveSession]),
+  );
+
+  useEffect(() => {
+    if (!activeSession?.sessionId) return;
+    if (isTracking) return; // 이미 복원된 경우 무시
+
+    const status = activeSession.status;
+    if (status === 'IN_PROGRESS' || status === 'PAUSED') {
+      setSessionId(activeSession.sessionId);
+      setIsTracking(true);
+      setIsPaused(status === 'PAUSED');
+      // 일시정지된 경우 경과 시간 복원 (pausedSecondsTotal 제외한 실제 등산 시간)
+      if (activeSession.startedAt) {
+        const startedMs = new Date(activeSession.startedAt).getTime();
+        const nowMs = Date.now();
+        const totalElapsed = Math.floor((nowMs - startedMs) / 1000);
+        const pausedSeconds = activeSession.pausedSecondsTotal ?? 0;
+        setElapsedSeconds(Math.max(0, totalElapsed - pausedSeconds));
+      }
+    }
+  }, [activeSession]);
 
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -25,6 +25,7 @@ import {
   TRAIL_BAR_WIDTH,
   TRAIL_MARKER_LEFT,
 } from "@/features/tracking/constants";
+import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -101,8 +102,14 @@ export default function TrackingScreen() {
     })();
   }, []);
 
+  const { data: nearbyData, isLoading: isNearbyLoading } = useNearbyMountain({
+    lat: userLocation?.latitude ?? null,
+    lng: userLocation?.longitude ?? null,
+  });
+
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
+  const selectedCourseId_num = selectedCourseId ? Number(selectedCourseId) : null;
 
   const startCountdown = (freeMode = false) => {
     if (freeMode) setIsFreeMode(true);
@@ -340,8 +347,11 @@ export default function TrackingScreen() {
       {/* Expanded 바텀시트 */}
       {!isTracking && !collapsed && (
         <CourseSelectSheet
-          selectedCourseId={selectedCourseId}
-          onSelectCourse={setSelectedCourseId}
+          mountain={nearbyData?.mountain}
+          courses={nearbyData?.courses}
+          isLoading={isNearbyLoading}
+          selectedCourseId={selectedCourseId_num}
+          onSelectCourse={(id) => setSelectedCourseId(String(id))}
           onFreeRecord={handleFreeRecord}
           onStartCountdown={startCountdown}
         />
@@ -380,6 +390,7 @@ export default function TrackingScreen() {
               onPause={pauseTracking}
               onResume={resumeTracking}
               onStop={requestStop}
+              onSummit={() => setShowSummitSheet(true)}
             />
           )}
         </View>

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -28,6 +28,7 @@ import {
 import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
 import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tracking-session";
 import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
+import { useResumeTrackingSession } from "@/features/tracking/hooks/use-resume-tracking-session";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -112,6 +113,7 @@ export default function TrackingScreen() {
 
   const { mutate: startSession } = useStartTrackingSession();
   const { mutate: pauseSession } = usePauseTrackingSession();
+  const { mutate: resumeSession } = useResumeTrackingSession();
 
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
@@ -227,7 +229,14 @@ export default function TrackingScreen() {
       });
     }
   };
-  const resumeTracking = () => setIsPaused(false);
+  const resumeTracking = () => {
+    setIsPaused(false);
+    if (sessionId != null) {
+      resumeSession(sessionId, {
+        onError: (err) => console.warn('[Tracking] 재개 실패:', err),
+      });
+    }
+  };
 
   const requestStop = () => setShowStopModal(true);
 

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -278,6 +278,13 @@ export default function TrackingScreen() {
   /** StopConfirmModal → 난이도 체감 화면으로 전환 */
   const finishTracking = () => {
     setShowStopModal(false);
+    // 정상 인증 없이 기록 종료하는 경우 세션 완료 API 호출
+    // (정상 인증 시에는 onCertify에서 이미 호출했으므로 중복 방지)
+    if (!hasSummited && sessionId != null) {
+      completeSession(sessionId, {
+        onError: (err) => console.warn('[Tracking] 세션 종료 실패:', err),
+      });
+    }
     setShowDifficultyRating(true);
   };
 

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/features/tracking/constants";
 import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
 import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tracking-session";
+import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -110,6 +111,7 @@ export default function TrackingScreen() {
   });
 
   const { mutate: startSession } = useStartTrackingSession();
+  const { mutate: pauseSession } = usePauseTrackingSession();
 
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
@@ -217,7 +219,14 @@ export default function TrackingScreen() {
     }
   }, [elapsedSeconds, isPaused, isFreeMode, selectedCourse]);
 
-  const pauseTracking = () => setIsPaused(true);
+  const pauseTracking = () => {
+    setIsPaused(true);
+    if (sessionId != null) {
+      pauseSession(sessionId, {
+        onError: (err) => console.warn('[Tracking] 일시정지 실패:', err),
+      });
+    }
+  };
   const resumeTracking = () => setIsPaused(false);
 
   const requestStop = () => setShowStopModal(true);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -26,6 +26,7 @@ import {
   TRAIL_MARKER_LEFT,
 } from "@/features/tracking/constants";
 import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
+import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tracking-session";
 import { isLiveActivityEnabled } from "@/constants/platform";
 import { LiveActivity } from "@/modules/live-activity";
 import {
@@ -68,6 +69,7 @@ export default function TrackingScreen() {
   );
   const [showStopModal, setShowStopModal] = useState(false);
   const [showDifficultyRating, setShowDifficultyRating] = useState(false);
+  const [sessionId, setSessionId] = useState<number | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
   const [barLayout, setBarLayout] = useState<{
@@ -107,6 +109,8 @@ export default function TrackingScreen() {
     lng: userLocation?.longitude ?? null,
   });
 
+  const { mutate: startSession } = useStartTrackingSession();
+
   const selectedCourse =
     MOCK_COURSES.find((c) => c.id === selectedCourseId) ?? MOCK_COURSES[0];
   const selectedCourseId_num = selectedCourseId ? Number(selectedCourseId) : null;
@@ -123,6 +127,26 @@ export default function TrackingScreen() {
     if (countdown === 0) {
       setIsTracking(true);
       setCountdown(null);
+
+      // 트래킹 세션 시작 API 호출
+      const mountainId = nearbyData?.mountain?.mountainId;
+      if (mountainId != null) {
+        startSession(
+          {
+            mountainId,
+            courseId: isFreeMode ? undefined : (selectedCourseId_num ?? undefined),
+            isFreeRecording: isFreeMode,
+          },
+          {
+            onSuccess: (data) => {
+              if (data.sessionId != null) setSessionId(data.sessionId);
+            },
+            onError: (err) => {
+              console.warn('[Tracking] 세션 시작 실패:', err);
+            },
+          },
+        );
+      }
       return;
     }
     const timer = setTimeout(

--- a/components/bottom-tab-bar.tsx
+++ b/components/bottom-tab-bar.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { HomeIcon } from "@/components/icons/home-icon";
 import { MountainIcon } from "@/components/icons/mountain-icon";
 import { MyIcon } from "@/components/icons/my-icon";
+import { NavigationIcon } from "@/components/icons/navigation-icon";
 import { useHomeStateContext } from "@/contexts/home-state-context";
 
 type TabItem = {
@@ -29,12 +30,12 @@ const TAB_ITEMS: TabItem[] = [
     label: "산목록",
     renderIcon: (color) => <MountainIcon size={24} color={color} />,
   },
-  // {
-  //   name: "tracking",
-  //   label: null,
-  //   renderIcon: (color) => <NavigationIcon size={24} color={color} />,
-  //   isCenter: true,
-  // },
+  {
+    name: "tracking",
+    label: null,
+    renderIcon: (color) => <NavigationIcon size={24} color={color} />,
+    isCenter: true,
+  },
   // {
   //   name: "community",
   //   label: "커뮤니티",

--- a/features/tracking/components/course-item.tsx
+++ b/features/tracking/components/course-item.tsx
@@ -3,8 +3,70 @@ import { AscentIcon } from '@/components/icons/ascent-icon';
 import { ClockIcon } from '@/components/icons/clock-icon';
 import { DescentIcon } from '@/components/icons/descent-icon';
 import { DistanceIcon } from '@/components/icons/distance-icon';
+import { NearbyMountainCourse } from '@/types/api.generated';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { Course, DIFFICULTY_BG, DIFFICULTY_TEXT_COLOR } from '../constants';
+
+// API 난이도 → 한글 라벨/스타일 매핑
+const API_DIFFICULTY_LABEL: Record<string, string> = {
+  EASY: '초급',
+  NORMAL: '중급',
+  HARD: '고급',
+};
+const API_DIFFICULTY_BG: Record<string, string> = {
+  EASY: 'bg-green-50',
+  NORMAL: 'bg-yellow-50',
+  HARD: 'bg-red-50',
+};
+const API_DIFFICULTY_TEXT: Record<string, string> = {
+  EASY: 'text-secondary-strong',
+  NORMAL: 'text-yellow-600',
+  HARD: 'text-red-500',
+};
+
+type ApiCourseItemProps = {
+  course: NearbyMountainCourse;
+  selected: boolean;
+  onPress: () => void;
+};
+
+export function ApiCourseItem({ course, selected, onPress }: ApiCourseItemProps) {
+  const difficultyLabel = API_DIFFICULTY_LABEL[course.difficulty ?? ''] ?? course.difficulty ?? '-';
+  const bg = API_DIFFICULTY_BG[course.difficulty ?? ''] ?? 'bg-fill-stronger';
+  const textColor = API_DIFFICULTY_TEXT[course.difficulty ?? ''] ?? 'text-label-normal';
+  const distanceKm = course.distance != null ? `${course.distance.toFixed(1)}km` : '-';
+  const durationMin = course.duration != null
+    ? course.duration >= 60
+      ? `${Math.floor(course.duration / 60)}h ${course.duration % 60}m`
+      : `${course.duration}m`
+    : '-';
+
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      className={`p-3 rounded-xl border gap-3 ${
+        selected ? 'border-primary-normal bg-fill-strong' : 'border-line-subtle bg-fill-normal'
+      }`}
+    >
+      <View className="flex-row items-center gap-2">
+        <View className={`rounded px-1 py-0.5 ${bg}`}>
+          <Text className={`typo-caption-1-medium ${textColor}`}>{difficultyLabel}</Text>
+        </View>
+        <Text className="typo-body-1-normal-semi-bold text-label-normal">{course.name}</Text>
+      </View>
+      <View className="flex-row gap-4">
+        <View className="flex-row items-center gap-1">
+          <DistanceIcon />
+          <Text className="typo-caption-1-medium text-label-subtler">거리 {distanceKm}</Text>
+        </View>
+        <View className="flex-row items-center gap-1">
+          <ClockIcon />
+          <Text className="typo-caption-1-medium text-label-subtler">소요시간 {durationMin}</Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+}
 
 type Props = {
   course: Course;

--- a/features/tracking/components/course-select-sheet.tsx
+++ b/features/tracking/components/course-select-sheet.tsx
@@ -1,15 +1,21 @@
-import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
-import { Course, MOCK_COURSES } from '../constants';
-import { CourseItem } from './course-item';
+import { NearbyMountainCourse, NearbyMountainInfo } from '@/types/api.generated';
+import { ActivityIndicator, ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { ApiCourseItem } from './course-item';
 
 type Props = {
-  selectedCourseId: string | null;
-  onSelectCourse: (id: string) => void;
+  mountain?: NearbyMountainInfo;
+  courses?: NearbyMountainCourse[];
+  isLoading?: boolean;
+  selectedCourseId: number | null;
+  onSelectCourse: (id: number) => void;
   onFreeRecord: () => void;
   onStartCountdown: () => void;
 };
 
 export function CourseSelectSheet({
+  mountain,
+  courses,
+  isLoading,
   selectedCourseId,
   onSelectCourse,
   onFreeRecord,
@@ -28,7 +34,7 @@ export function CourseSelectSheet({
       {/* 타이틀 */}
       <View className="px-4 pt-1 pb-4 gap-1">
         <Text className="typo-headline-1-semi-bold text-label-normal">
-          관악산 등산을 기록할까요?
+          {mountain?.name ? `${mountain.name} 등산을 기록할까요?` : '등산을 기록할까요?'}
         </Text>
         <Text className="typo-body-2-normal-regular text-label-subtler">
           코스를 선택해서 시작하거나 자유 기록을 시작하세요.
@@ -36,20 +42,31 @@ export function CourseSelectSheet({
       </View>
 
       {/* 코스 리스트 */}
-      <ScrollView
-        className="flex-1"
-        contentContainerClassName="px-4 gap-3 pb-2"
-        showsVerticalScrollIndicator={false}
-      >
-        {MOCK_COURSES.map((course: Course) => (
-          <CourseItem
-            key={course.id}
-            course={course}
-            selected={selectedCourseId === course.id}
-            onPress={() => onSelectCourse(course.id)}
-          />
-        ))}
-      </ScrollView>
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator />
+        </View>
+      ) : (
+        <ScrollView
+          className="flex-1"
+          contentContainerClassName="px-4 gap-3 pb-2"
+          showsVerticalScrollIndicator={false}
+        >
+          {(courses ?? []).map((course) => (
+            <ApiCourseItem
+              key={course.courseId}
+              course={course}
+              selected={selectedCourseId === course.courseId}
+              onPress={() => course.courseId != null && onSelectCourse(course.courseId)}
+            />
+          ))}
+          {!courses?.length && (
+            <Text className="typo-body-2-normal-regular text-label-subtler text-center py-4">
+              등록된 코스가 없어요
+            </Text>
+          )}
+        </ScrollView>
+      )}
 
       {/* 하단 버튼 */}
       <View className="flex-row gap-2 px-4 pt-5 pb-4">
@@ -62,6 +79,7 @@ export function CourseSelectSheet({
         <TouchableOpacity
           className="flex-1 h-12 bg-primary-normal rounded-[10px] px-5 items-center justify-center"
           onPress={onStartCountdown}
+          disabled={selectedCourseId === null}
         >
           <Text className="typo-label-large text-common-100">코스 따라가기</Text>
         </TouchableOpacity>

--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -22,6 +22,7 @@ type Props = {
   onPause: () => void;
   onResume: () => void;
   onStop: () => void;
+  onSummit: () => void;
 };
 
 export function TrackingSheet({
@@ -35,6 +36,7 @@ export function TrackingSheet({
   onPause,
   onResume,
   onStop,
+  onSummit,
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -124,29 +126,40 @@ export function TrackingSheet({
 
           {isPaused ? (
             <>
-              <TouchableOpacity
-                className="flex-1 bg-secondary-normal rounded-[10px] items-center justify-center"
-                style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
-                onPress={onResume}
-              >
-                <Text className="typo-label-large text-label-normal">기록 재개</Text>
-              </TouchableOpacity>
+              {/* 일시 정지 상태: 다시 시작 + 기록 종료 */}
               <TouchableOpacity
                 className="flex-1 bg-label-normal rounded-[10px] items-center justify-center"
                 style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
+                onPress={onResume}
+              >
+                <Text className="typo-label-large text-common-100">다시 시작</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                className="flex-1 bg-fill-stronger rounded-[10px] items-center justify-center"
+                style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
                 onPress={onStop}
               >
-                <Text className="typo-label-large text-common-100">기록 종료</Text>
+                <Text className="typo-label-large text-label-subtle">기록 종료</Text>
               </TouchableOpacity>
             </>
           ) : (
-            <TouchableOpacity
-              className="flex-1 bg-label-normal rounded-[10px] items-center justify-center"
-              style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
-              onPress={onPause}
-            >
-              <Text className="typo-label-large text-common-100">기록 중단</Text>
-            </TouchableOpacity>
+            <>
+              {/* 트래킹 중: 일시 정지 + 정상 도착 */}
+              <TouchableOpacity
+                className="flex-1 bg-fill-stronger rounded-[10px] items-center justify-center"
+                style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
+                onPress={onPause}
+              >
+                <Text className="typo-label-large text-label-subtle">일시 정지</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                className="flex-1 bg-secondary-normal rounded-[10px] items-center justify-center"
+                style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
+                onPress={onSummit}
+              >
+                <Text className="typo-label-large text-label-normal">정상 도착</Text>
+              </TouchableOpacity>
+            </>
           )}
         </View>
       </View>

--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -126,7 +126,7 @@ export function TrackingSheet({
 
           {isPaused ? (
             <>
-              {/* 일시 정지 상태: 다시 시작 + 기록 종료 */}
+              {/* 일시 정지 상태 (등산 중 / 하산 중 공통): 다시 시작 + 기록 종료 */}
               <TouchableOpacity
                 className="flex-1 bg-label-normal rounded-[10px] items-center justify-center"
                 style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
@@ -142,9 +142,20 @@ export function TrackingSheet({
                 <Text className="typo-label-large text-label-subtle">기록 종료</Text>
               </TouchableOpacity>
             </>
+          ) : hasSummited ? (
+            <>
+              {/* 하산 중: 일시 정지만 (전체 너비) */}
+              <TouchableOpacity
+                className="flex-1 bg-fill-stronger rounded-[10px] items-center justify-center"
+                style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}
+                onPress={onPause}
+              >
+                <Text className="typo-label-large text-label-subtle">일시 정지</Text>
+              </TouchableOpacity>
+            </>
           ) : (
             <>
-              {/* 트래킹 중: 일시 정지 + 정상 도착 */}
+              {/* 등산 중: 일시 정지 + 정상 도착 */}
               <TouchableOpacity
                 className="flex-1 bg-fill-stronger rounded-[10px] items-center justify-center"
                 style={{ minHeight: 48, maxHeight: 48, paddingVertical: 11, paddingHorizontal: 20 }}

--- a/features/tracking/hooks/use-active-tracking-session.ts
+++ b/features/tracking/hooks/use-active-tracking-session.ts
@@ -1,0 +1,19 @@
+import { api } from '@/lib/api';
+import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
+import { useQuery } from '@tanstack/react-query';
+
+export const ACTIVE_SESSION_KEY = [ENDPOINTS.TRACKING_SESSIONS_ACTIVE] as const;
+
+export function useActiveTrackingSession() {
+  return useQuery({
+    queryKey: ACTIVE_SESSION_KEY,
+    queryFn: async (): Promise<TrackingSessionResponse | null> => {
+      const res = await api.get<TrackingSessionResponse>({
+        path: ENDPOINTS.TRACKING_SESSIONS_ACTIVE,
+      });
+      // data가 비어있으면 null 반환
+      return res.data ?? null;
+    },
+    staleTime: 0,
+  });
+}

--- a/features/tracking/hooks/use-complete-tracking-session.ts
+++ b/features/tracking/hooks/use-complete-tracking-session.ts
@@ -1,0 +1,14 @@
+import { api } from '@/lib/api';
+import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
+import { useMutation } from '@tanstack/react-query';
+
+export function useCompleteTrackingSession() {
+  return useMutation({
+    mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
+      const res = await api.post<TrackingSessionResponse>({
+        path: ENDPOINTS.TRACKING_SESSIONS_COMPLETE(sessionId),
+      });
+      return res.data;
+    },
+  });
+}

--- a/features/tracking/hooks/use-nearby-mountain.ts
+++ b/features/tracking/hooks/use-nearby-mountain.ts
@@ -1,0 +1,23 @@
+import { api } from '@/lib/api';
+import { ENDPOINTS, NearbyMountainResponse } from '@/types/api.generated';
+import { useQuery } from '@tanstack/react-query';
+
+type Params = {
+  lat: number | null;
+  lng: number | null;
+};
+
+export function useNearbyMountain({ lat, lng }: Params) {
+  return useQuery({
+    queryKey: [ENDPOINTS.TRACKING_NEARBY_MOUNTAIN, lat, lng],
+    queryFn: async () => {
+      const res = await api.get<NearbyMountainResponse>({
+        path: ENDPOINTS.TRACKING_NEARBY_MOUNTAIN,
+        params: { lat: lat!, lng: lng! },
+      });
+      return res.data;
+    },
+    enabled: lat !== null && lng !== null,
+    staleTime: 1000 * 60 * 5, // 5분
+  });
+}

--- a/features/tracking/hooks/use-pause-tracking-session.ts
+++ b/features/tracking/hooks/use-pause-tracking-session.ts
@@ -1,0 +1,14 @@
+import { api } from '@/lib/api';
+import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
+import { useMutation } from '@tanstack/react-query';
+
+export function usePauseTrackingSession() {
+  return useMutation({
+    mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
+      const res = await api.post<TrackingSessionResponse>({
+        path: ENDPOINTS.TRACKING_SESSIONS_PAUSE(sessionId),
+      });
+      return res.data;
+    },
+  });
+}

--- a/features/tracking/hooks/use-resume-tracking-session.ts
+++ b/features/tracking/hooks/use-resume-tracking-session.ts
@@ -1,0 +1,14 @@
+import { api } from '@/lib/api';
+import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
+import { useMutation } from '@tanstack/react-query';
+
+export function useResumeTrackingSession() {
+  return useMutation({
+    mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
+      const res = await api.post<TrackingSessionResponse>({
+        path: ENDPOINTS.TRACKING_SESSIONS_RESUME(sessionId),
+      });
+      return res.data;
+    },
+  });
+}

--- a/features/tracking/hooks/use-start-tracking-session.ts
+++ b/features/tracking/hooks/use-start-tracking-session.ts
@@ -1,0 +1,19 @@
+import { api } from '@/lib/api';
+import {
+  ENDPOINTS,
+  StartTrackingSessionRequest,
+  TrackingSessionResponse,
+} from '@/types/api.generated';
+import { useMutation } from '@tanstack/react-query';
+
+export function useStartTrackingSession() {
+  return useMutation({
+    mutationFn: async (body: StartTrackingSessionRequest): Promise<TrackingSessionResponse> => {
+      const res = await api.post<TrackingSessionResponse>({
+        path: ENDPOINTS.TRACKING_SESSIONS,
+        body,
+      });
+      return res.data;
+    },
+  });
+}

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -48,6 +48,7 @@ export const ENDPOINTS = {
   TRACKING_SESSIONS: "/api/tracking/sessions",
   TRACKING_SESSIONS_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
   TRACKING_SESSIONS_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
+  TRACKING_SESSIONS_COMPLETE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/complete`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -44,6 +44,7 @@ export const ENDPOINTS = {
   COMMUNITY_COMMENTS_BY_COMMENTID_REPLIES: (commentId: number | string) => `/api/community/comments/${commentId}/replies`,
   COMMUNITY_COMMENTS_BY_COMMENTID: (commentId: number | string) => `/api/community/comments/${commentId}`,
   AUTH_WITHDRAW: "/api/auth/withdraw",
+  TRACKING_NEARBY_MOUNTAIN: "/api/tracking/nearby-mountain",
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -740,4 +741,28 @@ export type GetRepliesParams = {
 // DELETE /api/community/comments/{commentId}
 export type Delete3Params = {
   commentId: number;
+};
+
+// GET /api/tracking/nearby-mountain
+export type NearbyMountainCourse = {
+  courseId?: number;
+  name?: string;
+  difficulty?: "EASY" | "NORMAL" | "HARD";
+  distance?: number;
+  duration?: number;
+};
+
+export type NearbyMountainInfo = {
+  mountainId?: number;
+  name?: string;
+  address?: string;
+  altitude?: number;
+  latitude?: number;
+  longitude?: number;
+  imageUrls?: string[];
+};
+
+export type NearbyMountainResponse = {
+  mountain?: NearbyMountainInfo;
+  courses?: NearbyMountainCourse[];
 };

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -47,6 +47,7 @@ export const ENDPOINTS = {
   TRACKING_NEARBY_MOUNTAIN: "/api/tracking/nearby-mountain",
   TRACKING_SESSIONS: "/api/tracking/sessions",
   TRACKING_SESSIONS_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
+  TRACKING_SESSIONS_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -46,6 +46,7 @@ export const ENDPOINTS = {
   AUTH_WITHDRAW: "/api/auth/withdraw",
   TRACKING_NEARBY_MOUNTAIN: "/api/tracking/nearby-mountain",
   TRACKING_SESSIONS: "/api/tracking/sessions",
+  TRACKING_SESSIONS_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -49,6 +49,7 @@ export const ENDPOINTS = {
   TRACKING_SESSIONS_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
   TRACKING_SESSIONS_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
   TRACKING_SESSIONS_COMPLETE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/complete`,
+  TRACKING_SESSIONS_ACTIVE: "/api/tracking/sessions/me/active",
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -791,4 +792,5 @@ export type TrackingSessionResponse = {
   endedAt?: string;
   pausedAt?: string;
   pausedSecondsTotal?: number;
+  hikingRecordId?: number;
 };

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -45,6 +45,7 @@ export const ENDPOINTS = {
   COMMUNITY_COMMENTS_BY_COMMENTID: (commentId: number | string) => `/api/community/comments/${commentId}`,
   AUTH_WITHDRAW: "/api/auth/withdraw",
   TRACKING_NEARBY_MOUNTAIN: "/api/tracking/nearby-mountain",
+  TRACKING_SESSIONS: "/api/tracking/sessions",
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -765,4 +766,26 @@ export type NearbyMountainInfo = {
 export type NearbyMountainResponse = {
   mountain?: NearbyMountainInfo;
   courses?: NearbyMountainCourse[];
+};
+
+// POST /api/tracking/sessions
+export type StartTrackingSessionRequest = {
+  mountainId: number;
+  courseId?: number;
+  isFreeRecording: boolean;
+};
+
+export type TrackingSessionResponse = {
+  sessionId?: number;
+  userId?: number;
+  mountainId?: number;
+  mountainName?: string;
+  courseId?: number;
+  courseName?: string;
+  isFreeRecording?: boolean;
+  status?: "IN_PROGRESS" | "PAUSED" | "COMPLETED";
+  startedAt?: string;
+  endedAt?: string;
+  pausedAt?: string;
+  pausedSecondsTotal?: number;
 };


### PR DESCRIPTION
## 개요
트래킹 탭 활성화 및 트래킹 세션 API 전체 연동

## 작업 내용

### 트래킹 탭 활성화
- 바텀 탭바에서 주석 처리된 트래킹 탭 활성화

### 주변 산 조회 API 연동
- `GET /api/tracking/nearby-mountain` 연동
- 현재 GPS 위치 기반으로 주변 산 및 코스 정보 조회
- 코스 선택 바텀시트에 API 응답 데이터 렌더링

### 트래킹 세션 API 연동
- `POST /api/tracking/sessions` — 카운트다운 종료 시 세션 시작 (코스/자유기록 모두 연동)
- `POST /api/tracking/sessions/{sessionId}/pause` — 일시 정지 버튼 클릭 시 호출
- `POST /api/tracking/sessions/{sessionId}/resume` — 다시 시작 버튼 클릭 시 호출
- `POST /api/tracking/sessions/{sessionId}/complete` — 정상 인증하기 또는 기록 종료 시 호출

### 활성 세션 복원
- `GET /api/tracking/sessions/me/active` 연동
- 트래킹 탭 재진입 시 진행 중(IN_PROGRESS/PAUSED) 세션 자동 감지 및 상태 복원
- `startedAt` - `pausedSecondsTotal` 기반으로 경과 시간 복원

### 트래킹 바텀시트 UI 개선
- 등산 중: 일시 정지 + 정상 도착
- 등산 중 일시 정지: 다시 시작 + 기록 종료
- 하산 중 (정상 인증 후): 일시 정지만 표시
- 하산 중 일시 정지: 다시 시작 + 기록 종료

## 변경 파일
- `app/(tabs)/_layout.tsx` — 트래킹 탭 활성화
- `components/bottom-tab-bar.tsx` — 트래킹 탭 아이템 활성화
- `app/(tabs)/tracking.tsx` — 세션 상태 관리 및 전체 API 연동
- `features/tracking/components/tracking-sheet.tsx` — 바텀시트 버튼 상태 분기
- `features/tracking/components/course-select-sheet.tsx` — API 기반 코스 렌더링
- `features/tracking/hooks/use-nearby-mountain.ts` — 신규
- `features/tracking/hooks/use-start-tracking-session.ts` — 신규
- `features/tracking/hooks/use-pause-tracking-session.ts` — 신규
- `features/tracking/hooks/use-resume-tracking-session.ts` — 신규
- `features/tracking/hooks/use-complete-tracking-session.ts` — 신규
- `features/tracking/hooks/use-active-tracking-session.ts` — 신규
- `types/api.generated.ts` — 트래킹 관련 엔드포인트 및 타입 추가

## 참고 사항
- 세션 완료 API는 ① 정상 인증하기, ② 코스 없는 기록 종료 두 경로에서 각각 호출되며 중복 호출 방지 처리됨 (`hasSummited` 플래그)
- 지도 및 코스 경로는 현재 목 데이터 사용 (실제 GPS 연동은 별도 작업 예정)
- `isAtSummit` 정상 감지는 현재 목 값 사용 (GPS 좌표 비교 로직은 별도 작업 예정)