### PR TITLE
fix: web 호환성 개선 및 shadow → boxShadow 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,18 @@ Figma 재내보내기 후 반드시 실행하세요. `tokens.cjs`, `typography-p
 
 토큰으로 정의된 값이 있다면 Tailwind 클래스로 참조하세요. 원시 hex 값이나 숫자를 직접 사용하지 마세요.
 
+### 3. 그림자는 `boxShadow`를 사용할 것
+
+iOS 전용 shadow 속성(`shadowColor`, `shadowOffset`, `shadowOpacity`, `shadowRadius`) 및 Android 전용 `elevation` 사용 금지. 반드시 `boxShadow`를 사용하세요.
+
+```tsx
+// ✅
+style={{ boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.1)' }}
+
+// ❌
+style={{ shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.1, shadowRadius: 4, elevation: 4 }}
+```
+
 ---
 
 ## 디자인 토큰 참고

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,4 @@
 import Toast from "@/components/toast/toast";
-import { isExpoGo } from "@/constants/platform";
 import { useAuthState } from "@/features/auth/hooks/use-auth-state";
 import { useAppState } from "@/hooks/use-app-state";
 import { useOnlineManager } from "@/hooks/use-online-manager";
@@ -23,8 +22,7 @@ import "react-native-reanimated";
 import "../global.css";
 
 SplashScreen.preventAutoHideAsync();
-if (!isExpoGo)
-  initializeKakaoSDK(process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY!);
+if (!__DEV__) initializeKakaoSDK(process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY!);
 
 function onAppStateChange(status: AppStateStatus) {
   // React Query already supports in web browser refetch on window focus by default
@@ -44,7 +42,7 @@ export const unstable_settings = {
 export default function RootLayout(): React.JSX.Element | null {
   const { status: authStatus } = useAuthState();
 
-  usePushNotification(authStatus === "authenticated");
+  usePushNotification(!__DEV__ && authStatus === "authenticated");
   const [fontsLoaded] = useFonts({
     "Lexend-SemiBold": require("../assets/fonts/Lexend-SemiBold.ttf"),
     Lexend_700Bold,

--- a/app/mountain-info.tsx
+++ b/app/mountain-info.tsx
@@ -205,11 +205,7 @@ const styles = StyleSheet.create({
     left: 154,
   },
   shadowBtn: {
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
+    boxShadow: '0px 2px 2px 0px rgba(0, 0, 0, 0.1)',
   },
   crosshairBtn: {
     width: 48,
@@ -217,11 +213,7 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     borderWidth: 1,
     borderColor: '#D1D5DB',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.15)',
   },
   locationButton: {
     position: 'absolute',

--- a/app/mypage/permissions.tsx
+++ b/app/mypage/permissions.tsx
@@ -60,11 +60,7 @@ function ToggleSwitch({ value, onValueChange }: { value: boolean; onValueChange:
             height: THUMB_SIZE,
             borderRadius: 9999,
             backgroundColor: COLOR_THUMB,
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: 4 },
-            shadowOpacity: 0.1,
-            shadowRadius: 6,
-            elevation: 4,
+            boxShadow: '0px 4px 6px 0px rgba(0, 0, 0, 0.1)',
           }}
         />
       </Animated.View>

--- a/app/record/photo-report-edit.tsx
+++ b/app/record/photo-report-edit.tsx
@@ -327,11 +327,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#FFFFFF",
     alignItems: "center",
     justifyContent: "center",
-    shadowColor: "#000000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.1)',
   },
   photoRowScroll: {
     flexGrow: 0,

--- a/components/map-markers/unvisited-mountain-pill-marker.tsx
+++ b/components/map-markers/unvisited-mountain-pill-marker.tsx
@@ -41,10 +41,6 @@ const styles = StyleSheet.create({
     paddingBottom: 5,
     paddingLeft: 5,
     paddingRight: 10,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: '0px 1px 4px 0px rgba(0, 0, 0, 0.2)',
   },
 });

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -92,11 +92,7 @@ const styles = StyleSheet.create({
     top: 8,
     width: 92,
     height: 46,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: '0px 1px 4px 0px rgba(0, 0, 0, 0.2)',
   },
   imageGroup: {
     position: 'absolute',

--- a/components/slider.tsx
+++ b/components/slider.tsx
@@ -6,11 +6,7 @@ const THUMB_SIZE = 24;
 const TRACK_HEIGHT = 4;
 
 const THUMB_SHADOW = {
-  shadowColor: '#000',
-  shadowOffset: { width: 0, height: 2 },
-  shadowOpacity: 0.15,
-  shadowRadius: 4,
-  elevation: 4,
+  boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.15)',
 } as const;
 
 type Props = {

--- a/features/home/components/home-header.tsx
+++ b/features/home/components/home-header.tsx
@@ -9,11 +9,7 @@ import { MapTabToggle } from "./map-tab-toggle";
 export type MapTab = "map" | "feed";
 
 const buttonShadow = {
-  shadowColor: "#000",
-  shadowOffset: { width: 0, height: 2 },
-  shadowOpacity: 0.1,
-  shadowRadius: 2,
-  elevation: 2,
+  boxShadow: '0px 2px 2px 0px rgba(0, 0, 0, 0.1)',
 };
 
 type HomeHeaderProps = {

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -296,11 +296,7 @@ const styles = StyleSheet.create({
     right: 0,
   },
   bellButton: {
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
-    elevation: 2,
+    boxShadow: '0px 2px 2px 0px rgba(0, 0, 0, 0.1)',
   },
   locationButton: {
     position: "absolute",
@@ -313,10 +309,6 @@ const styles = StyleSheet.create({
     borderColor: "#D1D5DB",
     alignItems: "center",
     justifyContent: "center",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.15,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.15)',
   },
 });

--- a/features/mountains/components/region-filter-content.tsx
+++ b/features/mountains/components/region-filter-content.tsx
@@ -197,10 +197,7 @@ export function RegionFilterContent({ initialSelections = [], onApply }: Props) 
             className="absolute bottom-0 left-0 right-0 bg-fill-normal px-5 pb-3 pt-3"
             style={{
               zIndex: 10,
-              shadowColor: "#000",
-              shadowOffset: { width: 0, height: -12 },
-              shadowOpacity: 0.04,
-              shadowRadius: 20,
+              boxShadow: '0px -12px 20px 0px rgba(0, 0, 0, 0.04)',
             }}
           >
             <Text className="text-label-subtler typo-body-3-medium">

--- a/features/tracking/components/course-select-sheet.tsx
+++ b/features/tracking/components/course-select-sheet.tsx
@@ -1,10 +1,16 @@
-import { NearbyMountainCourse, NearbyMountainInfo } from '@/types/api.generated';
-import { ActivityIndicator, ScrollView, Text, TouchableOpacity, View } from 'react-native';
-import { ApiCourseItem } from './course-item';
+import { CourseInfo, NearbyMountainInfo } from "@/types/api.generated";
+import {
+  ActivityIndicator,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { ApiCourseItem } from "./course-item";
 
 type Props = {
   mountain?: NearbyMountainInfo;
-  courses?: NearbyMountainCourse[];
+  courses?: CourseInfo[];
   isLoading?: boolean;
   selectedCourseId: number | null;
   onSelectCourse: (id: number) => void;
@@ -23,20 +29,22 @@ export function CourseSelectSheet({
 }: Props) {
   return (
     <View
-      className="w-full bg-fill-normal overflow-hidden"
+      className="w-full overflow-hidden bg-fill-normal"
       style={{ height: 448, borderTopLeftRadius: 20, borderTopRightRadius: 20 }}
     >
       {/* 드래그 핸들 */}
-      <View className="items-center pt-3 pb-2">
-        <View className="w-10 h-1 rounded-full bg-fill-neutral" />
+      <View className="items-center pb-2 pt-3">
+        <View className="h-1 w-10 rounded-full bg-fill-neutral" />
       </View>
 
       {/* 타이틀 */}
-      <View className="px-4 pt-1 pb-4 gap-1">
-        <Text className="typo-headline-1-semi-bold text-label-normal">
-          {mountain?.name ? `${mountain.name} 등산을 기록할까요?` : '등산을 기록할까요?'}
+      <View className="gap-1 px-4 pb-4 pt-1">
+        <Text className="text-label-normal typo-headline-1-semi-bold">
+          {mountain?.name
+            ? `${mountain.name} 등산을 기록할까요?`
+            : "등산을 기록할까요?"}
         </Text>
-        <Text className="typo-body-2-normal-regular text-label-subtler">
+        <Text className="text-label-subtler typo-body-2-normal-regular">
           코스를 선택해서 시작하거나 자유 기록을 시작하세요.
         </Text>
       </View>
@@ -57,11 +65,13 @@ export function CourseSelectSheet({
               key={course.courseId}
               course={course}
               selected={selectedCourseId === course.courseId}
-              onPress={() => course.courseId != null && onSelectCourse(course.courseId)}
+              onPress={() =>
+                course.courseId != null && onSelectCourse(course.courseId)
+              }
             />
           ))}
           {!courses?.length && (
-            <Text className="typo-body-2-normal-regular text-label-subtler text-center py-4">
+            <Text className="py-4 text-center text-label-subtler typo-body-2-normal-regular">
               등록된 코스가 없어요
             </Text>
           )}
@@ -69,19 +79,23 @@ export function CourseSelectSheet({
       )}
 
       {/* 하단 버튼 */}
-      <View className="flex-row gap-2 px-4 pt-5 pb-4">
+      <View className="flex-row gap-2 px-4 pb-4 pt-5">
         <TouchableOpacity
-          className="flex-1 h-12 bg-fill-stronger rounded-[10px] px-5 items-center justify-center"
+          className="h-12 flex-1 items-center justify-center rounded-[10px] bg-fill-stronger px-5"
           onPress={onFreeRecord}
         >
-          <Text className="typo-label-large text-label-subtle">자유 기록하기</Text>
+          <Text className="text-label-subtle typo-label-large">
+            자유 기록하기
+          </Text>
         </TouchableOpacity>
         <TouchableOpacity
-          className="flex-1 h-12 bg-primary-normal rounded-[10px] px-5 items-center justify-center"
+          className="h-12 flex-1 items-center justify-center rounded-[10px] bg-primary-normal px-5"
           onPress={onStartCountdown}
           disabled={selectedCourseId === null}
         >
-          <Text className="typo-label-large text-common-100">코스 따라가기</Text>
+          <Text className="text-common-100 typo-label-large">
+            코스 따라가기
+          </Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/features/tracking/constants/index.ts
+++ b/features/tracking/constants/index.ts
@@ -101,19 +101,11 @@ export const DIFFICULTY_TEXT_COLOR: Record<Difficulty, string> = {
 };
 
 export const SHADOW = {
-  shadowColor: '#000',
-  shadowOffset: { width: 0, height: 1 },
-  shadowOpacity: 0.15,
-  shadowRadius: 4,
-  elevation: 4,
+  boxShadow: '0px 1px 4px 0px rgba(0, 0, 0, 0.15)',
 } as const;
 
 export const CARD_SHADOW = {
-  shadowColor: '#000',
-  shadowOffset: { width: 0, height: 2 },
-  shadowOpacity: 0.10,
-  shadowRadius: 4,
-  elevation: 3,
+  boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.1)',
 } as const;
 
 // ─── 타이포그래피 ─────────────────────────────────────────

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -9,6 +9,7 @@ export const ENDPOINTS = {
   USERS_ONBOARDING: "/api/users/onboarding",
   TRACKING_SESSIONS: "/api/tracking/sessions",
   TRACKING_SESSIONS_BY_SESSIONID_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
+  TRACKING_SESSIONS_BY_SESSIONID_PHOTOS: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/photos`,
   TRACKING_SESSIONS_BY_SESSIONID_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
   TRACKING_SESSIONS_BY_SESSIONID_COMPLETE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/complete`,
   TRACKING_SESSIONS_BY_SESSIONID_ABANDON: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/abandon`,
@@ -52,12 +53,6 @@ export const ENDPOINTS = {
   COMMUNITY_COMMENTS_BY_COMMENTID_REPLIES: (commentId: number | string) => `/api/community/comments/${commentId}/replies`,
   COMMUNITY_COMMENTS_BY_COMMENTID: (commentId: number | string) => `/api/community/comments/${commentId}`,
   AUTH_WITHDRAW: "/api/auth/withdraw",
-  TRACKING_NEARBY_MOUNTAIN: "/api/tracking/nearby-mountain",
-  TRACKING_SESSIONS: "/api/tracking/sessions",
-  TRACKING_SESSIONS_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
-  TRACKING_SESSIONS_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
-  TRACKING_SESSIONS_COMPLETE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/complete`,
-  TRACKING_SESSIONS_ACTIVE: "/api/tracking/sessions/me/active",
 } as const;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -115,6 +110,32 @@ export type TrackingSessionResponse = {
   pausedAt?: string;
   pausedSecondsTotal?: number;
   hikingRecordId?: number;
+};
+export type TrackingPhotoUploadRequest = {
+  milestoneIndex: number;
+  milestoneDistanceM: number;
+  imageUrl?: string;
+  capturedAt: string;
+  lat: number;
+  lng: number;
+  altitude?: number;
+};
+export type ApiResponseTrackingPhotoResponse = {
+  isSuccess?: boolean;
+  code?: string;
+  message?: string;
+  data?: TrackingPhotoResponse;
+};
+export type TrackingPhotoResponse = {
+  photoId?: number;
+  trackingSessionId?: number;
+  milestoneIndex?: number;
+  milestoneDistanceM?: number;
+  imageUrl?: string;
+  capturedAt?: string;
+  lat?: number;
+  lng?: number;
+  altitude?: number;
 };
 export type OAuthKakaoLoginRequest = {
   accessToken?: string;
@@ -285,6 +306,12 @@ export type GetNotificationSettingResponse = {
   pushNotificationEnabled?: boolean;
   liveActivityEnabled?: boolean;
   voiceEnabled?: boolean;
+};
+export type ApiResponseListTrackingPhotoResponse = {
+  isSuccess?: boolean;
+  code?: string;
+  message?: string;
+  data?: TrackingPhotoResponse[];
 };
 export type ApiResponseNearbyMountainResponse = {
   isSuccess?: boolean;
@@ -603,6 +630,17 @@ export type ResumeSessionParams = {
   sessionId: number;
 };
 
+// GET /api/tracking/sessions/{sessionId}/photos
+export type ListParams = {
+  sessionId: number;
+};
+
+// POST /api/tracking/sessions/{sessionId}/photos
+export type UploadParams = {
+  sessionId: number;
+};
+export type UploadBody = TrackingPhotoUploadRequest;
+
 // POST /api/tracking/sessions/{sessionId}/pause
 export type PauseSessionParams = {
   sessionId: number;
@@ -835,51 +873,4 @@ export type GetRepliesParams = {
 // DELETE /api/community/comments/{commentId}
 export type Delete3Params = {
   commentId: number;
-};
-
-// GET /api/tracking/nearby-mountain
-export type NearbyMountainCourse = {
-  courseId?: number;
-  name?: string;
-  difficulty?: "EASY" | "NORMAL" | "HARD";
-  distance?: number;
-  duration?: number;
-};
-
-export type NearbyMountainInfo = {
-  mountainId?: number;
-  name?: string;
-  address?: string;
-  altitude?: number;
-  latitude?: number;
-  longitude?: number;
-  imageUrls?: string[];
-};
-
-export type NearbyMountainResponse = {
-  mountain?: NearbyMountainInfo;
-  courses?: NearbyMountainCourse[];
-};
-
-// POST /api/tracking/sessions
-export type StartTrackingSessionRequest = {
-  mountainId: number;
-  courseId?: number;
-  isFreeRecording: boolean;
-};
-
-export type TrackingSessionResponse = {
-  sessionId?: number;
-  userId?: number;
-  mountainId?: number;
-  mountainName?: string;
-  courseId?: number;
-  courseName?: string;
-  isFreeRecording?: boolean;
-  status?: "IN_PROGRESS" | "PAUSED" | "COMPLETED";
-  startedAt?: string;
-  endedAt?: string;
-  pausedAt?: string;
-  pausedSecondsTotal?: number;
-  hikingRecordId?: number;
 };


### PR DESCRIPTION
## Summary

- iOS/Android 전용 shadow 속성(`shadowColor`, `shadowOffset`, `shadowOpacity`, `shadowRadius`, `elevation`)을 `boxShadow`로 전면 교체 (10개 파일)
- 카카오 SDK 초기화 및 푸시 알림 등록 조건을 `isExpoGo` → `__DEV__` 기반으로 전환
- 트래킹 사진 업로드 API 타입 및 엔드포인트 추가, 중복 레거시 타입 제거
- CLAUDE.md에 `boxShadow` 사용 규칙 추가

## Test plan

- [ ] iOS에서 그림자 렌더링 정상 확인
- [ ] Android에서 그림자 렌더링 정상 확인
- [ ] Web에서 그림자 렌더링 정상 확인
- [ ] 프로덕션 빌드에서 카카오 SDK 초기화 정상 확인
- [ ] 프로덕션 빌드에서 푸시 알림 등록 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)