### PR TITLE
feat : 닉네임 중복 체크 API 연동

### DIFF
--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -3,7 +3,9 @@ import { UserIcon } from "@/components/icons/user-icon";
 import { LongButton } from "@/components/long-button";
 import { TextField } from "@/components/text-field";
 import { uploadImage } from "@/features/mypage/hooks/use-upload-image";
+import { useCheckNickname } from "@/features/onboarding/hooks/use-check-nickname";
 import { useOnboardingStore } from "@/features/onboarding/store/onboarding-store";
+import { ApiError } from "@/lib/api";
 import {
   formatBirthDate,
   isAtLeast14YearsOld,
@@ -33,6 +35,7 @@ export function OnboardingScreen() {
   const weightRef = useRef<TextInput>(null);
 
   const setProfile = useOnboardingStore((s) => s.setProfile);
+  const { mutateAsync: checkNickname } = useCheckNickname();
 
   const [step, setStep] = useState(0);
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
@@ -94,7 +97,7 @@ export function OnboardingScreen() {
     }
   }
 
-  function handleNicknameEnd(): void {
+  async function handleNicknameEnd(): Promise<void> {
     const trimmed = nickname.trim();
     if (!trimmed) return;
     if (!/^[가-힣a-zA-Z0-9]+$/.test(trimmed)) {
@@ -105,8 +108,17 @@ export function OnboardingScreen() {
       setNicknameError("2자 이상 입력해 주세요");
       return;
     }
-    setNicknameError(null);
-    advance(1);
+    try {
+      await checkNickname(trimmed);
+      setNicknameError(null);
+      advance(1);
+    } catch (e) {
+      if (e instanceof ApiError && e.statusCode === 409) {
+        setNicknameError("이미 사용 중인 닉네임이에요");
+      } else {
+        setNicknameError("닉네임 확인 중 오류가 발생했어요");
+      }
+    }
   }
 
   function handleGenderSelect(value: Gender): void {

--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -90,8 +90,16 @@ export function OnboardingScreen() {
 
   function handleNicknameChange(text: string): void {
     setNickname(text);
-    if (text.length > 0 && !/^[가-힣a-zA-Z0-9]+$/.test(text)) {
+    if (text.length === 0) {
+      setNicknameError(null);
+      return;
+    }
+    if (/[ㄱ-ㅎㅏ-ㅣ]/.test(text)) {
+      setNicknameError("자음·모음만으로는 사용할 수 없어요");
+    } else if (!/^[가-힣a-zA-Z0-9]+$/.test(text)) {
       setNicknameError("한글, 영문, 숫자만 입력 가능해요");
+    } else if (/^[0-9]+$/.test(text)) {
+      setNicknameError("숫자만으로는 사용할 수 없어요");
     } else {
       setNicknameError(null);
     }
@@ -101,8 +109,16 @@ export function OnboardingScreen() {
     if (isCheckingNickname) return;
     const trimmed = nickname.trim();
     if (!trimmed) return;
+    if (/[ㄱ-ㅎㅏ-ㅣ]/.test(trimmed)) {
+      setNicknameError("자음·모음만으로는 사용할 수 없어요");
+      return;
+    }
     if (!/^[가-힣a-zA-Z0-9]+$/.test(trimmed)) {
       setNicknameError("한글, 영문, 숫자만 입력 가능해요");
+      return;
+    }
+    if (/^[0-9]+$/.test(trimmed)) {
+      setNicknameError("숫자만으로는 사용할 수 없어요");
       return;
     }
     if (trimmed.length < 2) {

--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -35,7 +35,7 @@ export function OnboardingScreen() {
   const weightRef = useRef<TextInput>(null);
 
   const setProfile = useOnboardingStore((s) => s.setProfile);
-  const { mutateAsync: checkNickname } = useCheckNickname();
+  const { mutateAsync: checkNickname, isPending: isCheckingNickname } = useCheckNickname();
 
   const [step, setStep] = useState(0);
   const [profileImageUrl, setProfileImageUrl] = useState<string | null>(null);
@@ -98,6 +98,7 @@ export function OnboardingScreen() {
   }
 
   async function handleNicknameEnd(): Promise<void> {
+    if (isCheckingNickname) return;
     const trimmed = nickname.trim();
     if (!trimmed) return;
     if (!/^[가-힣a-zA-Z0-9]+$/.test(trimmed)) {
@@ -110,9 +111,11 @@ export function OnboardingScreen() {
     }
     try {
       await checkNickname(trimmed);
+      if (nickname.trim() !== trimmed) return;
       setNicknameError(null);
       advance(1);
     } catch (e) {
+      if (nickname.trim() !== trimmed) return;
       if (e instanceof ApiError && e.statusCode === 409) {
         setNicknameError("이미 사용 중인 닉네임이에요");
       } else {

--- a/features/onboarding/hooks/use-check-nickname.ts
+++ b/features/onboarding/hooks/use-check-nickname.ts
@@ -1,0 +1,14 @@
+import { api, ApiError } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useMutation } from "@tanstack/react-query";
+
+export function useCheckNickname() {
+  return useMutation({
+    mutationFn: async (nickname: string): Promise<void> => {
+      await api.get(
+        { path: ENDPOINTS.USERS_NICKNAME, params: { nickname } },
+        { ignoreErrorToast: true },
+      );
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- 닉네임 입력 완료 시 `GET /api/users/nickname`으로 중복 확인
- 409 응답 → "이미 사용 중인 닉네임이에요" 에러 표시
- 기타 오류 → "닉네임 확인 중 오류가 발생했어요" 에러 표시
- 기존 형식 검증(2자 이상, 한글/영문/숫자) 통과 후 API 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)