### PR TITLE
feat: 코스 상세 맵 내 일부 필드 추가 및 코스가 이미지 내 잘 보이도록 수정

### DIFF
--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -6,7 +6,6 @@ import { parseCoursePolyline } from "@/features/tracking/utils/parse-course-poly
 import { formatDuration } from "@/modules/format-duration";
 import { CourseDetailResponse } from "@/types/api.generated";
 import { getCenterCoordinate } from "@/utils/get-center-coordinate";
-import { getZoomForCoords } from "@/utils/get-zoom-for-coords";
 import {
   NaverMapMarkerOverlay,
   NaverMapPathOverlay,
@@ -24,6 +23,29 @@ const DIFFICULTY_LABEL: Record<
   HARD: "어려움",
 };
 
+type Coord = { latitude: number; longitude: number };
+
+// zoom 11 기준: 맵 뷰에 가로 12km, 세로 7km 표시. zoom ±1마다 2배씩 확대/축소.
+const VIEW_WIDTH_KM_AT_ZOOM_11 = 12;
+const VIEW_HEIGHT_KM_AT_ZOOM_11 = 7;
+const KM_PER_LAT_DEG = 111;
+const KM_PER_LNG_DEG = 89; // cos(37°N) × 111
+const TARGET_FILL = 0.60;
+
+function getCourseZoom(coords: Coord[]): number {
+  if (coords.length < 2) return 14;
+  const lats = coords.map((c) => c.latitude);
+  const lngs = coords.map((c) => c.longitude);
+  const latKm = (Math.max(...lats) - Math.min(...lats)) * KM_PER_LAT_DEG;
+  const lngKm = (Math.max(...lngs) - Math.min(...lngs)) * KM_PER_LNG_DEG;
+  const dominantRatio = Math.max(
+    lngKm / VIEW_WIDTH_KM_AT_ZOOM_11,
+    latKm / VIEW_HEIGHT_KM_AT_ZOOM_11,
+  );
+  const zoom = 11 + Math.log2(TARGET_FILL / dominantRatio);
+  return Math.min(Math.max(Math.round(zoom), 6), 18);
+}
+
 type CourseDetailInfoProps = {
   course: CourseDetailResponse;
 };
@@ -33,8 +55,15 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
     () => parseCoursePolyline(course.polyline),
     [course.polyline],
   );
+
+  const lats = courseCoords.map((c) => c.latitude);
+  const lngs = courseCoords.map((c) => c.longitude);
+  console.log({
+    latSpan: Math.max(...lats) - Math.min(...lats),
+    lngSpan: Math.max(...lngs) - Math.min(...lngs),
+  });
   const center = getCenterCoordinate(courseCoords);
-  const zoom = getZoomForCoords(courseCoords, 1.5);
+  const zoom = useMemo(() => getCourseZoom(courseCoords), [courseCoords]);
 
   const statRows = [
     [
@@ -58,9 +87,27 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
       },
     ],
     [
-      { label: "고도", value: "-" },
-      { label: "오르막길", value: "-" },
-      { label: "내리막길", value: "-" },
+      {
+        label: "고도",
+        value:
+          typeof course.maxAltitude === "number"
+            ? `${Math.round(course.maxAltitude)}m`
+            : "-",
+      },
+      {
+        label: "오르막길",
+        value:
+          typeof course.ascent === "number"
+            ? `${Math.round(course.ascent)}m`
+            : "-",
+      },
+      {
+        label: "내리막길",
+        value:
+          typeof course.descent === "number"
+            ? `${Math.round(course.descent)}m`
+            : "-",
+      },
     ],
   ];
 
@@ -110,8 +157,12 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
                 </NaverMapMarkerOverlay>
                 {/* 정상 마커 — 코스 거리의 1/2 지점 */}
                 <NaverMapMarkerOverlay
-                  latitude={courseCoords[Math.floor(courseCoords.length / 2)].latitude}
-                  longitude={courseCoords[Math.floor(courseCoords.length / 2)].longitude}
+                  latitude={
+                    courseCoords[Math.floor(courseCoords.length / 2)].latitude
+                  }
+                  longitude={
+                    courseCoords[Math.floor(courseCoords.length / 2)].longitude
+                  }
                   width={22}
                   height={30}
                   anchor={{ x: 0.3, y: 1 }}

--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -30,7 +30,7 @@ const VIEW_WIDTH_KM_AT_ZOOM_11 = 12;
 const VIEW_HEIGHT_KM_AT_ZOOM_11 = 7;
 const KM_PER_LAT_DEG = 111;
 const KM_PER_LNG_DEG = 89; // cos(37°N) × 111
-const TARGET_FILL = 0.60;
+const TARGET_FILL = 0.6;
 
 function getCourseZoom(coords: Coord[]): number {
   if (coords.length < 2) return 14;
@@ -56,12 +56,6 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
     [course.polyline],
   );
 
-  const lats = courseCoords.map((c) => c.latitude);
-  const lngs = courseCoords.map((c) => c.longitude);
-  console.log({
-    latSpan: Math.max(...lats) - Math.min(...lats),
-    lngSpan: Math.max(...lngs) - Math.min(...lngs),
-  });
   const center = getCenterCoordinate(courseCoords);
   const zoom = useMemo(() => getCourseZoom(courseCoords), [courseCoords]);
 

--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -11,7 +11,6 @@ import {
   NaverMapPathOverlay,
   NaverMapView,
 } from "@mj-studio/react-native-naver-map";
-import { useMemo } from "react";
 import { Pressable, Text, View } from "react-native";
 
 const DIFFICULTY_LABEL: Record<
@@ -51,13 +50,9 @@ type CourseDetailInfoProps = {
 };
 
 export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
-  const courseCoords = useMemo(
-    () => parseCoursePolyline(course.polyline),
-    [course.polyline],
-  );
-
+  const courseCoords = parseCoursePolyline(course.polyline);
   const center = getCenterCoordinate(courseCoords);
-  const zoom = useMemo(() => getCourseZoom(courseCoords), [courseCoords]);
+  const zoom = getCourseZoom(courseCoords);
 
   const statRows = [
     [

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -18,12 +18,15 @@ export const ENDPOINTS = {
   OAUTH_KAKAO_LOGIN: "/api/oauth/kakao/login",
   OAUTH_APPLE_LOGIN: "/api/oauth/apple/login",
   MOUNTAINS_BY_MOUNTAINID_LIKE: (mountainId: number | string) => `/api/mountains/${mountainId}/like`,
+  HIKING_RECORDS_BY_HIKINGRECORDID_DIFFICULTY_FEEDBACK: (hikingRecordId: number | string) => `/api/hiking-records/${hikingRecordId}/difficulty-feedback`,
   FCM_TOKENS: "/api/fcm/tokens",
   COMMUNITY_RECORD_POSTS: "/api/community/record-posts",
   COMMUNITY_POSTS_BY_POSTID_LIKES: (postId: number | string) => `/api/community/posts/${postId}/likes`,
   COMMUNITY_POSTS_BY_POSTID_COMMENTS: (postId: number | string) => `/api/community/posts/${postId}/comments`,
   COMMUNITY_POSTS_BY_POSTID_COMMENTS_REPLIES: (postId: number | string) => `/api/community/posts/${postId}/comments/replies`,
   COMMUNITY_FREE_POSTS: "/api/community/free-posts",
+  COMMUNITY_FREE_POSTS_BY_POSTID_REPORTS: (postId: number | string) => `/api/community/free-posts/${postId}/reports`,
+  COMMUNITY_FREE_POSTS_BY_POSTID_BLOCKS: (postId: number | string) => `/api/community/free-posts/${postId}/blocks`,
   AUTH_TOKEN_REISSUE: "/api/auth/token/reissue",
   AUTH_TEST_LOGIN: "/api/auth/test/login",
   AUTH_LOGOUT: "/api/auth/logout",
@@ -198,6 +201,25 @@ export type OAuthAppleLoginRequest = {
   name?: string;
   deviceType: "IOS" | "ANDROID";
 };
+export type CreateCourseDifficultyFeedbackRequest = {
+  comparison: "SIMILAR" | "EASIER" | "HARDER";
+};
+export type ApiResponseCourseDifficultyFeedbackResponse = {
+  isSuccess?: boolean;
+  code?: string;
+  message?: string;
+  data?: CourseDifficultyFeedbackResponse;
+};
+export type CourseDifficultyFeedbackResponse = {
+  feedbackId?: number;
+  hikingRecordId?: number;
+  mountainId?: number;
+  mountainName?: string;
+  courseId?: number;
+  courseName?: string;
+  guideDifficulty?: "EASY" | "NORMAL" | "HARD";
+  comparison?: "SIMILAR" | "EASIER" | "HARDER";
+};
 export type FcmTokenRegisterRequest = {
   token?: string;
   deviceType: "IOS" | "ANDROID";
@@ -263,6 +285,7 @@ export type CommentResponse = {
   mentionedUser?: AuthorResponse;
   createdAt?: string;
   isDeleted?: boolean;
+  isBlocked?: boolean;
 };
 export type CommentReplyRequest = {
   parentId: number;
@@ -289,6 +312,7 @@ export type FreePostDetailResponse = {
   images?: PostImageResponse[];
   viewCount?: number;
   likeCount?: number;
+  likedByMe?: boolean;
   commentCount?: number;
   createdAt?: string;
 };
@@ -297,6 +321,9 @@ export type PostImageResponse = {
   imageUrl?: string;
   sortOrder?: number;
   main?: boolean;
+};
+export type FreePostReportRequest = {
+  reason: "SPAM" | "ABUSE" | "OBSCENE" | "FALSE_INFO" | "ETC";
 };
 export type ReissueResponse = {
   accessToken?: string;
@@ -643,6 +670,9 @@ export type CourseDetailResponse = {
   duration?: number;
   startName?: string;
   endName?: string;
+  ascent?: number;
+  descent?: number;
+  maxAltitude?: number;
   polyline?: string;
   altitudes?: string;
 };
@@ -784,6 +814,12 @@ export type UnlikeMountainParams = {
   mountainId: number;
 };
 
+// POST /api/hiking-records/{hikingRecordId}/difficulty-feedback
+export type CreateCourseDifficultyFeedbackParams = {
+  hikingRecordId: number;
+};
+export type CreateCourseDifficultyFeedbackBody = CreateCourseDifficultyFeedbackRequest;
+
 // POST /api/fcm/tokens
 export type RegisterBody = FcmTokenRegisterRequest;
 
@@ -834,6 +870,17 @@ export type GetList1Params = {
 
 // POST /api/community/free-posts
 export type Create3Body = FreePostCreateRequest;
+
+// POST /api/community/free-posts/{postId}/reports
+export type ReportParams = {
+  postId: number;
+};
+export type ReportBody = FreePostReportRequest;
+
+// POST /api/community/free-posts/{postId}/blocks
+export type BlockParams = {
+  postId: number;
+};
 
 // POST /api/auth/test/login
 export type LoginBody = LoginRequest;


### PR DESCRIPTION
## Summary
- 코스 맵 줌 레벨 계산 로직을 물리 기반 수학 공식으로 전면 교체 (기존 경험적 분기 로직 제거)
  - zoom 11 기준 가로 12km/세로 7km 표시, zoom ±1마다 2배 확대/축소 원리 적용
  - `latSpan × 111`, `lngSpan × 89(cos 37°N)`로 km 변환 후 지배 비율로 최적 줌 산출
- 코스 상세 통계 그리드에 고도(`maxAltitude`), 오르막길(`ascent`), 내리막길(`descent`) API 필드 연동
- `api.generated.ts`에 새 API 타입 추가 (난이도 피드백, 커뮤니티 신고/차단 등)

