### PR TITLE
fix: 마이페이지 프로필 카드 디자인 수정 및 이메일 표시 추가

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -17,7 +17,6 @@ export default function MyPageScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
-
   const { data: profile } = useProfile();
   const { mutate: logout } = useLogout();
   const { mutate: withdraw } = useWithdraw();
@@ -27,15 +26,20 @@ export default function MyPageScreen() {
       label: "저장한 산 목록",
       onPress: () => router.push("/mypage/saved-mountains"),
     },
-    { label: "내 게시글", onPress: () => {} },
-    { label: "내 반응", onPress: () => {} },
-    { label: "차단 목록", onPress: () => {} },
+    // { label: "내 게시글", onPress: () => {} },
+    // { label: "내 반응", onPress: () => {} },
+    // { label: "차단 목록", onPress: () => {} },
   ];
 
   const serviceItems = [
     { label: "권한 관리", onPress: () => router.push("/mypage/permissions") },
     { label: "이용약관", onPress: () => router.push("/mypage/terms") },
-    { label: "버전 정보", value: `v ${APP_VERSION}`, onPress: () => {}, hideChevron: true },
+    {
+      label: "버전 정보",
+      value: `v ${APP_VERSION}`,
+      onPress: () => {},
+      hideChevron: true,
+    },
   ];
 
   const accountItems = [
@@ -58,15 +62,19 @@ export default function MyPageScreen() {
       onPress: () =>
         Alert.alert("탈퇴하기", "정말 탈퇴하시겠어요?", [
           { text: "취소", style: "cancel" },
-          { text: "탈퇴", style: "destructive", onPress: () => withdraw(undefined, { onSuccess: () => router.replace("/login") }) },
+          {
+            text: "탈퇴",
+            style: "destructive",
+            onPress: () =>
+              withdraw(undefined, {
+                onSuccess: () => router.replace("/login"),
+              }),
+          },
         ]),
     },
   ];
 
   const nickname = profile?.nickname ?? "-";
-  const grade = profile?.hikingLevel
-    ? HIKING_LEVEL_LABEL[profile.hikingLevel]
-    : "-";
 
   return (
     <View className="flex-1 bg-fill-stronger">
@@ -84,21 +92,24 @@ export default function MyPageScreen() {
         {/* 프로필 카드 */}
         <View className="bg-fill-normal">
           <TouchableOpacity
-            className="flex-row items-center justify-between gap-3 self-stretch px-4 py-5"
+            className="flex-row items-center justify-between px-4 py-5"
             activeOpacity={0.6}
             onPress={() => router.push("/mypage/info")}
           >
-            <ProfileAvatar url={profile?.profileUrl} />
-
-            <View className="flex-1 gap-1">
-              <View className="flex-row items-center gap-2">
-                <Text className="text-label-normal typo-body-1-normal-semi-bold">
-                  {nickname}
-                </Text>
-                <View className="rounded bg-secondary-subtle px-2 py-0.5">
-                  <Text className="text-secondary-strong typo-caption-1-semi-bold">
-                    {grade}
+            <View className="flex-row items-center gap-3">
+              <ProfileAvatar url={profile?.profileUrl} size={60} />
+              <View className="gap-[4px]">
+                <View className="flex-row items-center gap-[4px]">
+                  <Text className="text-label-normal typo-heading-1-semi-bold">
+                    {nickname}
                   </Text>
+                  <View className="items-center justify-center rounded bg-secondary-subtle px-[4px] py-0.5">
+                    {profile?.hikingLevel && (
+                      <Text className="text-secondary-strong typo-caption-1-semi-bold">
+                        {HIKING_LEVEL_LABEL[profile.hikingLevel]}
+                      </Text>
+                    )}
+                  </View>
                 </View>
               </View>
             </View>
@@ -110,10 +121,15 @@ export default function MyPageScreen() {
         {/* 내 활동 */}
         <SectionDivider />
         <View className="bg-fill-normal">
-          <MenuRow
-            label="저장한 산 목록"
-            onPress={() => router.push("/mypage/saved-mountains")}
-          />
+          <Text
+            className="text-label-alternative px-4 pb-2 pt-5 typo-body-2-normal-semi-bold"
+            style={{ letterSpacing: -0.14 }}
+          >
+            내 활동
+          </Text>
+          {activityItems.map((item) => (
+            <MenuRow key={item.label} {...item} />
+          ))}
         </View>
 
         {/* 서비스 */}

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -77,7 +77,7 @@ export default function MyPageScreen() {
   const nickname = profile?.nickname ?? "-";
 
   return (
-    <View className="flex-1 bg-fill-stronger">
+    <View className="flex-1 bg-fill-normal">
       {/* 헤더 */}
       <View
         className="flex-row items-center bg-fill-normal"
@@ -111,6 +111,11 @@ export default function MyPageScreen() {
                     )}
                   </View>
                 </View>
+                {profile?.email && (
+                  <Text className="text-label-subtler typo-body-2-normal-regular">
+                    {profile.email}
+                  </Text>
+                )}
               </View>
             </View>
 
@@ -122,7 +127,7 @@ export default function MyPageScreen() {
         <SectionDivider />
         <View className="bg-fill-normal">
           <Text
-            className="text-label-alternative px-4 pb-2 pt-5 typo-body-2-normal-semi-bold"
+            className="px-4 pb-2 pt-5 text-label-subtler typo-body-2-normal-semi-bold"
             style={{ letterSpacing: -0.14 }}
           >
             내 활동
@@ -136,7 +141,7 @@ export default function MyPageScreen() {
         <SectionDivider />
         <View className="bg-fill-normal">
           <Text
-            className="text-label-alternative px-4 pb-2 pt-5 typo-body-2-normal-semi-bold"
+            className="px-4 pb-2 pt-5 text-label-subtler typo-body-2-normal-semi-bold"
             style={{ letterSpacing: -0.14 }}
           >
             서비스

--- a/features/mypage/components/menu-row.tsx
+++ b/features/mypage/components/menu-row.tsx
@@ -1,5 +1,5 @@
-import { Text, TouchableOpacity, View } from 'react-native';
-import { MenuChevronIcon } from './menu-chevron-icon';
+import { Text, TouchableOpacity, View } from "react-native";
+import { MenuChevronIcon } from "./menu-chevron-icon";
 
 type Props = {
   label: string;
@@ -19,7 +19,7 @@ export function MenuRow({ label, value, onPress, danger, hideChevron }: Props) {
     >
       <Text
         className={`typo-body-1-normal-medium ${
-          danger ? 'text-status-negative-normal' : 'text-label-normal'
+          danger ? "text-status-negative-normal" : "text-label-normal"
         }`}
         style={{ letterSpacing: -0.16 }}
       >
@@ -27,11 +27,13 @@ export function MenuRow({ label, value, onPress, danger, hideChevron }: Props) {
       </Text>
       <View className="flex-row items-center gap-1">
         {value && (
-          <Text className="typo-body-1-normal-regular text-label-alternative">
+          <Text className="text-label-alternative typo-body-1-normal-semi-bold">
             {value}
           </Text>
         )}
-        {!hideChevron && <MenuChevronIcon color={danger ? '#ff5249' : '#73798C'} />}
+        {!hideChevron && (
+          <MenuChevronIcon color={danger ? "#ff5249" : "#73798C"} />
+        )}
       </View>
     </TouchableOpacity>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -2466,7 +2466,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -2533,7 +2532,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -2549,8 +2547,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -3001,7 +2998,6 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -4128,7 +4124,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
       "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -4150,7 +4145,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/app/-/app-24.0.0.tgz",
       "integrity": "sha512-rLWNd8/4FjKYV7PeDR9uiT5vwYWdJ7dJ1yiIIaZ/eL+Y56Ij2iXbqRCUu4zWkvu/ZrJfaGOyT12Vhy1SLy0NMg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "firebase": "12.10.0"
       },
@@ -16128,7 +16122,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -18,12 +18,15 @@ export const ENDPOINTS = {
   OAUTH_KAKAO_LOGIN: "/api/oauth/kakao/login",
   OAUTH_APPLE_LOGIN: "/api/oauth/apple/login",
   MOUNTAINS_BY_MOUNTAINID_LIKE: (mountainId: number | string) => `/api/mountains/${mountainId}/like`,
+  HIKING_RECORDS_BY_HIKINGRECORDID_DIFFICULTY_FEEDBACK: (hikingRecordId: number | string) => `/api/hiking-records/${hikingRecordId}/difficulty-feedback`,
   FCM_TOKENS: "/api/fcm/tokens",
   COMMUNITY_RECORD_POSTS: "/api/community/record-posts",
   COMMUNITY_POSTS_BY_POSTID_LIKES: (postId: number | string) => `/api/community/posts/${postId}/likes`,
   COMMUNITY_POSTS_BY_POSTID_COMMENTS: (postId: number | string) => `/api/community/posts/${postId}/comments`,
   COMMUNITY_POSTS_BY_POSTID_COMMENTS_REPLIES: (postId: number | string) => `/api/community/posts/${postId}/comments/replies`,
   COMMUNITY_FREE_POSTS: "/api/community/free-posts",
+  COMMUNITY_FREE_POSTS_BY_POSTID_REPORTS: (postId: number | string) => `/api/community/free-posts/${postId}/reports`,
+  COMMUNITY_FREE_POSTS_BY_POSTID_BLOCKS: (postId: number | string) => `/api/community/free-posts/${postId}/blocks`,
   AUTH_TOKEN_REISSUE: "/api/auth/token/reissue",
   AUTH_TEST_LOGIN: "/api/auth/test/login",
   AUTH_LOGOUT: "/api/auth/logout",
@@ -198,6 +201,25 @@ export type OAuthAppleLoginRequest = {
   name?: string;
   deviceType: "IOS" | "ANDROID";
 };
+export type CreateCourseDifficultyFeedbackRequest = {
+  comparison: "SIMILAR" | "EASIER" | "HARDER";
+};
+export type ApiResponseCourseDifficultyFeedbackResponse = {
+  isSuccess?: boolean;
+  code?: string;
+  message?: string;
+  data?: CourseDifficultyFeedbackResponse;
+};
+export type CourseDifficultyFeedbackResponse = {
+  feedbackId?: number;
+  hikingRecordId?: number;
+  mountainId?: number;
+  mountainName?: string;
+  courseId?: number;
+  courseName?: string;
+  guideDifficulty?: "EASY" | "NORMAL" | "HARD";
+  comparison?: "SIMILAR" | "EASIER" | "HARDER";
+};
 export type FcmTokenRegisterRequest = {
   token?: string;
   deviceType: "IOS" | "ANDROID";
@@ -263,6 +285,7 @@ export type CommentResponse = {
   mentionedUser?: AuthorResponse;
   createdAt?: string;
   isDeleted?: boolean;
+  isBlocked?: boolean;
 };
 export type CommentReplyRequest = {
   parentId: number;
@@ -289,6 +312,7 @@ export type FreePostDetailResponse = {
   images?: PostImageResponse[];
   viewCount?: number;
   likeCount?: number;
+  likedByMe?: boolean;
   commentCount?: number;
   createdAt?: string;
 };
@@ -297,6 +321,9 @@ export type PostImageResponse = {
   imageUrl?: string;
   sortOrder?: number;
   main?: boolean;
+};
+export type FreePostReportRequest = {
+  reason: "SPAM" | "ABUSE" | "OBSCENE" | "FALSE_INFO" | "ETC";
 };
 export type ReissueResponse = {
   accessToken?: string;
@@ -349,6 +376,7 @@ export type GetUserProfileResponse = {
   weight?: number;
   exerciseType?: "GYM" | "HOME_TRAINING" | "PILATES_YOGA" | "WALKING" | "RUNNING" | "HIKING" | "SPORTS" | "CROSSFIT" | "SWIMMING" | "NONE";
   birthDate?: string;
+  email?: string;
 };
 export type ApiResponseGetNotificationSettingResponse = {
   isSuccess?: boolean;
@@ -643,6 +671,9 @@ export type CourseDetailResponse = {
   duration?: number;
   startName?: string;
   endName?: string;
+  ascent?: number;
+  descent?: number;
+  maxAltitude?: number;
   polyline?: string;
   altitudes?: string;
 };
@@ -784,6 +815,12 @@ export type UnlikeMountainParams = {
   mountainId: number;
 };
 
+// POST /api/hiking-records/{hikingRecordId}/difficulty-feedback
+export type CreateCourseDifficultyFeedbackParams = {
+  hikingRecordId: number;
+};
+export type CreateCourseDifficultyFeedbackBody = CreateCourseDifficultyFeedbackRequest;
+
 // POST /api/fcm/tokens
 export type RegisterBody = FcmTokenRegisterRequest;
 
@@ -834,6 +871,17 @@ export type GetList1Params = {
 
 // POST /api/community/free-posts
 export type Create3Body = FreePostCreateRequest;
+
+// POST /api/community/free-posts/{postId}/reports
+export type ReportParams = {
+  postId: number;
+};
+export type ReportBody = FreePostReportRequest;
+
+// POST /api/community/free-posts/{postId}/blocks
+export type BlockParams = {
+  postId: number;
+};
 
 // POST /api/auth/test/login
 export type LoginBody = LoginRequest;


### PR DESCRIPTION
## Summary
- 프로필 카드 디자인 Figma 기준으로 재퍼블리싱
  - 아바타 크기 60px, 닉네임 폰트 `typo-heading-1-semi-bold` (18px)
  - 닉네임·뱃지 간격 4px, 뱃지 패딩 `px-[4px]`
- `profile.email` 필드 연동 — 닉네임 아래 이메일 표시 추가

<img width="353" height="733" alt="image" src="https://github.com/user-attachments/assets/41ad50d8-d10b-4862-8da8-6aef0eb2d253" />


## Test plan
- [ ] 프로필 카드에 아바타(60px), 닉네임, 등급 뱃지 정상 표시 확인
- [ ] 이메일 있을 때 닉네임 아래 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)