### PR TITLE
fix: 세모피드 imageUrl 큰따옴표 제거 처리

### DIFF
--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -45,7 +45,7 @@ export const FeedCell = memo(function FeedCell({
         <View style={{ flex: 1 }}>
           {imageUrl && (
             <Image
-              source={{ uri: imageUrl }}
+              source={{ uri: imageUrl.replace(/"/g, "") }}
               className="absolute inset-0 h-full w-full"
               resizeMode="cover"
             />

--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -45,6 +45,7 @@ export const FeedCell = memo(function FeedCell({
         <View style={{ flex: 1 }}>
           {imageUrl && (
             <Image
+              // TODO: 백엔드에서 URL에 큰따옴표 포함 저장 현상 수정되면 replace 로직 제거
               source={{ uri: imageUrl.replace(/"/g, "") }}
               className="absolute inset-0 h-full w-full"
               resizeMode="cover"

--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -33,7 +33,7 @@ export const FeedCell = memo(function FeedCell({
   return (
     <Animated.View
       entering={FadeInDown.duration(300).delay(200)}
-      className="absolute overflow-hidden rounded-xl bg-[#1a1a1a]"
+      className="absolute overflow-hidden rounded-2xl bg-transparent"
       style={{
         left: col * CELL_W + CELL_GAP / 2,
         top: row * CELL_H + CELL_GAP / 2 - (col % 2 !== 0 ? 60 : 0),


### PR DESCRIPTION
## Summary
- `FeedCell` 컴포넌트에서 `imageUrl`에 포함된 큰따옴표(`"`)를 제거하는 로직 추가

## Test plan
- [ ] 세모피드 이미지가 정상적으로 렌더링되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)