### PR TITLE
fix: 탈퇴하기 화살표 색상을 label-subtler로 변경

### DIFF
--- a/features/mypage/components/menu-row.tsx
+++ b/features/mypage/components/menu-row.tsx
@@ -32,7 +32,7 @@ export function MenuRow({ label, value, onPress, danger, hideChevron }: Props) {
           </Text>
         )}
         {!hideChevron && (
-          <MenuChevronIcon color={danger ? "#ff5249" : "#73798C"} />
+          <MenuChevronIcon color="#73798C" />
         )}
       </View>
     </TouchableOpacity>


### PR DESCRIPTION
## 개요
마이페이지 탈퇴하기 항목의 화살표 색상을 수정했습니다.

## 변경 사항
- 탈퇴하기 행의 화살표(chevron) 색상: 빨간색 → `Color/Label/Subtler` (`#73798C`)
- 탈퇴하기 텍스트 색상(빨간색)은 유지