### PR TITLE
fix: 홈 지도 마커 관련 디자인/로직 수정

### DIFF
--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -150,16 +150,20 @@ export default function BottomSheet({
     >
       {activeTab === '내 기록' && (
         <View className="w-full gap-y-4">
-          {Array.from({ length: Math.ceil(cards.length / 2) }).map((_, rowIdx) => (
-            <View key={rowIdx} className="flex-row gap-x-[9px]">
-              {cards.slice(rowIdx * 2, rowIdx * 2 + 2).map((card) => (
-                <MountainCard key={card.id} card={card} onPress={() => {
-                  onCardSelect?.(card.id);
-                  setSelectedCard(card);
-                }} />
-              ))}
-            </View>
-          ))}
+          {Array.from({ length: Math.ceil(cards.length / 2) }).map((_, rowIdx) => {
+            const rowCards = cards.slice(rowIdx * 2, rowIdx * 2 + 2);
+            return (
+              <View key={rowIdx} className="flex-row gap-x-[9px]">
+                {rowCards.map((card) => (
+                  <MountainCard key={card.id} card={card} onPress={() => {
+                    onCardSelect?.(card.id);
+                    setSelectedCard(card);
+                  }} />
+                ))}
+                {rowCards.length === 1 && <View className="flex-1" />}
+              </View>
+            );
+          })}
         </View>
       )}
 

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -4,6 +4,8 @@ import Svg, { ClipPath, Defs, G, Image as SvgImage, Path } from 'react-native-sv
 import { MountainIcon } from '@/components/icons/mountain-icon';
 import { MountainMarkerTextBox } from '@/components/map-markers/mountain-marker-textbox';
 
+const FALLBACK_IMAGE = require('@/assets/photo-thumb-1.jpg');
+
 type Props = {
   name: string;
   visitCount: number;
@@ -45,18 +47,14 @@ export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864
               />
 
               <G clipPath={`url(#${clipIdInner})`}>
-                {imageUri ? (
-                  <SvgImage
-                    href={{ uri: imageUri }}
-                    x={0}
-                    y={0}
-                    width={32}
-                    height={29}
-                    preserveAspectRatio="xMidYMid slice"
-                  />
-                ) : (
-                  <Path d="M0 0H32V29H0Z" fill="#FFFFFF" />
-                )}
+                <SvgImage
+                  href={imageUri ? { uri: imageUri } : FALLBACK_IMAGE}
+                  x={0}
+                  y={0}
+                  width={32}
+                  height={29}
+                  preserveAspectRatio="xMidYMid slice"
+                />
               </G>
 
             </Svg>

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -1,4 +1,5 @@
 import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
 import { Image, ScrollView, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 import { HikingStartBanner } from '@/components/icons/hiking-start-banner';
 import { InfoIcon } from '@/components/icons/info-icon';

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -1,5 +1,4 @@
 import { LinearGradient } from 'expo-linear-gradient';
-import { useRouter } from 'expo-router';
 import { Image, ScrollView, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 import { HikingStartBanner } from '@/components/icons/hiking-start-banner';
 import { InfoIcon } from '@/components/icons/info-icon';
@@ -19,7 +18,6 @@ type Props = {
 };
 
 export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled = false, lat = 0, lng = 0 }: Props) {
-  const router = useRouter();
   const { width: screenWidth } = useWindowDimensions();
   const bannerWidth = screenWidth - 32;
   const bannerHeight = Math.round(90 * bannerWidth / 343);
@@ -30,12 +28,9 @@ export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled
     <View className="flex-1 w-full">
       {/* 섹션 1: 첫 등산 CTA */}
       <View style={{ marginHorizontal: 16, marginTop: 12 }}>
-        <TouchableOpacity
-          activeOpacity={0.85}
-          onPress={() => router.push('/(tabs)/tracking' as never)}
-        >
+        <View>
           <HikingStartBanner width={bannerWidth} height={bannerHeight} />
-        </TouchableOpacity>
+        </View>
       </View>
 
       {/* 섹션 2: 레벨 맞는 산 추천 */}

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -15,6 +15,7 @@ import {
 import {
   VISITED_MARKER_OVERLAY_HEIGHT,
   VISITED_MARKER_OVERLAY_WIDTH,
+  VisitedMarker,
 } from "@/components/map-markers/visited-marker";
 import NoRecordBottomSheet from "@/components/no-record-bottom-sheet";
 import { useMountains } from "@/features/mountains/hooks/use-mountains";
@@ -115,6 +116,10 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
       ),
     }));
 
+    const myMountainImageMap = Object.fromEntries(
+      myMountains.map((m) => [m.mountainId, m.imageUrl])
+    );
+
     const visitedCards = myMountains.map((m) => ({
       id: String(m.mountainId),
       name: m.mountainName ?? "",
@@ -147,7 +152,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
           }}
         >
           {hasRecords
-            ? mapData?.mountains?.map((mountain) => (
+            ? mapData?.mountains?.filter((m) => m.visited).map((mountain) => (
                 <NaverMapMarkerOverlay
                   key={`${mountain.id}-${activeTab}-${selectedMountainId}`}
                   latitude={mountain.latitude}
@@ -169,44 +174,29 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
                 >
                   <View
                     collapsable={false}
-                    // style={{
-                    //   width: mountain.visited
-                    //     ? VISITED_MARKER_OVERLAY_WIDTH
-                    //     : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
-                    //   height: mountain.visited
-                    //     ? VISITED_MARKER_OVERLAY_HEIGHT
-                    //     : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
-                    // }}
                     style={{
-                      width: UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
-                      height: UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
+                      width: mountain.visited
+                        ? VISITED_MARKER_OVERLAY_WIDTH
+                        : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
+                      height: mountain.visited
+                        ? VISITED_MARKER_OVERLAY_HEIGHT
+                        : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
                     }}
                   >
-                    <UnvisitedMountainPillMarker
-                      name={mountain.name ?? ""}
-                      variant={"visited"}
-                      selected={mountain?.id === selectedMountainId}
-                    />
-                    {/* {mountain.visited ? (
-                         <VisitedMarker
-                           name={mountain.name}
-                           visitCount={mountain.visitCount}
-                           imageUri={mountain.imageUrl}
-                           selected={mountain.id === selectedMountainId}
-                         />
-                       ) : (
-                         <UnvisitedMountainPillMarker
-                           name={mountain.name}
-                           variant={
-                             mountain.visited
-                               ? "visited"
-                               : activeTab === "큐레이션"
-                                 ? "curation"
-                                 : "trending"
-                           }
-                           selected={mountain.id === selectedMountainId}
-                         />
-                       )} */}
+                    {mountain.visited ? (
+                      <VisitedMarker
+                        name={mountain.name}
+                        visitCount={mountain.visitCount}
+                        imageUri={myMountainImageMap[mountain.id] ?? mountain.imageUrl}
+                        selected={mountain.id === selectedMountainId}
+                      />
+                    ) : (
+                      <UnvisitedMountainPillMarker
+                        name={mountain.name ?? ""}
+                        variant="trending"
+                        selected={mountain.id === selectedMountainId}
+                      />
+                    )}
                   </View>
                 </NaverMapMarkerOverlay>
               ))

--- a/features/home/components/map-tab-toggle.tsx
+++ b/features/home/components/map-tab-toggle.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { Pressable, Text, View } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from "react-native-reanimated";
 
 export type MapTab = "map" | "feed";
 
@@ -7,23 +9,53 @@ type MapTabToggleProps = {
   onChange: (tab: MapTab) => void;
 };
 
+const TOGGLE_WIDTH = 171;
+const PADDING = 2;
+const INDICATOR_WIDTH = (TOGGLE_WIDTH - PADDING * 2) / 2;
+
 export function MapTabToggle({ value, onChange }: MapTabToggleProps): React.JSX.Element {
+  const translateX = useSharedValue(value === "feed" ? INDICATOR_WIDTH : 0);
+
+  useEffect(() => {
+    translateX.value = withTiming(value === "feed" ? INDICATOR_WIDTH : 0, { duration: 200 });
+  }, [value]);
+
+  const indicatorStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: translateX.value }],
+  }));
+
   return (
-    <View className="h-[39px] w-[171px] flex-row rounded-full bg-[#2F323A] p-0.5">
-      {(["map", "feed"] as const).map((tab) => (
-        <Pressable
-          key={tab}
-          className={`flex-1 items-center justify-center rounded-full ${value === tab ? "bg-fill-normal" : ""}`}
-          onPress={() => onChange(tab)}
-        >
-          <Text
-            className={value === tab ? "text-label-normal" : "text-line-subtle"}
-            style={{ fontFamily: "Pretendard", fontSize: 15, fontWeight: "600" }}
+    <View className="h-[39px] w-[171px] rounded-full bg-[#2F323A]" style={{ padding: PADDING }}>
+      <Animated.View
+        style={[
+          {
+            position: "absolute",
+            top: PADDING,
+            left: PADDING,
+            width: INDICATOR_WIDTH,
+            bottom: PADDING,
+            borderRadius: 999,
+            backgroundColor: "#FFFFFF",
+          },
+          indicatorStyle,
+        ]}
+      />
+      <View className="flex-1 flex-row">
+        {(["map", "feed"] as const).map((tab) => (
+          <Pressable
+            key={tab}
+            className="flex-1 items-center justify-center"
+            onPress={() => onChange(tab)}
           >
-            {tab === "map" ? "정복 지도" : "세모피드"}
-          </Text>
-        </Pressable>
-      ))}
+            <Text
+              className={value === tab ? "text-label-normal" : "text-line-subtle"}
+              style={{ fontFamily: "Pretendard", fontSize: 15, fontWeight: "600" }}
+            >
+              {tab === "map" ? "정복 지도" : "세모피드"}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
     </View>
   );
 }

--- a/features/mountains/hooks/use-mountains.ts
+++ b/features/mountains/hooks/use-mountains.ts
@@ -20,7 +20,7 @@ export type GetMountainsParams = {
 
 async function getMountains({
   page = 0,
-  size = 10,
+  size,
   sort = "name,ASC",
 }: GetMountainsParams = {}): Promise<PageResponseMountainListResponse> {
   const res = await api.get<PageResponseMountainListResponse>({

--- a/features/mountains/hooks/use-mountains.ts
+++ b/features/mountains/hooks/use-mountains.ts
@@ -25,7 +25,7 @@ async function getMountains({
 }: GetMountainsParams = {}): Promise<PageResponseMountainListResponse> {
   const res = await api.get<PageResponseMountainListResponse>({
     path: ENDPOINTS.MOUNTAINS,
-    params: { page, size, sort },
+    params: { page, ...(size !== undefined && { size }), sort },
   });
   return res.data;
 }


### PR DESCRIPTION
## Summary
- 홈 지도 방문한 산 마커를 `VisitedMarker` 디자인으로 교체 (삼각형 사진 + 방문 횟수 pill)
- 기록 있는 유저: 방문한 산만 마커 표시, 미방문 산 마커 제거
- 첫 등산 배너 클릭 시 트래킹 탭 이동 비활성화
- `useMountains` size 기본값(10) 제거 → 백엔드 기본값 사용

## Test plan
- [ ] 기록 있는 유저 - 방문한 산에만 `VisitedMarker` 표시
- [ ] 기록 없는 유저 - 전체 산 목록 마커 표시
- [ ] 첫 등산 배너 클릭 시 반응 없음