### PR TITLE
fix: 저장한 산 목록 주소 텍스트 북마크 버튼 겹침 수정

### DIFF
--- a/app/mypage/saved-mountains.tsx
+++ b/app/mypage/saved-mountains.tsx
@@ -30,11 +30,11 @@ function SavedMountainItem({ mountain }: { mountain: LikedMountainResponse }) {
       {/* 정보 */}
       <View style={{ flex: 1, gap: 6 }}>
         <View className="flex-row items-end" style={{ gap: 8 }}>
-          <Text className="typo-headline-1-semi-bold text-label-normal">
+          <Text className="typo-headline-1-semi-bold text-label-normal shrink-0">
             {mountain.name}
           </Text>
           <Text
-            className="typo-body-3-medium text-label-subtler"
+            className="typo-body-3-medium text-label-subtler shrink"
             style={{ paddingBottom: 2 }}
             numberOfLines={1}
           >


### PR DESCRIPTION
## 개요
저장한 산 목록에서 주소 텍스트가 길 경우 북마크 버튼과 겹치는 UI 문제를 수정했습니다.

## 변경 사항
- 산 이름: `shrink-0` 적용 — 공간이 부족해도 줄어들지 않음
- 주소: `shrink` 적용 — 공간 부족 시 말줄임(`...`) 처리, 북마크 버튼 영역 침범 안 함