### PR TITLE
fix: exhibition QA 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,6 @@ import {
   FEED_SLIDE_UP_DISTANCE,
   HOME_TAB_TRANSITION_DURATION,
 } from "@/features/home/constants";
-import { setStatusBarStyle } from "expo-status-bar";
 import { useRef, useState } from "react";
 import { View } from "react-native";
 import Animated, {
@@ -59,7 +58,6 @@ export default function HomeScreen() {
         easing: Easing.bezier(0.45, 0.05, 0.55, 0.95),
       });
       setTabBarVariant("dark");
-      setStatusBarStyle("light");
     } else {
       mapViewRef.current?.expandSheet();
       tabProgress.value = withTiming(0, {
@@ -67,7 +65,6 @@ export default function HomeScreen() {
         easing: Easing.in(Easing.sin),
       });
       setTabBarVariant("light");
-      setStatusBarStyle("dark");
     }
   }
 

--- a/features/community/components/comment-input-bar.tsx
+++ b/features/community/components/comment-input-bar.tsx
@@ -2,7 +2,7 @@ import { CloseSmallIcon } from "@/components/icons/close-small-icon";
 import { PaperPlaneIcon } from "@/components/icons/paper-plane-icon";
 import { useCreateComment } from "@/features/community/hooks/use-create-comment";
 import { useCreateReply } from "@/features/community/hooks/use-create-reply";
-import { useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -18,13 +18,21 @@ type CommentInputBarProps = {
   onReplyCancel: () => void;
 };
 
-export function CommentInputBar({
+export type CommentInputBarRef = {
+  focus: () => void;
+};
+
+export const CommentInputBar = forwardRef<CommentInputBarRef, CommentInputBarProps>(function CommentInputBar({
   postId,
   replyTarget,
   onReplyCancel,
-}: CommentInputBarProps) {
+}: CommentInputBarProps, ref) {
   const insets = useSafeAreaInsets();
   const inputRef = useRef<TextInput>(null);
+
+  useImperativeHandle(ref, () => ({
+    focus: () => inputRef.current?.focus(),
+  }));
   const [text, setText] = useState("");
 
   useEffect(() => {
@@ -89,4 +97,4 @@ export function CommentInputBar({
       </View>
     </View>
   );
-}
+});

--- a/features/community/components/comment-item.tsx
+++ b/features/community/components/comment-item.tsx
@@ -17,7 +17,11 @@ type ReplyItemProps = {
   postId: number;
   parentCommentId: number;
   currentUserNickname?: string;
-  onReplyPress: (commentId: number, authorId: number, authorName: string) => void;
+  onReplyPress: (
+    commentId: number,
+    authorId: number,
+    authorName: string,
+  ) => void;
 };
 
 function ReplyItem({
@@ -33,7 +37,7 @@ function ReplyItem({
 
   return (
     <View className="flex-row gap-2 py-3 pl-[38px]">
-      <PostAvatar size="sm" />
+      <PostAvatar size="sm" imageUrl={reply.author?.profileUrl} />
       <View className="flex-1 gap-1">
         <View className="flex-row flex-wrap items-center gap-1">
           <Text className="text-label-normal typo-caption-1-semi-bold">
@@ -50,13 +54,20 @@ function ReplyItem({
           <Pressable
             hitSlop={8}
             onPress={() =>
-              onReplyPress(parentCommentId, reply.author?.id ?? 0, reply.author?.nickname ?? "")
+              onReplyPress(
+                parentCommentId,
+                reply.author?.id ?? 0,
+                reply.author?.nickname ?? "",
+              )
             }
           >
             <Text className="text-neutral-500 typo-label-small">답글 달기</Text>
           </Pressable>
           {isAuthor && (
-            <Pressable hitSlop={8} onPress={() => confirmDelete(() => deleteComment(reply.id!))}>
+            <Pressable
+              hitSlop={8}
+              onPress={() => confirmDelete(() => deleteComment(reply.id!))}
+            >
               <Text className="text-neutral-500 typo-label-small">삭제</Text>
             </Pressable>
           )}
@@ -70,7 +81,11 @@ type CommentItemProps = {
   comment: CommentResponse;
   postId: number;
   currentUserNickname?: string;
-  onReplyPress: (commentId: number, authorId: number, authorName: string) => void;
+  onReplyPress: (
+    commentId: number,
+    authorId: number,
+    authorName: string,
+  ) => void;
 };
 
 export function CommentItem({
@@ -87,7 +102,7 @@ export function CommentItem({
   return (
     <View>
       <View className="flex-row gap-2 py-3">
-        <PostAvatar size="md" />
+        <PostAvatar size="md" imageUrl={comment.author?.profileUrl} />
         <View className="flex-1 gap-1">
           <View className="flex-row flex-wrap items-center gap-1">
             <Text className="text-label-normal typo-caption-1-semi-bold">
@@ -104,7 +119,11 @@ export function CommentItem({
             <Pressable
               hitSlop={8}
               onPress={() =>
-                onReplyPress(comment.id!, comment.author?.id ?? 0, comment.author?.nickname ?? "")
+                onReplyPress(
+                  comment.id!,
+                  comment.author?.id ?? 0,
+                  comment.author?.nickname ?? "",
+                )
               }
             >
               <Text className="text-neutral-500 typo-label-small">
@@ -112,7 +131,10 @@ export function CommentItem({
               </Text>
             </Pressable>
             {isAuthor && (
-              <Pressable hitSlop={8} onPress={() => confirmDelete(() => deleteComment(comment.id!))}>
+              <Pressable
+                hitSlop={8}
+                onPress={() => confirmDelete(() => deleteComment(comment.id!))}
+              >
                 <Text className="text-neutral-500 typo-label-small">삭제</Text>
               </Pressable>
             )}

--- a/features/community/components/free-board-detail-screen.tsx
+++ b/features/community/components/free-board-detail-screen.tsx
@@ -2,10 +2,10 @@ import { useDeletePost } from "@/features/community/hooks/use-delete-post";
 import { useFreePostDetail } from "@/features/community/hooks/use-free-post-detail";
 import { useProfile } from "@/features/mypage/hooks/use-profile";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { KeyboardAvoidingView, Platform, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { CommentInputBar } from "./comment-input-bar";
+import { CommentInputBar, CommentInputBarRef } from "./comment-input-bar";
 import { CommentList } from "./comment-list";
 import { PostBody } from "./post-body";
 import { PostDetailHeader } from "./post-detail-header";
@@ -24,6 +24,7 @@ export function FreeBoardDetailScreen({ postId }: FreeBoardDetailScreenProps) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
+  const inputBarRef = useRef<CommentInputBarRef>(null);
 
   const { data: post } = useFreePostDetail(postId);
   const { data: profile } = useProfile();
@@ -54,6 +55,7 @@ export function FreeBoardDetailScreen({ postId }: FreeBoardDetailScreenProps) {
               post={post}
               currentUserNickname={profile?.nickname}
               onDelete={handleDeletePost}
+              onCommentPress={() => inputBarRef.current?.focus()}
             />
           )}
           <View className="h-[6px] bg-fill-strong" />
@@ -64,6 +66,7 @@ export function FreeBoardDetailScreen({ postId }: FreeBoardDetailScreenProps) {
           />
         </ScrollView>
         <CommentInputBar
+          ref={inputBarRef}
           postId={postId}
           replyTarget={replyTarget}
           onReplyCancel={() => setReplyTarget(null)}

--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -2,14 +2,13 @@ import { PlusIcon } from "@/components/icons/plus-icon";
 import { useFreePosts } from "@/features/community/hooks/use-free-posts";
 import { useRouter } from "expo-router";
 import { LoadingSpinner } from "@/components/loading-spinner";
-import { FlatList, Pressable, View } from "react-native";
+import { FlatList, Pressable, RefreshControl, View } from "react-native";
 import { PostItem } from "./post-item";
 
 export function FreeBoardScreen() {
   const router = useRouter();
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, refetch, isRefetching } =
     useFreePosts();
-
   const posts = data?.pages.flatMap((page) => page.content ?? []) ?? [];
 
   return (
@@ -22,6 +21,9 @@ export function FreeBoardScreen() {
           if (hasNextPage && !isFetchingNextPage) fetchNextPage();
         }}
         onEndReachedThreshold={0.5}
+        refreshControl={
+          <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
+        }
         ListFooterComponent={
           isFetchingNextPage ? (
             <View className="items-center py-4">

--- a/features/community/components/post-avatar.tsx
+++ b/features/community/components/post-avatar.tsx
@@ -1,8 +1,12 @@
 import { UserIcon } from "@/components/icons/user-icon";
-import React from "react";
-import { View } from "react-native";
+import { Image, View } from "react-native";
 
 type AvatarSize = "sm" | "md" | "lg";
+
+type PostAvatarProps = {
+  size?: AvatarSize;
+  imageUrl?: string;
+};
 
 const SIZE_MAP: Record<AvatarSize, { container: number; icon: number }> = {
   sm: { container: 24, icon: 17 },
@@ -10,14 +14,21 @@ const SIZE_MAP: Record<AvatarSize, { container: number; icon: number }> = {
   lg: { container: 40, icon: 28 },
 };
 
-export function PostAvatar({ size = "md" }: { size?: AvatarSize }) {
+export function PostAvatar({ size = "md", imageUrl }: PostAvatarProps) {
   const { container, icon } = SIZE_MAP[size];
   return (
     <View
-      className="rounded-full bg-fill-strongest items-center justify-center"
+      className="items-center justify-center overflow-hidden rounded-full bg-fill-strongest"
       style={{ width: container, height: container }}
     >
-      <UserIcon size={icon} color="#A4ABC0" />
+      {imageUrl ? (
+        <Image
+          source={{ uri: imageUrl }}
+          style={{ width: container, height: container }}
+        />
+      ) : (
+        <UserIcon size={icon} color="#A4ABC0" />
+      )}
     </View>
   );
 }

--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -1,11 +1,18 @@
 import { ChatIcon } from "@/components/icons/chat-icon";
 import { DotsThreeIcon } from "@/components/icons/dots-three-icon";
-import { HeartFilledIcon, HeartOutlineIcon } from "@/components/icons/heart-icon";
+import {
+  HeartFilledIcon,
+  HeartOutlineIcon,
+} from "@/components/icons/heart-icon";
 import { SirenIcon } from "@/components/icons/siren-icon";
 import { TrashIcon } from "@/components/icons/trash-icon";
 import { useTogglePostLike } from "@/features/community/hooks/use-post-like";
+import { useReportPost } from "@/features/community/hooks/use-report-post";
 import { formatDate } from "@/lib/utils";
-import { FreePostDetailResponse } from "@/types/api.generated";
+import {
+  FreePostDetailResponse,
+  FreePostReportRequest,
+} from "@/types/api.generated";
 import { useRef, useState } from "react";
 import {
   Alert,
@@ -22,18 +29,30 @@ import { PostAvatar } from "./post-avatar";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 
+const REASON_MAP: { label: string; value: FreePostReportRequest["reason"] }[] =
+  [
+    { label: "스팸", value: "SPAM" },
+    { label: "욕설/혐오", value: "ABUSE" },
+    { label: "음란/부적절", value: "OBSCENE" },
+    { label: "허위정보", value: "FALSE_INFO" },
+    { label: "기타", value: "ETC" },
+  ];
+
 type PostBodyProps = {
   post: FreePostDetailResponse;
   currentUserNickname?: string;
   onDelete?: () => void;
+  onCommentPress?: () => void;
 };
 
 export function PostBody({
   post,
   currentUserNickname,
   onDelete,
+  onCommentPress,
 }: PostBodyProps) {
   const { mutate: toggleLike } = useTogglePostLike(post.id!);
+  const { mutate: reportPost } = useReportPost(post.id!);
   const [liked, setLiked] = useState(post.likedByMe ?? false);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
@@ -67,15 +86,19 @@ export function PostBody({
 
   function handleReport(): void {
     setMenuVisible(false);
-    const reasons = ["스팸", "욕설/혐오", "음란/부적절", "허위정보", "기타"];
     Alert.alert("신고 사유 선택", "신고 사유를 선택해주세요.", [
-      ...reasons.map((reason) => ({
-        text: reason,
+      ...REASON_MAP.map(({ label, value }) => ({
+        text: label,
         onPress: () =>
-          Alert.alert(
-            "신고 완료",
-            "정상적으로 신고 접수되었습니다.\n\n신고된 게시글은 커뮤니티 가이드라인에 따라 모니터링 및 조치될 예정입니다.",
-          ),
+          reportPost(value, {
+            onSuccess: () =>
+              Alert.alert(
+                "신고 완료",
+                "정상적으로 신고 접수되었습니다.\n\n신고된 게시글은 커뮤니티 가이드라인에 따라 모니터링 및 조치될 예정입니다.",
+              ),
+            onError: () =>
+              Alert.alert("오류", "신고 처리 중 오류가 발생했습니다."),
+          }),
       })),
       { text: "취소", style: "cancel" as const },
     ]);
@@ -117,7 +140,10 @@ export function PostBody({
             {[...post.images]
               .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
               .map((img) => (
-                <Pressable key={img.id} onPress={() => setSelectedImage(img.imageUrl ?? null)}>
+                <Pressable
+                  key={img.id}
+                  onPress={() => setSelectedImage(img.imageUrl ?? null)}
+                >
                   {img.imageUrl ? (
                     <Image
                       source={{ uri: img.imageUrl }}
@@ -126,7 +152,10 @@ export function PostBody({
                       resizeMode="cover"
                     />
                   ) : (
-                    <View className="rounded-xl bg-fill-stronger" style={{ width: 148, height: 148 }} />
+                    <View
+                      className="rounded-xl bg-fill-stronger"
+                      style={{ width: 148, height: 148 }}
+                    />
                   )}
                 </Pressable>
               ))}
@@ -144,17 +173,21 @@ export function PostBody({
           }
           hitSlop={8}
         >
-          {liked ? <HeartFilledIcon size={20} /> : <HeartOutlineIcon size={20} />}
+          {liked ? (
+            <HeartFilledIcon size={20} />
+          ) : (
+            <HeartOutlineIcon size={20} />
+          )}
           <Text className="text-label-subtle typo-body-1-normal-medium">
             {post.likeCount ?? 0}
           </Text>
         </Pressable>
-        <View className="flex-row items-center gap-1">
+        <Pressable className="flex-row items-center gap-1" onPress={onCommentPress} hitSlop={8}>
           <ChatIcon size={20} color="#464a57" />
           <Text className="text-label-subtle typo-body-1-normal-medium">
             {post.commentCount ?? 0}
           </Text>
-        </View>
+        </Pressable>
       </View>
 
       <Modal

--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -85,14 +85,7 @@ export function PostBody({
     <View className="gap-3 px-5 py-4">
       <View className="flex-row items-center gap-2">
         <View className="flex-1 flex-row items-center gap-2">
-          {post.author?.profileUrl ? (
-            <Image
-              source={{ uri: post.author.profileUrl }}
-              className="size-10 rounded-full"
-            />
-          ) : (
-            <PostAvatar size="lg" />
-          )}
+          <PostAvatar size="lg" imageUrl={post.author?.profileUrl} />
           <View>
             <Text className="text-label-normal typo-body-2-normal-semi-bold">
               {post.author?.nickname ?? ""}

--- a/features/community/hooks/use-post-like.ts
+++ b/features/community/hooks/use-post-like.ts
@@ -29,7 +29,10 @@ export function useTogglePostLike(postId: number) {
     onSuccess: (res) => {
       queryClient.setQueryData<FreePostDetailResponse>(
         [ENDPOINTS.COMMUNITY_FREE_POSTS_BY_POSTID(postId)],
-        (old) => (old ? { ...old, likeCount: res.data.count } : old),
+        (old) =>
+          old
+            ? { ...old, likeCount: res.data.count, likedByMe: !old.likedByMe }
+            : old,
       );
     },
   });

--- a/features/community/hooks/use-report-post.ts
+++ b/features/community/hooks/use-report-post.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS, FreePostReportRequest } from "@/types/api.generated";
+import { useMutation } from "@tanstack/react-query";
+
+export function useReportPost(postId: number) {
+  return useMutation({
+    mutationFn: async (reason: FreePostReportRequest["reason"]) => {
+      const { data } = await api.post({
+        path: ENDPOINTS.COMMUNITY_FREE_POSTS_BY_POSTID_REPORTS(postId),
+        body: { reason },
+      });
+
+      return data;
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- `PostAvatar` 프로필 이미지 지원 추가 (imageUrl prop, fallback 기본 아이콘)
- 댓글/답글/게시글 작성자 아바타에 프로필 이미지 적용
- 좋아요 토글 시 `likedByMe` 상태 즉시 반영
- 자유게시판 목록 pull-to-refresh 추가
- 탭 전환 시 status bar dark 고정
- 게시글 신고 API(`POST /api/community/free-posts/{postId}/reports`) 연동
- 댓글 아이콘 탭 시 댓글 입력창 포커스 연결

## Test plan

- [ ] 프로필 이미지 있는 유저의 댓글/게시글에서 아바타 이미지 표시 확인
- [ ] 프로필 이미지 없을 때 기본 아이콘 fallback 확인
- [ ] 좋아요 버튼 토글 후 하트 상태 즉시 변경 확인
- [ ] 자유게시판 목록에서 위로 당겨 새로고침 확인
- [ ] 홈 외 탭(산목록/트래킹/커뮤니티/마이페이지)에서 상단 status bar 다크 확인
- [ ] 게시글 신고 → 사유 선택 → API 호출 및 완료 알럿 확인
- [ ] 댓글 수 아이콘 탭 시 하단 댓글 입력창 포커스 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)