### PR TITLE
fix: 세모피드 여백 제거 및 기록리포트 새 api 연동

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -293,7 +293,7 @@ export default function RecordScreen() {
         {/* 클라이브 */}
         {activeTab === "클라이브" && (
           <View className="pb-10 pt-2">
-            <ViewShot ref={cliveShotRef} options={{ format: "jpg", quality: 1 }}>
+            <ViewShot ref={cliveShotRef} options={{ format: "jpg", quality: 1 }} style={{ width: 335, alignSelf: "center" }}>
               <View style={styles.cardWrap}>
                 {/* 왼쪽 그라디언트 바 — 정상 완료: 빨강까지 full */}
                 <LinearGradient
@@ -433,7 +433,7 @@ export default function RecordScreen() {
         {/* 포토 리포트 */}
         {activeTab === "포토 리포트" && (
           <View className="pb-10 pt-2">
-            <ViewShot ref={photoReportShotRef} options={{ format: "jpg", quality: 1 }}>
+            <ViewShot ref={photoReportShotRef} options={{ format: "jpg", quality: 1 }} style={{ width: 335, alignSelf: "center" }}>
               <View style={styles.cardWrap}>
                 {/* 배경 사진 */}
                 <ExpoImage

--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -48,6 +48,7 @@ import { XIcon } from "@/components/icons/x-icon";
 import { CliveBottomBar } from "@/components/clive-bottom-bar";
 import { getPhotoReportState } from "@/features/photo-report/photo-report-state";
 import { useHikingSummary } from "@/features/mypage/hooks/use-hiking-summary";
+import { useHikingRecordDetail } from "@/features/home/hooks/use-hiking-record-detail";
 import { uploadImage } from "@/hooks/use-upload-image";
 import { api } from "@/lib/api";
 import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
@@ -55,8 +56,9 @@ import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
 type RecordTab = "클라이브" | "포토 리포트";
 
 export default function RecordScreen() {
-  const { id, name, courseName, imageUri, distance, duration } = useLocalSearchParams<{
+  const { id, hikingRecordId, name, courseName, imageUri, distance, duration } = useLocalSearchParams<{
     id: string;
+    hikingRecordId?: string;
     name: string;
     courseName?: string;
     imageUri?: string;
@@ -64,6 +66,7 @@ export default function RecordScreen() {
     duration?: string;
   }>();
   const sessionId = id ? parseInt(id) : null;
+  const hikingRecordIdNum = hikingRecordId ? parseInt(hikingRecordId) : null;
   const distanceKm = distance ? parseFloat(distance) / 1000 : null;
   const durationSec = duration ? parseInt(duration) : null;
   const router = useRouter();
@@ -87,6 +90,7 @@ export default function RecordScreen() {
   const privateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { data: clivePhotos = [] } = useClivePhotos(sessionId);
   const { data: hikingSummary } = useHikingSummary();
+  const { data: recordDetail } = useHikingRecordDetail(hikingRecordIdNum);
   const displayPhotos = [...clivePhotos].reverse();
   const cliveShotRef = useRef<ViewShot | null>(null);
   const photoReportShotRef = useRef<ViewShot | null>(null);
@@ -260,9 +264,9 @@ export default function RecordScreen() {
         {/* 통계 */}
         <View style={{ flexDirection: "row", marginHorizontal: 20, marginTop: 16, marginBottom: 16, gap: 4 }}>
           {[
-            { label: "소요시간", value: formatDuration(durationSec) },
-            { label: "고도", value: hikingSummary?.totalAltitude != null ? `${Math.round(hikingSummary.totalAltitude)}Nm` : "--" },
-            { label: "칼로리", value: "360kcal" },
+            { label: "소요시간", value: formatDuration(recordDetail?.durationSeconds ?? durationSec) },
+            { label: "고도", value: recordDetail?.ascentMeters != null ? `${Math.round(recordDetail.ascentMeters)}Nm` : "--" },
+            { label: "칼로리", value: recordDetail?.calories != null ? `${recordDetail.calories}kcal` : "--" },
           ].map((stat) => (
             <View key={stat.label} style={styles.statItem}>
               <Text style={styles.statLabel}>{stat.label}</Text>

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -101,6 +101,7 @@ export default function BottomSheet({
                 pathname: '/record/[id]',
                 params: {
                   id: String(record?.sessionId ?? courseId),
+                  hikingRecordId: String(record?.hikingRecordId ?? ''),
                   name: selectedCard.name,
                   courseName: record?.courseName ?? '',
                   imageUri: selectedCard.imageUri ?? '',

--- a/components/hiking-stats-card.tsx
+++ b/components/hiking-stats-card.tsx
@@ -5,7 +5,7 @@ export function HikingStatsCard() {
   const { data } = useHikingSummary();
 
   return (
-    <View className="bg-fill-strong rounded-2xl px-2 py-[22px] flex-row mx-2 mb-3">
+    <View className="bg-fill-strong rounded-2xl px-2 py-[22px] flex-row mb-3">
       <StatItem label="누적 등산 횟수" value={`${data?.totalHikingCount ?? 0}회`} />
       <Divider />
       <StatItem label="정복한 산" value={`${data?.conqueredMountainCount ?? 0}개`} />

--- a/components/hiking-stats-card.tsx
+++ b/components/hiking-stats-card.tsx
@@ -5,7 +5,7 @@ export function HikingStatsCard() {
   const { data } = useHikingSummary();
 
   return (
-    <View className="bg-fill-strong rounded-2xl px-6 py-[22px] flex-row mx-2 mb-3">
+    <View className="bg-fill-strong rounded-2xl px-2 py-[22px] flex-row mx-2 mb-3">
       <StatItem label="누적 등산 횟수" value={`${data?.totalHikingCount ?? 0}회`} />
       <Divider />
       <StatItem label="정복한 산" value={`${data?.conqueredMountainCount ?? 0}개`} />

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -141,6 +141,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
             zoom: region.zoom,
           }}
           isShowLocationButton={false}
+          isShowZoomControls={false}
           onTapMap={() => sheetRef.current?.collapseToMin()}
           onCameraIdle={(e) => {
             const { latitude, longitude, latitudeDelta, longitudeDelta } =

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -52,7 +52,7 @@ type Region = {
 const DEFAULT_REGION: Region = {
   latitude: 37.5665,
   longitude: 126.978,
-  zoom: 10,
+  zoom: 8,
 };
 
 export type MapHomeViewRef = {

--- a/features/home/hooks/use-hiking-record-detail.ts
+++ b/features/home/hooks/use-hiking-record-detail.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export type HikingRecordDetail = {
+  hikingRecordId: number;
+  distanceMeters?: number;
+  durationSeconds?: number;
+  maxAltitudeMeters?: number;
+  ascentMeters?: number;
+  descentMeters?: number;
+  calories?: number;
+  startedAt?: string;
+  endedAt?: string;
+};
+
+export function useHikingRecordDetail(hikingRecordId: number | null) {
+  return useQuery({
+    queryKey: ["hikingRecordDetail", hikingRecordId],
+    enabled: hikingRecordId != null,
+    queryFn: async () => {
+      const res = await api.get<HikingRecordDetail>({
+        path: `/api/hiking-records/${hikingRecordId}`,
+      });
+      return res.data;
+    },
+  });
+}


### PR DESCRIPTION
## **Summary**
- 기록 리포트 소요시간·고도·칼로리 `/api/hiking-records/{hikingRecordId}` 연동
- 세모피드 저장 시 흰 여백 제거 (`ViewShot` 335×596 고정)
