### PR TITLE
fix : 전시 QA 트래킹 반영

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -970,7 +970,7 @@ export default function TrackingScreen() {
               elapsedSeconds={elapsedSeconds}
               isPaused={isPaused}
               showTooltip={showTooltip}
-              isPhotoWindowOpen={photoWindow?.status === "OPEN"}
+              isPhotoWindowOpen={photoWindow?.status === "OPEN" || hasSummited}
               hasSummited={hasSummited}
               timeToTarget={timeToTarget}
               distanceToTarget={distanceToTarget}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -958,6 +958,7 @@ export default function TrackingScreen() {
           onSelectCourse={(id) => setSelectedCourseId(String(id))}
           onFreeRecord={handleFreeRecord}
           onStartCountdown={startCountdown}
+          onCollapse={() => setCollapsed(true)}
         />
       )}
 

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -837,6 +837,12 @@ export default function TrackingScreen() {
             longitude: 126.9636,
             zoom: 12,
           }}
+          mapPadding={{
+            bottom: isTracking ? trackingSheetHeight : collapsed ? COLLAPSED_PEEK_HEIGHT : 448,
+            top: 0,
+            left: 0,
+            right: 0,
+          }}
           onCameraChanged={({ reason }) => {
             if (reason === 'Gesture') setIsFollowingUser(false);
           }}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -135,6 +135,7 @@ export default function TrackingScreen() {
   const simIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const backgroundedAtRef = useRef<number | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
+  const [isFollowingUser, setIsFollowingUser] = useState(false);
   const isMountedRef = useRef(true);
   useEffect(() => () => { isMountedRef.current = false; }, []);
 
@@ -495,6 +496,22 @@ export default function TrackingScreen() {
     return () => clearTimeout(timer);
   }, [courseDetail?.polyline, isTracking]);
 
+  // 트래킹 시작/종료 시 follow 모드 토글
+  useEffect(() => {
+    setIsFollowingUser(isTracking);
+  }, [isTracking]);
+
+  // 트래킹 중 실시간 위치 마커 카메라 추적 (사용자가 직접 조작하면 follow 해제)
+  useEffect(() => {
+    if (!isFollowingUser || !markerCoord) return;
+    mapRef.current?.animateCameraTo({
+      latitude: markerCoord.latitude,
+      longitude: markerCoord.longitude,
+      zoom: 15,
+      duration: 800,
+    });
+  }, [markerCoord, isFollowingUser]);
+
   const startCountdown = (freeMode = false) => {
     setIsFreeMode(freeMode === true); // 이벤트 객체 등 non-boolean 방지
     setCountdown(3);
@@ -820,6 +837,9 @@ export default function TrackingScreen() {
             longitude: 126.9636,
             zoom: 12,
           }}
+          onCameraChanged={({ reason }) => {
+            if (reason === 'Gesture') setIsFollowingUser(false);
+          }}
         >
           {staticMapOverlays}
 
@@ -831,6 +851,7 @@ export default function TrackingScreen() {
               width={28}
               height={34}
               anchor={{ x: 0.5, y: 0.47 }}
+              onTap={() => setIsFollowingUser(true)}
             >
               {/* 총 높이: 삼각형 9 + 원 28 - 겹침 3 = 34 */}
               <View collapsable={false} style={{ width: 28, height: 34 }}>

--- a/features/tracking/components/course-item.tsx
+++ b/features/tracking/components/course-item.tsx
@@ -39,7 +39,7 @@ export function ApiCourseItem({
   const textColor =
     API_DIFFICULTY_TEXT[course.difficulty ?? ""] ?? "text-label-normal";
   const distanceKm =
-    course.distance != null ? `${course.distance.toFixed(1)}km` : "-";
+    course.distance != null ? `${(course.distance / 1000).toFixed(1)}km` : "-";
   const durationMin =
     course.duration != null
       ? course.duration >= 60

--- a/features/tracking/components/course-select-sheet.tsx
+++ b/features/tracking/components/course-select-sheet.tsx
@@ -3,6 +3,13 @@ import {
   NearbyMountainInfo,
 } from "@/types/api.generated";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
 import {
   ScrollView,
   Text,
@@ -10,6 +17,9 @@ import {
   View,
 } from "react-native";
 import { ApiCourseItem } from "./course-item";
+
+const SHEET_HEIGHT = 448;
+const COLLAPSE_THRESHOLD = 80;
 
 type Props = {
   mountain?: NearbyMountainInfo;
@@ -19,6 +29,7 @@ type Props = {
   onSelectCourse: (id: number) => void;
   onFreeRecord: () => void;
   onStartCountdown: () => void;
+  onCollapse?: () => void;
 };
 
 export function CourseSelectSheet({
@@ -29,16 +40,53 @@ export function CourseSelectSheet({
   onSelectCourse,
   onFreeRecord,
   onStartCountdown,
+  onCollapse,
 }: Props) {
+  const translateY = useSharedValue(0);
+
+  const panGesture = Gesture.Pan()
+    .activeOffsetY(5)
+    .onUpdate((e) => {
+      if (e.translationY > 0) {
+        translateY.value = e.translationY;
+      }
+    })
+    .onEnd((e) => {
+      if (e.translationY > COLLAPSE_THRESHOLD || e.velocityY > 600) {
+        if (onCollapse) runOnJS(onCollapse)();
+        translateY.value = withSpring(0, { damping: 30, stiffness: 300 });
+      } else {
+        translateY.value = withSpring(0, { damping: 30, stiffness: 300 });
+      }
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }));
+
   return (
-    <View
-      className="w-full overflow-hidden bg-fill-normal"
-      style={{ height: 448, borderTopLeftRadius: 20, borderTopRightRadius: 20 }}
+    <Animated.View
+      style={[
+        {
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          height: SHEET_HEIGHT,
+          borderTopLeftRadius: 20,
+          borderTopRightRadius: 20,
+          overflow: "hidden",
+        },
+        animatedStyle,
+      ]}
+      className="bg-fill-normal"
     >
-      {/* 드래그 핸들 */}
-      <View className="items-center pb-2 pt-3">
-        <View className="h-1 w-10 rounded-full bg-fill-neutral" />
-      </View>
+      {/* 드래그 핸들 — 이 영역에만 pan gesture 적용 */}
+      <GestureDetector gesture={panGesture}>
+        <View className="items-center pb-2 pt-3" style={{ paddingHorizontal: 60 }}>
+          <View className="h-1 w-10 rounded-full bg-fill-neutral" />
+        </View>
+      </GestureDetector>
 
       {/* 타이틀 */}
       <View className="gap-1 px-4 pb-4 pt-1">
@@ -99,6 +147,6 @@ export function CourseSelectSheet({
           </Text>
         </TouchableOpacity>
       </View>
-    </View>
+    </Animated.View>
   );
 }

--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -52,7 +52,7 @@ export function TrackingSheet({
   return (
     <View
       className="w-full bg-fill-normal overflow-hidden"
-      style={{ borderTopLeftRadius: 20, borderTopRightRadius: 20 }}
+      style={{ borderTopLeftRadius: 20, borderTopRightRadius: 20, minHeight: 220 }}
     >
       {/* 핸들 — 탭하면 펼침/접힘 */}
       <TouchableOpacity
@@ -103,12 +103,12 @@ export function TrackingSheet({
         </View>
       )}
 
-      {/* 버튼 영역 */}
-      <View className="px-4 gap-2" style={{ paddingTop: 12, paddingBottom: insets.bottom }}>
+      {/* 버튼 영역 — 툴팁은 absolute로 위에 띄워서 시트 높이 유지 */}
+      <View style={{ paddingHorizontal: 16, paddingTop: 12, paddingBottom: insets.bottom }}>
 
-        {/* 말풍선 툴팁 — 트래킹 중(비일시정지)에만 표시 */}
+        {/* 말풍선 툴팁 — absolute로 버튼 위에 오버레이 */}
         {!isPaused && (isPhotoWindowOpen || showTooltip) && (
-          <View style={{ alignItems: 'flex-start', marginLeft: 25 }}>
+          <View style={{ position: 'absolute', bottom: 48 + 12, left: 25, zIndex: 10 }}>
             <View
               className="flex-row items-center justify-center gap-2"
               style={{ paddingHorizontal: 16, paddingVertical: 8, borderRadius: 10, backgroundColor: TOOLTIP_BG }}

--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -1,6 +1,7 @@
 import { CameraIcon } from '@/components/icons/camera-icon';
 import { useState } from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Path, Svg } from 'react-native-svg';
 import { TRACKING_TIMER_STYLE, formatElapsedTime } from '../constants';
 
@@ -43,6 +44,7 @@ export function TrackingSheet({
   onSummit,
 }: Props) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const insets = useSafeAreaInsets();
 
   const timeLabel = hasSummited ? '하산까지 시간' : '정상까지 시간';
   const distanceLabel = hasSummited ? '하산까지 거리' : '정상까지 거리';
@@ -86,7 +88,7 @@ export function TrackingSheet({
       {/* 펼침 상태 — 정상/하산까지 시간 & 거리 */}
       {isExpanded && (
         <View className="border-t border-line-subtle flex-row">
-          <View className="flex-1 items-center gap-1 py-3">
+          <View className="flex-1 items-center gap-1 py-5">
             <Text className="typo-caption-1-medium text-label-subtler">{timeLabel}</Text>
             <Text className="typo-body-1-normal-semi-bold text-label-normal">{timeToTarget}</Text>
           </View>
@@ -94,7 +96,7 @@ export function TrackingSheet({
           <View className="w-px bg-line-subtle self-stretch" />
 
           {/* 거리 */}
-          <View className="flex-1 items-center gap-1 py-3">
+          <View className="flex-1 items-center gap-1 py-5">
             <Text className="typo-caption-1-medium text-label-subtler">{distanceLabel}</Text>
             <Text className="typo-body-1-normal-semi-bold text-label-normal">{distanceToTarget}</Text>
           </View>
@@ -102,7 +104,7 @@ export function TrackingSheet({
       )}
 
       {/* 버튼 영역 */}
-      <View className="px-4 pb-4 gap-2">
+      <View className="px-4 gap-2" style={{ paddingTop: 12, paddingBottom: insets.bottom }}>
 
         {/* 말풍선 툴팁 — 트래킹 중(비일시정지)에만 표시 */}
         {!isPaused && (isPhotoWindowOpen || showTooltip) && (


### PR DESCRIPTION
## Summary

- 코스 선택 시 지도 카메라가 전체 경로를 보이도록 `animateCameraWithTwoCoords` 적용 (15% 패딩)
- `mapPadding` 적용으로 바텀시트에 가려지지 않는 영역 기준으로 카메라 fitBounds 계산
- 코스 선택 바텀시트 아래로 드래그하면 collapse되는 pan gesture 추가
- 트래킹 중 실시간 위치로 지도 카메라 자동 추적 (사용자 직접 조작 시 추적 해제, 위치 마커 탭 시 재활성화)
- 정상 인증 후 카메라 버튼 활성화
- 트래킹 시트 높이 고정 (툴팁 노출 여부에 관계없이 유지, 툴팁 absolute 처리)
- 트래킹 버튼 사이즈 디자인 스펙 반영 (`minHeight/maxHeight: 48`, `padding: 11px 20px`)
- safe area inset 적용으로 홈 인디케이터와 버튼 간격 확보
- 코스 거리 단위 수정 (m → km 변환)

## Test plan

- [ ] 코스 선택 시 지도가 해당 코스 전체가 보이도록 카메라 이동되는지 확인
- [ ] 바텀시트를 아래로 드래그하면 collapse되는지 확인
- [ ] 트래킹 시작 후 실시간 위치 마커로 카메라가 따라가는지 확인
- [ ] 지도 직접 조작 시 카메라 추적 해제되고, 마커 탭 시 재활성화되는지 확인
- [ ] 정상 인증 버튼 탭 후 카메라 버튼 활성화 확인
- [ ] 툴팁 노출/미노출 시 트래킹 시트 높이 동일한지 확인
- [ ] 버튼 간격 및 safe area 여백 아이폰 실기기에서 확인
- [ ] 코스 거리 km 단위 올바르게 표시되는지 확인 (예: 8.9km)