### PR TITLE
feat: 코스 좋아요 기능 추가

### DIFF
--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -95,14 +95,14 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
         label: "오르막길",
         value:
           typeof course.ascent === "number"
-            ? `${Math.round(course.ascent)}m`
+            ? `${(course.ascent / 1000).toFixed(1)}km`
             : "-",
       },
       {
         label: "내리막길",
         value:
           typeof course.descent === "number"
-            ? `${Math.round(course.descent)}m`
+            ? `${(course.descent / 1000).toFixed(1)}km`
             : "-",
       },
     ],

--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -129,7 +129,7 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
               <>
                 <NaverMapPathOverlay
                   coords={courseCoords}
-                  width={6}
+                  width={4}
                   color="#ffd40d"
                   outlineWidth={1}
                   outlineColor="#eab308"

--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -1,7 +1,11 @@
 import { DotMarkerIcon } from "@/components/icons/dot-marker-icon";
 import { FlagMarkerIcon } from "@/components/icons/flag-marker-icon";
-import { HeartIcon } from "@/components/icons/heart-icon";
+import {
+  HeartFilledIcon,
+  HeartOutlineIcon,
+} from "@/components/icons/heart-icon";
 import { CourseBadge } from "@/features/mountains/components/course-badge";
+import { useToggleCourseLike } from "@/features/tracking/hooks/use-toggle-course-like";
 import { parseCoursePolyline } from "@/features/tracking/utils/parse-course-polyline";
 import { formatDuration } from "@/modules/format-duration";
 import { CourseDetailResponse } from "@/types/api.generated";
@@ -11,6 +15,7 @@ import {
   NaverMapPathOverlay,
   NaverMapView,
 } from "@mj-studio/react-native-naver-map";
+import { useState } from "react";
 import { Pressable, Text, View } from "react-native";
 
 const DIFFICULTY_LABEL: Record<
@@ -50,6 +55,9 @@ type CourseDetailInfoProps = {
 };
 
 export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
+  const [liked, setLiked] = useState(course.likedByMe ?? false);
+  const { mutate: toggleLike } = useToggleCourseLike(course.id!);
+
   const courseCoords = parseCoursePolyline(course.polyline);
   const center = getCenterCoordinate(courseCoords);
   const zoom = getCourseZoom(courseCoords);
@@ -177,8 +185,17 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
               {course.name}
             </Text>
           </View>
-          <Pressable hitSlop={8}>
-            <HeartIcon />
+          <Pressable
+            hitSlop={8}
+            onPress={() =>
+              toggleLike(undefined, { onSuccess: () => setLiked((v) => !v) })
+            }
+          >
+            {liked ? (
+              <HeartFilledIcon size={24} />
+            ) : (
+              <HeartOutlineIcon size={24} />
+            )}
           </Pressable>
         </View>
 

--- a/features/mountains-detail/components/course-detail-info.tsx
+++ b/features/mountains-detail/components/course-detail-info.tsx
@@ -162,7 +162,7 @@ export function CourseDetailInfo({ course }: CourseDetailInfoProps) {
                   }
                   width={22}
                   height={30}
-                  anchor={{ x: 0.3, y: 1 }}
+                  anchor={{ x: 0.3, y: 0.93 }}
                 >
                   <FlagMarkerIcon />
                 </NaverMapMarkerOverlay>

--- a/features/tracking/hooks/use-toggle-course-like.ts
+++ b/features/tracking/hooks/use-toggle-course-like.ts
@@ -1,0 +1,14 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+export function useToggleCourseLike(courseId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api.post({ path: ENDPOINTS.COURSES_BY_COURSEID_LIKE(courseId) }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["course-detail", courseId] });
+    },
+  });
+}

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -22,6 +22,7 @@ export const ENDPOINTS = {
   MOUNTAINS_BY_MOUNTAINID_LIKE: (mountainId: number | string) => `/api/mountains/${mountainId}/like`,
   HIKING_RECORDS_BY_HIKINGRECORDID_DIFFICULTY_FEEDBACK: (hikingRecordId: number | string) => `/api/hiking-records/${hikingRecordId}/difficulty-feedback`,
   FCM_TOKENS: "/api/fcm/tokens",
+  COURSES_BY_COURSEID_LIKE: (courseId: number | string) => `/api/courses/${courseId}/like`,
   COMMUNITY_RECORD_POSTS: "/api/community/record-posts",
   COMMUNITY_POSTS_BY_POSTID_LIKES: (postId: number | string) => `/api/community/posts/${postId}/likes`,
   COMMUNITY_POSTS_BY_POSTID_COMMENTS: (postId: number | string) => `/api/community/posts/${postId}/comments`,
@@ -248,6 +249,15 @@ export type CourseDifficultyFeedbackResponse = {
 export type FcmTokenRegisterRequest = {
   token?: string;
   deviceType: "IOS" | "ANDROID";
+};
+export type ApiResponseCourseLikeToggleResponse = {
+  isSuccess?: boolean;
+  code?: string;
+  message?: string;
+  data?: CourseLikeToggleResponse;
+};
+export type CourseLikeToggleResponse = {
+  liked?: boolean;
 };
 export type RecordPostCreateRequest = {
   hikingRecordId: number;
@@ -706,6 +716,7 @@ export type ApiResponseCourseDetailResponse = {
 };
 export type CourseDetailResponse = {
   id?: number;
+  mountainId?: number;
   name?: string;
   difficulty?: "EASY" | "NORMAL" | "HARD";
   distance?: number;
@@ -715,6 +726,7 @@ export type CourseDetailResponse = {
   ascent?: number;
   descent?: number;
   maxAltitude?: number;
+  likedByMe?: boolean;
   polyline?: string;
   altitudes?: string;
 };
@@ -876,6 +888,11 @@ export type RegisterBody = FcmTokenRegisterRequest;
 
 // DELETE /api/fcm/tokens
 export type DeleteBody = FcmTokenDeleteRequest;
+
+// POST /api/courses/{courseId}/like
+export type ToggleCourseLikeParams = {
+  courseId: number;
+};
 
 // GET /api/community/record-posts
 export type GetListParams = {


### PR DESCRIPTION
## Summary

- 코스 상세 화면에 좋아요 토글 기능 추가 (`POST /api/courses/{courseId}/like`)
- `likedByMe` 초기값 기반 하트 아이콘 상태 표시 (`HeartFilledIcon` / `HeartOutlineIcon`)
- 오르막길/내리막길 단위 m → km 변경
- 코스 미리보기 지도 polyline 두께 및 정상 마커 anchor 조정

## Test plan

- [ ] 코스 상세 진입 시 `likedByMe` 값에 따라 하트 상태 표시 확인
- [ ] 하트 버튼 탭 → API 호출 → 하트 토글 확인
- [ ] 오르막길/내리막길 값이 km 단위로 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)