### PR TITLE
fix: 산 상세 UI 수정

### DIFF
--- a/features/mountains-detail/components/restaurant-tab.tsx
+++ b/features/mountains-detail/components/restaurant-tab.tsx
@@ -1,6 +1,6 @@
+import { LoadingSpinner } from "@/components/loading-spinner";
 import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import { useLocalSearchParams } from "expo-router";
-import { LoadingSpinner } from "@/components/loading-spinner";
 import { Image, ScrollView, Text, View } from "react-native";
 
 export function RestaurantTab() {
@@ -21,7 +21,7 @@ export function RestaurantTab() {
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{ paddingHorizontal: 24, gap: 12 }}
+            contentContainerStyle={{ paddingHorizontal: 20, gap: 12 }}
           >
             {section.restaurants?.map((item) => (
               <View key={item.restaurantId} className="gap-2">

--- a/features/mountains-detail/components/weather-accordion.tsx
+++ b/features/mountains-detail/components/weather-accordion.tsx
@@ -37,12 +37,15 @@ function SunriseSunset({
   );
 }
 
-export function WeatherAccordion({ latitude, longitude }: WeatherAccordionProps): React.JSX.Element {
+export function WeatherAccordion({
+  latitude,
+  longitude,
+}: WeatherAccordionProps): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const weatherDays = buildSunTimesDays(latitude, longitude);
 
   return (
-    <View className="mx-5 mt-4 gap-2 rounded-[8px] bg-[#F9FAFB] px-4 py-[10px]">
+    <View className="mx-5 mt-4 gap-[10px] rounded-[8px] bg-[#F9FAFB] px-4 py-[10px]">
       <Pressable
         className="flex-row items-center justify-between"
         onPress={() => setOpen(!open)}

--- a/features/mountains/components/mountain-bookmark-button.tsx
+++ b/features/mountains/components/mountain-bookmark-button.tsx
@@ -9,10 +9,18 @@ type Props = {
 };
 
 export function MountainBookmarkButton({ mountainId, mountainData }: Props) {
-  const { isBookmarked, isPending, toggle } = useMountainBookmark(mountainId, mountainData);
+  const { isBookmarked, isPending, toggle } = useMountainBookmark(
+    mountainId,
+    mountainData,
+  );
 
   return (
-    <Pressable hitSlop={8} onPress={toggle} disabled={isPending}>
+    <Pressable
+      className="h-6 w-6"
+      hitSlop={8}
+      onPress={toggle}
+      disabled={isPending}
+    >
       <BookmarkIcon color={"#1A1B1F"} filled={isBookmarked} />
     </Pressable>
   );


### PR DESCRIPTION
## Summary

- 맛집 탭 가로 패딩 24 → 20 조정
- 날씨 아코디언 아이템 간격 gap-2 → gap-[10px] 조정
- 북마크 버튼 크기 명시 (`h-6 w-6`)

## Test plan

- [ ] 산 상세 맛집 탭 레이아웃 확인
- [ ] 날씨 아코디언 펼쳤을 때 항목 간격 확인
- [ ] 북마크 버튼 탭 영역 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)