### PR TITLE
fix: 트래킹 툴팁 말풍선 위치 조정

### DIFF
--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -108,7 +108,7 @@ export function TrackingSheet({
 
         {/* 말풍선 툴팁 — absolute로 버튼 위에 오버레이 */}
         {!isPaused && (isPhotoWindowOpen || showTooltip) && (
-          <View style={{ position: 'absolute', bottom: 48 + 12, left: 25, zIndex: 10 }}>
+          <View style={{ position: 'absolute', bottom: insets.bottom + 48 + 4, left: 36, zIndex: 10 }}>
             <View
               className="flex-row items-center justify-center gap-2"
               style={{ paddingHorizontal: 16, paddingVertical: 8, borderRadius: 10, backgroundColor: TOOLTIP_BG }}


### PR DESCRIPTION
## Summary
- 트래킹 시트 툴팁 말풍선 위치 조정 (카메라 버튼 미겹침, absolute 처리로 시트 높이 고정)
## Test plan
- [ ] 툴팁 말풍선이 카메라 버튼을 가리지 않고 위에 표시되는지 확인