### PR TITLE
fix: QA 수정

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -50,6 +50,7 @@ import { getPhotoReportState } from "@/features/photo-report/photo-report-state"
 import { useHikingSummary } from "@/features/mypage/hooks/use-hiking-summary";
 import { useHikingRecordDetail } from "@/features/home/hooks/use-hiking-record-detail";
 import { uploadImage } from "@/hooks/use-upload-image";
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
 
@@ -70,6 +71,7 @@ export default function RecordScreen() {
   const distanceKm = distance ? parseFloat(distance) / 1000 : null;
   const durationSec = duration ? parseInt(duration) : null;
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { top } = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<RecordTab>("클라이브");
   const [showSaveToast, setShowSaveToast] = useState(false);
@@ -180,6 +182,7 @@ export default function RecordScreen() {
 
       const nextPublic = !activeTabPublic;
       setIsPublicByTab((prev) => ({ ...prev, [activeTab]: nextPublic }));
+      queryClient.invalidateQueries({ queryKey: [ENDPOINTS.SEMOFEED] });
 
       if (nextPublic) {
         setShowPrivateToast(false);

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -41,17 +41,8 @@ const OVERSCAN = 1; // 화면 밖 여유분 (셀 단위)
 export function FeedHomeView() {
   const { data: semofeedData } = useSemofeed();
 
-  const apiItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
-  const feedItems =
-    apiItems.length > 0
-      ? apiItems
-      : [
-          {
-            id: 0,
-            imageUrl: "https://picsum.photos/seed/test/320/570",
-            isPublic: true,
-          },
-        ];
+  const feedItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
+
   // 화면 크기 (onLayout으로 측정)
   const [screen, setScreen] = useState({ w: 0, h: 0 });
 


### PR DESCRIPTION
## Summary

- 세모피드 공개/비공개 토글 후 `GET /api/semofeed` 쿼리 무효화
- 세모피드 홈뷰 개선

## Test plan

- [ ] 클라이브/포토 리포트 공개 토글 후 세모피드 목록 즉시 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)