### PR TITLE
fix  : tracking 실제 gps 반영 및 photo 수정

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -839,8 +839,8 @@ export default function TrackingScreen() {
           </View>
         )}
 
-        {/* 트래킹 중 — 고도 그라데이션 바 + 아바타 마커 */}
-        {isTracking && (
+        {/* 트래킹 중 — 고도 그라데이션 바 + 아바타 마커 (자유기록 제외) */}
+        {isTracking && !isFreeMode && (
           <>
             <LinearGradient
               colors={TRAIL_BAR_COLORS}
@@ -874,8 +874,8 @@ export default function TrackingScreen() {
         )}
       </View>
 
-      {/* 트래킹 중 — 상단 코스 카드 */}
-      {isTracking && (
+      {/* 트래킹 중 — 상단 코스 카드 (자유기록 제외) */}
+      {isTracking && !isFreeMode && (
         <TrackingCourseCard
           course={selectedCourse}
           style={{ top: TRACKING_COURSE_CARD_TOP }}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -257,26 +257,92 @@ export default function TrackingScreen() {
     [courseDetail?.polyline],
   );
 
-  // 마커 Y 비율: 0.0(바 상단/정상) ~ 1.0(바 하단/출발)
-  // markerCoord 기준으로 코스에서 가장 가까운 좌표 인덱스를 찾아 정상까지의 진행률 계산
-  const markerRatio = useMemo(() => {
-    if (hasSummited) return 0.0; // 정상 인증 후 바 상단 고정
-    if (!markerCoord || courseCoords.length < 2) return 1.0;
+  // 정상/하산까지 시간·거리 — 코스 전체의 절반 (courseProgressState useMemo보다 먼저 선언)
+  const halfDurationMinutes = Math.round((courseDetail?.duration ?? 0) / 2);
+  const halfDistanceM = Math.round((courseDetail?.distance ?? 0) / 2);
+
+  // 코스 진행 상태 — GPS 기반 실시간 (markerRatio + 남은 거리/시간 통합)
+  const courseProgressState = useMemo(() => {
+    // ── 1순위: liveActivityCourse + Haversine 실측 거리 계산 ──────────────
+    if (liveActivityCourse && userLocation && liveActivityCourse.totalDistance > 0) {
+      const result = calcCourseProgress(
+        userLocation,
+        liveActivityCourse.coordinates,
+        liveActivityCourse.totalDistance,
+      );
+      // 분/m 페이스 (전체 코스 기준 일정 속도 가정)
+      const paceMinPerM = liveActivityCourse.estimatedTime / liveActivityCourse.totalDistance;
+      const traveledM = liveActivityCourse.totalDistance - result.remainingMeters;
+
+      if (hasSummited) {
+        // 하산 중: 코스 끝까지 남은 거리/시간
+        return {
+          markerRatio: 0.0,
+          remainingDistanceM: Math.round(result.remainingMeters),
+          remainingDurationMin: Math.round(result.remainingMeters * paceMinPerM),
+        };
+      }
+
+      // 등산 중: 코스 중간(정상)까지 남은 거리/시간
+      const halfDistance = liveActivityCourse.totalDistance / 2;
+      const remainingToSummitM = Math.max(0, halfDistance - traveledM);
+      const ascProgress = Math.min(traveledM / halfDistance, 1); // 0(출발) ~ 1(정상)
+      return {
+        markerRatio: Math.max(0, 1.0 - ascProgress), // 1.0(바 하단/출발) ~ 0.0(바 상단/정상)
+        remainingDistanceM: Math.round(remainingToSummitM),
+        remainingDurationMin: Math.round(remainingToSummitM * paceMinPerM),
+      };
+    }
+
+    // ── 2순위 폴백: 인덱스 기반 선형 보간 (liveActivityCourse 로딩 전) ──
     const summitIdx = Math.floor(courseCoords.length / 2);
+    const totalIdx = courseCoords.length - 1;
+
+    if (hasSummited) {
+      if (!markerCoord || courseCoords.length < 2) {
+        return { markerRatio: 0.0, remainingDistanceM: halfDistanceM, remainingDurationMin: halfDurationMinutes };
+      }
+      let closestIdx = summitIdx;
+      let minDist = Infinity;
+      for (let i = summitIdx; i <= totalIdx; i++) {
+        const dLat = courseCoords[i].latitude - markerCoord.latitude;
+        const dLng = courseCoords[i].longitude - markerCoord.longitude;
+        const dist = dLat * dLat + dLng * dLng;
+        if (dist < minDist) { minDist = dist; closestIdx = i; }
+      }
+      const descentTotal = totalIdx - summitIdx;
+      const ratio = descentTotal > 0
+        ? Math.max(0, Math.min(1, 1 - (closestIdx - summitIdx) / descentTotal))
+        : 0;
+      return {
+        markerRatio: 0.0,
+        remainingDistanceM: Math.round(halfDistanceM * ratio),
+        remainingDurationMin: Math.round(halfDurationMinutes * ratio),
+      };
+    }
+
+    if (!markerCoord || courseCoords.length < 2) {
+      return { markerRatio: 1.0, remainingDistanceM: halfDistanceM, remainingDurationMin: halfDurationMinutes };
+    }
+
     let closestIdx = 0;
     let minDist = Infinity;
     for (let i = 0; i <= summitIdx; i++) {
       const dLat = courseCoords[i].latitude - markerCoord.latitude;
       const dLng = courseCoords[i].longitude - markerCoord.longitude;
       const dist = dLat * dLat + dLng * dLng;
-      if (dist < minDist) {
-        minDist = dist;
-        closestIdx = i;
-      }
+      if (dist < minDist) { minDist = dist; closestIdx = i; }
     }
-    const progress = closestIdx / summitIdx; // 0.0(출발) ~ 1.0(정상)
-    return 1.0 - progress; // 0.0(바 상단/정상) ~ 1.0(바 하단/출발)
-  }, [markerCoord, courseCoords]);
+    const progress = summitIdx > 0 ? closestIdx / summitIdx : 0;
+    const remaining = Math.max(0, 1 - progress);
+    return {
+      markerRatio: 1.0 - progress,
+      remainingDistanceM: Math.round(halfDistanceM * remaining),
+      remainingDurationMin: Math.round(halfDurationMinutes * remaining),
+    };
+  }, [markerCoord, courseCoords, hasSummited, halfDistanceM, halfDurationMinutes, liveActivityCourse, userLocation]);
+
+  const { markerRatio, remainingDistanceM, remainingDurationMin } = courseProgressState;
 
   // altitudes 문자열에서 최고 고도(m) 파싱
   const peakAltitudeM = useMemo(() => {
@@ -295,10 +361,6 @@ export default function TrackingScreen() {
     return null;
   }, [courseDetail?.altitudes]);
 
-  // 정상/하산까지 시간·거리 — 코스 전체의 절반
-  const halfDurationMinutes = Math.round((courseDetail?.duration ?? 0) / 2);
-  const halfDistanceM = Math.round((courseDetail?.distance ?? 0) / 2);
-
   const selectedCourse = useMemo((): Course => ({
     id: String(courseDetail?.id ?? ''),
     name: courseDetail?.name ?? '',
@@ -315,12 +377,12 @@ export default function TrackingScreen() {
     zoom: 14,
   }), [courseDetail, peakAltitudeM, halfDistanceM]);
 
-  const timeToTarget = halfDurationMinutes > 0
-    ? `${Math.floor(halfDurationMinutes / 60) > 0 ? `${Math.floor(halfDurationMinutes / 60)}h ` : ''}${halfDurationMinutes % 60 > 0 ? `${halfDurationMinutes % 60}m` : ''}`
+  const timeToTarget = remainingDurationMin > 0
+    ? `${Math.floor(remainingDurationMin / 60) > 0 ? `${Math.floor(remainingDurationMin / 60)}h ` : ''}${remainingDurationMin % 60 > 0 ? `${remainingDurationMin % 60}m` : ''}`
     : '-';
-  const distanceToTarget = halfDistanceM >= 1000
-    ? `${(halfDistanceM / 1000).toFixed(1)}km`
-    : halfDistanceM > 0 ? `${halfDistanceM}m` : '-';
+  const distanceToTarget = remainingDistanceM >= 1000
+    ? `${(remainingDistanceM / 1000).toFixed(1)}km`
+    : remainingDistanceM > 0 ? `${remainingDistanceM}m` : '-';
 
   // 정적 맵 오버레이 — markerCoord 변경 시 리렌더 방지
   const staticMapOverlays = useMemo(() => (
@@ -952,6 +1014,7 @@ export default function TrackingScreen() {
               elapsedSeconds={elapsedSeconds}
               isPaused={isPaused}
               showTooltip={showTooltip}
+              isFreeMode={isFreeMode}
               isPhotoWindowOpen={photoWindow?.status === "OPEN" || hasSummited}
               hasSummited={hasSummited}
               timeToTarget={timeToTarget}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -260,6 +260,7 @@ export default function TrackingScreen() {
   // 마커 Y 비율: 0.0(바 상단/정상) ~ 1.0(바 하단/출발)
   // markerCoord 기준으로 코스에서 가장 가까운 좌표 인덱스를 찾아 정상까지의 진행률 계산
   const markerRatio = useMemo(() => {
+    if (hasSummited) return 0.0; // 정상 인증 후 바 상단 고정
     if (!markerCoord || courseCoords.length < 2) return 1.0;
     const summitIdx = Math.floor(courseCoords.length / 2);
     let closestIdx = 0;

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -33,7 +33,6 @@ import { useActiveTrackingSession } from "@/features/tracking/hooks/use-active-t
 import { useCompleteTrackingSession } from "@/features/tracking/hooks/use-complete-tracking-session";
 import { useCourseDetail } from "@/features/tracking/hooks/use-course-detail";
 import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
-// [DEMO] import { DEMO_NEARBY_DATA } from "@/features/tracking/constants/demo-gwanaksan";
 import { useProfile } from "@/features/mypage/hooks/use-profile";
 import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
 import { useResumeTrackingSession } from "@/features/tracking/hooks/use-resume-tracking-session";
@@ -132,7 +131,6 @@ export default function TrackingScreen() {
   } | null>(null);
   // 자유기록 실시간 경로 누적 (회색 polyline)
   const [recordedCoords, setRecordedCoords] = useState<{ latitude: number; longitude: number }[]>([]);
-  const simIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const backgroundedAtRef = useRef<number | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
@@ -169,14 +167,9 @@ export default function TrackingScreen() {
     })();
   }, []);
 
-  // [DEMO] 전시 데모용 관악산 좌표 고정 — 복원 시 아래 DEMO 줄 지우고 주석 해제
-  // const { data: nearbyData, isLoading: isNearbyLoading } = useNearbyMountain({
-  //   lat: userLocation?.latitude ?? null,
-  //   lng: userLocation?.longitude ?? null,
-  // });
   const { data: nearbyData, isLoading: isNearbyLoading } = useNearbyMountain({
-    lat: 37.4449,  // [DEMO] 관악산 정상 위도
-    lng: 126.9636, // [DEMO] 관악산 정상 경도
+    lat: userLocation?.latitude ?? null,
+    lng: userLocation?.longitude ?? null,
   });
 
   const handlePhotoWindow = useCallback((payload: PhotoWindowPayload) => {
@@ -423,51 +416,6 @@ export default function TrackingScreen() {
   ), [courseCoords, isFreeMode, recordedCoords, isTracking, nearbyData]);
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
-  const startCoordSimulation = useCallback(() => {
-    if (!sessionId) return;
-    if (simIntervalRef.current) {
-      console.warn('[SIM] 이미 실행 중');
-      return;
-    }
-    const coords = courseCoords;
-    if (coords.length === 0) {
-      console.warn('[SIM] 코스 좌표 없음');
-      return;
-    }
-
-    // [DEMO] 즉시 출발지 마커 세팅 (실제 GPS가 덮기 전에)
-    setMarkerCoord({ latitude: coords[0].latitude, longitude: coords[0].longitude });
-
-    let idx = 0;
-    console.log(`[SIM] 시작 — 총 ${coords.length}개 좌표`);
-    simIntervalRef.current = setInterval(() => {
-      if (idx >= coords.length) {
-        clearInterval(simIntervalRef.current!);
-        simIntervalRef.current = null;
-        console.log('[SIM] 완료');
-        return;
-      }
-      const { latitude, longitude } = coords[idx];
-      publishGps(sessionId, {
-        lat: latitude,
-        lng: longitude,
-        altitude: 0,
-        recordedAt: new Date().toISOString(),
-      });
-      setMarkerCoord({ latitude, longitude });
-      idx++;
-    }, 50);
-  }, [sessionId, courseCoords, publishGps]);
-
-  // [DEMO] 트래킹 시작 + 코스 좌표 준비 시 자동 시뮬레이션 시작 (자유기록 제외)
-  useEffect(() => {
-    if (!isTracking || isFreeMode) return;
-    if (!sessionId || courseCoords.length === 0) return;
-    if (simIntervalRef.current) return; // 이미 실행 중
-    // 실제 GPS 콜백이 시뮬 마커를 덮어쓰지 않도록 먼저 해제
-    setLocationTaskCallback(null);
-    startCoordSimulation();
-  }, [isTracking, isFreeMode, sessionId, courseCoords.length]);
 
   // polyline 로드되거나 트래킹 시작 시 카메라를 전체 경로가 보이도록 맞춤
   useEffect(() => {

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -109,9 +109,9 @@ export default function TrackingScreen() {
   const [sessionId, setSessionId] = useState<number | null>(null);
   const [hikingRecordId, setHikingRecordId] = useState<number | null>(null);
   const [hasSummited, setHasSummited] = useState(false);
-  const [photoWindow, setPhotoWindow] = useState<PhotoWindowPayload | null>(
-    null,
-  );
+  const [photoWindow, setPhotoWindow] = useState<PhotoWindowPayload | null>(null);
+  // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
+  const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
   const [barLayout, setBarLayout] = useState<{
@@ -685,8 +685,11 @@ export default function TrackingScreen() {
 
     if (result.canceled || !result.assets?.[0]?.uri) return;
 
-    // 사진 윈도우 OPEN 상태일 때 → MinIO 업로드 → 메타 저장
-    if (photoWindow?.status === "OPEN" && sessionId != null) {
+    const isWindowOpen = photoWindow?.status === "OPEN";
+    // 정상 인증 후에는 summitPhotoWindowRef에 저장된 photoWindow 사용
+    const activeWindow = isWindowOpen ? photoWindow : (hasSummited ? summitPhotoWindowRef.current : null);
+
+    if (activeWindow != null && sessionId != null) {
       try {
         const capturedAt = new Date().toISOString();
         const imageUrl = await uploadTrackingPhoto(result.assets[0].uri);
@@ -695,8 +698,8 @@ export default function TrackingScreen() {
         await savePhoto({
           sessionId,
           body: {
-            milestoneIndex: photoWindow.milestoneIndex,
-            milestoneDistanceM: photoWindow.milestoneDistance,
+            milestoneIndex: activeWindow.milestoneIndex,
+            milestoneDistanceM: activeWindow.milestoneDistance,
             imageUrl,
             capturedAt,
             lat: userLocation?.latitude ?? 0,
@@ -754,6 +757,7 @@ export default function TrackingScreen() {
     setSessionId(null);
     setHikingRecordId(null);
     setPhotoWindow(null);
+    summitPhotoWindowRef.current = null;
     setCollapsed(false);
     setRecordedCoords([]);
   };
@@ -935,7 +939,8 @@ export default function TrackingScreen() {
           {showSummitSheet ? (
             <SummitSheet
               onCertify={() => {
-                // 정상 인증 → 하산 시트로만 전환 (세션 완료는 기록 종료 시)
+                // 정상 인증 → 현재 photoWindow 저장 후 하산 시트로 전환
+                summitPhotoWindowRef.current = photoWindow;
                 setHasSummited(true);
                 setShowSummitSheet(false);
               }}

--- a/features/tracking/components/tracking-sheet.tsx
+++ b/features/tracking/components/tracking-sheet.tsx
@@ -12,6 +12,8 @@ type Props = {
   elapsedSeconds: number;
   isPaused: boolean;
   showTooltip: boolean;
+  /** 자유기록 모드 — true이면 토글 화살표·펼침 섹션 숨김 */
+  isFreeMode?: boolean;
   /** 사진 윈도우 열림 여부 — 열리면 툴팁 문구가 "사진 기록을 남겨보세요!"로 전환 */
   isPhotoWindowOpen: boolean;
   /** 정상 인증 후 true → 라벨이 "하산까지"로 전환 */
@@ -32,6 +34,7 @@ export function TrackingSheet({
   elapsedSeconds,
   isPaused,
   showTooltip,
+  isFreeMode = false,
   isPhotoWindowOpen,
   hasSummited,
   timeToTarget,
@@ -54,28 +57,32 @@ export function TrackingSheet({
       className="w-full bg-fill-normal overflow-hidden"
       style={{ borderTopLeftRadius: 20, borderTopRightRadius: 20, minHeight: 220 }}
     >
-      {/* 핸들 — 탭하면 펼침/접힘 */}
-      <TouchableOpacity
-        className="items-center pt-3 pb-1"
-        onPress={() => setIsExpanded((v) => !v)}
-        activeOpacity={0.7}
-      >
-        <Svg
-          width={23}
-          height={9}
-          viewBox="0 0 23 9"
-          fill="none"
-          style={{ transform: [{ rotate: isExpanded ? '180deg' : '0deg' }] }}
+      {/* 핸들 — 자유기록이 아닐 때만 표시 (탭하면 펼침/접힘) */}
+      {!isFreeMode ? (
+        <TouchableOpacity
+          className="items-center pt-3 pb-1"
+          onPress={() => setIsExpanded((v) => !v)}
+          activeOpacity={0.7}
         >
-          <Path
-            d="M21.5 1.49988L11.4972 7.50195L1.5 1.49988"
-            stroke="#D1D5DB"
-            strokeWidth={3}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </Svg>
-      </TouchableOpacity>
+          <Svg
+            width={23}
+            height={9}
+            viewBox="0 0 23 9"
+            fill="none"
+            style={{ transform: [{ rotate: isExpanded ? '180deg' : '0deg' }] }}
+          >
+            <Path
+              d="M21.5 1.49988L11.4972 7.50195L1.5 1.49988"
+              stroke="#D1D5DB"
+              strokeWidth={3}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </Svg>
+        </TouchableOpacity>
+      ) : (
+        <View className="pt-3 pb-1" />
+      )}
 
       {/* 등산 시간 + 타이머 */}
       <View className="items-center py-3">
@@ -85,8 +92,8 @@ export function TrackingSheet({
         </Text>
       </View>
 
-      {/* 펼침 상태 — 정상/하산까지 시간 & 거리 */}
-      {isExpanded && (
+      {/* 펼침 상태 — 정상/하산까지 시간 & 거리 (자유기록 제외) */}
+      {!isFreeMode && isExpanded && (
         <View className="border-t border-line-subtle flex-row">
           <View className="flex-1 items-center gap-1 py-5">
             <Text className="typo-caption-1-medium text-label-subtler">{timeLabel}</Text>

--- a/features/tracking/hooks/use-complete-tracking-session.ts
+++ b/features/tracking/hooks/use-complete-tracking-session.ts
@@ -1,14 +1,20 @@
 import { api } from '@/lib/api';
 import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ACTIVE_SESSION_KEY } from './use-active-tracking-session';
 
 export function useCompleteTrackingSession() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
       const res = await api.post<TrackingSessionResponse>({
         path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_COMPLETE(sessionId),
       });
       return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACTIVE_SESSION_KEY });
     },
   });
 }

--- a/features/tracking/hooks/use-pause-tracking-session.ts
+++ b/features/tracking/hooks/use-pause-tracking-session.ts
@@ -1,14 +1,20 @@
 import { api } from '@/lib/api';
 import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ACTIVE_SESSION_KEY } from './use-active-tracking-session';
 
 export function usePauseTrackingSession() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
       const res = await api.post<TrackingSessionResponse>({
         path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_PAUSE(sessionId),
       });
       return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACTIVE_SESSION_KEY });
     },
   });
 }

--- a/features/tracking/hooks/use-resume-tracking-session.ts
+++ b/features/tracking/hooks/use-resume-tracking-session.ts
@@ -1,14 +1,20 @@
 import { api } from '@/lib/api';
 import { ENDPOINTS, TrackingSessionResponse } from '@/types/api.generated';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ACTIVE_SESSION_KEY } from './use-active-tracking-session';
 
 export function useResumeTrackingSession() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
       const res = await api.post<TrackingSessionResponse>({
         path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_RESUME(sessionId),
       });
       return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACTIVE_SESSION_KEY });
     },
   });
 }

--- a/features/tracking/hooks/use-start-tracking-session.ts
+++ b/features/tracking/hooks/use-start-tracking-session.ts
@@ -4,9 +4,12 @@ import {
   CreateTrackingSessionRequest,
   TrackingSessionResponse,
 } from '@/types/api.generated';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ACTIVE_SESSION_KEY } from './use-active-tracking-session';
 
 export function useStartTrackingSession() {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: async (body: CreateTrackingSessionRequest): Promise<TrackingSessionResponse> => {
       const res = await api.post<TrackingSessionResponse>({
@@ -14,6 +17,9 @@ export function useStartTrackingSession() {
         body,
       });
       return res.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ACTIVE_SESSION_KEY });
     },
   });
 }

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -10,11 +10,22 @@ type Options = {
   onPhotoWindow: (payload: PhotoWindowPayload) => void;
 };
 
-type FcmData = { type?: string; distance?: string; extras?: string } | null;
+type FcmExtras = {
+  distance?: string | number;
+  milestoneIndex?: string | number;
+  [key: string]: unknown;
+};
+
+type FcmData = {
+  type?: string;
+  distance?: string;
+  milestoneIndex?: string;
+  extras?: string;
+} | null;
 
 /**
  * TRACKING_PHOTO_MILESTONE FCM 수신 처리.
- * - 포어그라운드: addNotificationReceivedListener → 인앱 배너
+ * - 포어그라운드: Firebase onMessage → 인앱 배너 + 로컬 알림
  * - 백그라운드/잠금화면에서 알림 탭: addNotificationResponseReceivedListener → 인앱 배너
  * Firebase SDK 충돌로 content.data가 null인 경우 trigger.payload에서 직접 읽음.
  */
@@ -22,16 +33,36 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
   useEffect(() => {
     if (!enabled) return;
 
+    const parseExtras = (data: FcmData): FcmExtras => {
+      if (!data?.extras) return {};
+      try {
+        return JSON.parse(data.extras) as FcmExtras;
+      } catch {
+        return {};
+      }
+    };
+
     const parseDistance = (data: FcmData): number => {
       if (!data) return 0;
-      if (data.extras) {
-        try {
-          const extras = JSON.parse(data.extras);
-          if (extras.distance != null) return Number(extras.distance);
-        } catch {}
-      }
+      const extras = parseExtras(data);
+      if (extras.distance != null) return Number(extras.distance);
       return parseFloat(data.distance ?? '0');
     };
+
+    const parseMilestoneIndex = (data: FcmData): number => {
+      if (!data) return 0;
+      const extras = parseExtras(data);
+      if (extras.milestoneIndex != null) return Number(extras.milestoneIndex);
+      if (data.milestoneIndex != null) return Number(data.milestoneIndex);
+      return 0;
+    };
+
+    const buildPayload = (data: FcmData): PhotoWindowPayload => ({
+      milestoneIndex: parseMilestoneIndex(data),
+      milestoneDistance: parseDistance(data),
+      status: 'OPEN',
+      openedAt: new Date().toISOString(),
+    });
 
     const extractPayload = (notification: Notifications.Notification) => {
       // content.data 우선, Firebase SDK 충돌로 null이면 trigger.payload에서 읽음
@@ -41,12 +72,7 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
 
       if (!data || data.type !== 'TRACKING_PHOTO_MILESTONE') return;
 
-      onPhotoWindow({
-        milestoneIndex: 0,
-        milestoneDistance: parseDistance(data),
-        status: 'OPEN',
-        openedAt: new Date().toISOString(),
-      });
+      onPhotoWindow(buildPayload(data));
     };
 
     // 포어그라운드 FCM 수신 — Firebase SDK가 expo-notifications보다 우선하므로 onMessage 사용
@@ -56,26 +82,21 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
       const data = remoteMessage.data as FcmData;
       if (!data || data.type !== 'TRACKING_PHOTO_MILESTONE') return;
 
-      const distance = parseDistance(data);
+      const payload = buildPayload(data);
+      console.log('[TrackingFCM] milestoneIndex:', payload.milestoneIndex, 'distance:', payload.milestoneDistance);
 
       // 인앱 PhotoWindowBanner 활성화
-      onPhotoWindow({
-        milestoneIndex: 0,
-        milestoneDistance: distance,
-        status: 'OPEN',
-        openedAt: new Date().toISOString(),
-      });
+      onPhotoWindow(payload);
 
       // 포어그라운드 시스템 배너 수동 표시 (Firebase SDK가 자동 표시 안 함)
       try {
-        const notifId = await Notifications.scheduleNotificationAsync({
+        await Notifications.scheduleNotificationAsync({
           content: {
             title: 'SEMOSAN',
-            body: `${distance}m 돌파! 인증 사진을 남겨보세요!`,
+            body: `${payload.milestoneDistance}m 돌파! 인증 사진을 남겨보세요!`,
           },
           trigger: null,
         });
-        console.log('[TrackingFCM] 로컬 알림 예약 완료 id:', notifId);
       } catch (err) {
         console.warn('[TrackingFCM] 로컬 알림 예약 실패:', err);
       }

--- a/features/tracking/utils/upload-tracking-photo.ts
+++ b/features/tracking/utils/upload-tracking-photo.ts
@@ -9,7 +9,7 @@ type PresignedUrlResponse = {
 /**
  * 트래킹 인증 사진을 tracking-photos 버킷에 업로드합니다.
  * 1. Presigned URL 발급 (GET /api/images/presigned-url?bucket=tracking-photos)
- * 2. uploadUrl로 MinIO에 직접 PUT (Authorization 헤더 없음)
+ * 2. uri → blob 변환 후 uploadUrl로 MinIO에 직접 PUT
  * @returns 업로드된 이미지의 최종 URL
  */
 export async function uploadTrackingPhoto(uri: string): Promise<string> {
@@ -22,18 +22,20 @@ export async function uploadTrackingPhoto(uri: string): Promise<string> {
     params: { bucket: 'tracking-photos', filename },
   });
 
-  // 2. MinIO에 직접 PUT (서명된 URL이므로 Authorization 헤더 불필요)
-  await new Promise<void>((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open('PUT', data.uploadUrl);
-    xhr.setRequestHeader('Content-Type', 'image/jpeg');
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) resolve();
-      else reject(new Error(`이미지 업로드 실패: ${xhr.status}`));
-    };
-    xhr.onerror = () => reject(new Error('네트워크 오류'));
-    xhr.send({ uri, type: 'image/jpeg', name: filename } as any);
+  // 2. uri → blob 변환 (React Native에서 file:// URI를 바이너리로 읽음)
+  const fileResponse = await fetch(uri);
+  const blob = await fileResponse.blob();
+
+  // 3. MinIO에 직접 PUT (Presigned URL이므로 Authorization 헤더 불필요)
+  const uploadResponse = await fetch(data.uploadUrl, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'image/jpeg' },
+    body: blob,
   });
+
+  if (!uploadResponse.ok) {
+    throw new Error(`이미지 업로드 실패: ${uploadResponse.status}`);
+  }
 
   return data.imageUrl;
 }


### PR DESCRIPTION
## 요약

- 인근 산 조회 하드코딩 제거 → 실제 GPS 위치 기반 `/api/tracking/nearby-mountain` API 사용
- 정상 인증 후 카메라 버튼 클릭 시 사진 메타 업로드 안 되는 버그 수정 (`summitPhotoWindowRef` 도입)
- FCM `milestoneIndex` 항상 0으로 고정되던 버그 수정 → FCM 페이로드에서 실제 값 파싱
- 정상까지 프로그레스바 정상 인증 후 고정(100%) 처리
- 자유기록에서 코스 카드 및 프로그레스바 제거
- 세션 뮤테이션(start/pause/resume/complete) 후 `invalidateQueries` 누락 추가
- 정상까지/하산까지 남은 시간·거리를 Haversine 실측 거리 기반 실시간 반영으로 개선

## 변경 파일

- `app/(tabs)/tracking.tsx` — 인근 산 실제 API 연동, summitPhotoWindowRef, 프로그레스바 로직, 자유기록 UI 조건 처리, 남은 거리·시간 실시간 계산
- `features/tracking/hooks/use-tracking-fcm.ts` — milestoneIndex 파싱 로직 추가
- `features/tracking/hooks/use-start-tracking-session.ts` — onSuccess invalidateQueries 추가
- `features/tracking/hooks/use-pause-tracking-session.ts` — onSuccess invalidateQueries 추가
- `features/tracking/hooks/use-resume-tracking-session.ts` — onSuccess invalidateQueries 추가
- `features/tracking/hooks/use-complete-tracking-session.ts` — onSuccess invalidateQueries 추가
- `features/tracking/components/tracking-sheet.tsx` — isFreeMode prop 추가, 자유기록 시 토글 화살표 숨김

## 테스트 체크리스트

- [ ] 현재 위치 기반 인근 산·코스 정상 조회되는지 확인
- [ ] 코스 따라가기 → 정상 인증 → 카메라 버튼 → 사진 업로드 및 메타 저장 확인
- [ ] FCM 알림 수신 시 milestoneIndex가 올바른 값으로 들어오는지 확인
- [ ] 정상 인증 후 프로그레스바 상단 고정 확인
- [ ] 자유기록 모드에서 코스 카드·프로그레스바·토글 화살표 미표시 확인
- [ ] 일시정지/재개/종료 후 세션 상태 정상 갱신 확인
- [ ] 코스 따라가기 중 정상까지/하산까지 남은 거리·시간 실시간 변경 확인