### PR TITLE
feat : 피드 홈 리패치 버튼 추가

### DIFF
--- a/components/icons/reset-icon.tsx
+++ b/components/icons/reset-icon.tsx
@@ -1,17 +1,22 @@
 import Svg, { Path } from "react-native-svg";
 
-export function ResetIcon(): React.JSX.Element {
+type ResetIconProps = {
+  size?: number;
+  color?: string;
+};
+
+export function ResetIcon({ size = 14, color = "#1A1B1F" }: ResetIconProps): React.JSX.Element {
   return (
-    <Svg width={14} height={14} viewBox="0 0 16 16" fill="none">
+    <Svg width={size} height={size} viewBox="0 0 16 16" fill="none">
       <Path
         d="M2 8C2 11.3137 4.68629 14 8 14C11.3137 14 14 11.3137 14 8C14 4.68629 11.3137 2 8 2C5.92286 2 4.07719 3.05771 3 4.66667"
-        stroke="#1A1B1F"
+        stroke={color}
         strokeWidth="1.5"
         strokeLinecap="round"
       />
       <Path
         d="M3 2V5H6"
-        stroke="#1A1B1F"
+        stroke={color}
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -1,5 +1,4 @@
 import { ResetIcon } from "@/components/icons/reset-icon";
-import { refresh } from "@react-native-community/netinfo";
 import { Image } from "expo-image";
 import { useRef, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
@@ -9,6 +8,7 @@ import Animated, {
   useAnimatedStyle,
   useSharedValue,
   withDecay,
+  withSpring,
 } from "react-native-reanimated";
 import { scheduleOnRN } from "react-native-worklets";
 import { FEED_SLIDE_UP_DISTANCE } from "../constants";
@@ -61,6 +61,9 @@ export function FeedHomeView() {
   // 제스처 시작 시점의 누적값 (Pan은 매번 0부터 시작하므로)
   const savedX = useSharedValue(0);
   const savedY = useSharedValue(0);
+
+  // 초기 중심 위치 저장 (리셋 버튼용)
+  const initPosRef = useRef({ x: 0, y: 0 });
 
   // rAF 스로틀용
   const rafRef = useRef<number | null>(null);
@@ -173,6 +176,7 @@ export function FeedHomeView() {
             // 셀(0,0) 중심의 그리드 좌표 = CELL_GAP/2 + CELL_CONTENT_W/2 = CELL_W/2
             const initX = width / 2 - CELL_W / 2;
             const initY = height / 2 - CELL_H / 2 + FEED_SLIDE_UP_DISTANCE / 2;
+            initPosRef.current = { x: initX, y: initY };
             translateX.value = initX;
             translateY.value = initY;
             savedX.value = initX;
@@ -197,7 +201,12 @@ export function FeedHomeView() {
         className="absolute bottom-3 right-3 items-center justify-center rounded-full bg-label-normal px-4 py-[13px]"
         style={{ boxShadow: "0px 2px 4px 0px rgba(0, 0, 0, 0.1)" }}
         hitSlop={8}
-        onPress={refresh}
+        onPress={() => {
+          refetch();
+          const { x, y } = initPosRef.current;
+          translateX.value = withSpring(x);
+          translateY.value = withSpring(y);
+        }}
       >
         <ResetIcon size={24} color="#ffffff" />
       </Pressable>

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -1,6 +1,8 @@
+import { ResetIcon } from "@/components/icons/reset-icon";
+import { refresh } from "@react-native-community/netinfo";
 import { Image } from "expo-image";
 import { useRef, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
   useAnimatedReaction,
@@ -39,7 +41,7 @@ const OVERSCAN = 1; // 화면 밖 여유분 (셀 단위)
 // 메인 그리드
 // ─────────────────────────────────────────────
 export function FeedHomeView() {
-  const { data: semofeedData } = useSemofeed();
+  const { data: semofeedData, refetch } = useSemofeed();
 
   const feedItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
 
@@ -190,6 +192,15 @@ export function FeedHomeView() {
           </Animated.View>
         </View>
       </GestureDetector>
+
+      <Pressable
+        className="absolute bottom-3 right-3 items-center justify-center rounded-full bg-label-normal px-4 py-[13px]"
+        style={{ boxShadow: "0px 2px 4px 0px rgba(0, 0, 0, 0.1)" }}
+        hitSlop={8}
+        onPress={refresh}
+      >
+        <ResetIcon size={24} color="#ffffff" />
+      </Pressable>
 
       {selectedImageUri !== null && (
         <FeedCellDetail


### PR DESCRIPTION
## Summary
- `FeedHomeView` 우측 하단에 리패치 버튼 추가 (Figma 디자인 반영)
- 버튼 누르면 데이터 refetch + `withSpring`으로 (0,0) 셀 중심으로 부드럽게 복귀
- `ResetIcon`에 `size`, `color` prop 추가

## Test plan
- [ ] 피드 화면에서 그리드를 드래그해 이동 후 리패치 버튼 탭 → (0,0) 중심으로 복귀 확인
- [ ] 버튼 UI (우측 하단 다크 원형 버튼, 흰색 아이콘) 디자인 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)