### PR TITLE
fix: 다녀온 산 카드 썸네일 및 바텀시트 개선

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -9,7 +9,7 @@ import Svg, {
   Image as SvgImage,
 } from "react-native-svg";
 import { LinearGradient } from "expo-linear-gradient";
-import { Image as ExpoImage } from "expo-image";
+import { Image as ExpoImage, Image } from "expo-image";
 import * as MediaLibrary from "expo-media-library";
 import {
   ScrollView,
@@ -138,9 +138,11 @@ export default function RecordScreen() {
     }, [])
   );
 
-  // 클라이브 사진 로드 후 포토리포트 기본 사진 = 마지막 사진(정상)
+  // 클라이브 사진 프리페치 + 포토리포트 기본 사진 = 마지막 사진(정상)
   useEffect(() => {
-    if (clivePhotos.length > 0 && photoReportSource === null) {
+    if (clivePhotos.length === 0) return;
+    clivePhotos.forEach((url) => Image.prefetch(url));
+    if (photoReportSource === null) {
       setPhotoReportSource({ uri: clivePhotos[clivePhotos.length - 1] });
     }
   }, [clivePhotos]);

--- a/components/bottom-sheet-shell.tsx
+++ b/components/bottom-sheet-shell.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView } from 'react-native-gesture-handler';
+import { Text, View } from 'react-native';
 
 type Props = {
   title: string;

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -1,4 +1,5 @@
 import { useMyMountainRecords } from '@/features/home/hooks/use-my-mountain-records';
+import { useClivePhotos } from '@/features/tracking/hooks/use-clive-photos';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
@@ -11,11 +12,11 @@ export type Tab = '내 기록' | '큐레이션';
 
 type MountainCard = {
   id: string;
+  mountainId: number;
   name: string;
   trailNumber: number;
   daysAgo: number;
   badgeCount: number;
-  imageUri?: string;
 };
 
 type Props = {
@@ -34,10 +35,10 @@ type Props = {
 const TABS: Tab[] = ['내 기록', '큐레이션'];
 
 const MOCK_CARDS: MountainCard[] = [
-  { id: '1', name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '2', name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '3', name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '4', name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
+  { id: '1', mountainId: 1, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
+  { id: '2', mountainId: 2, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
+  { id: '3', mountainId: 3, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
+  { id: '4', mountainId: 4, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
 ];
 
 export default function BottomSheet({
@@ -104,7 +105,7 @@ export default function BottomSheet({
                   hikingRecordId: String(record?.hikingRecordId ?? ''),
                   name: selectedCard.name,
                   courseName: record?.courseName ?? '',
-                  imageUri: selectedCard.imageUri ?? '',
+                  imageUri: '',
                   distance: String(record?.distance ?? ''),
                   duration: String(record?.duration ?? ''),
                 },
@@ -175,21 +176,42 @@ export default function BottomSheet({
   );
 }
 
+function MountainCardThumbnail({ mountainId }: { mountainId: number }) {
+  const { data: records = [] } = useMyMountainRecords(mountainId);
+  const latestSessionId = records[0]?.sessionId ?? null;
+  const { data: photos = [] } = useClivePhotos(latestSessionId);
+
+  const mainPhoto = photos[photos.length - 1];
+  const bgPhoto = photos[photos.length - 2];
+
+  return (
+    <>
+      {bgPhoto ? (
+        <Image
+          source={{ uri: bgPhoto }}
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          resizeMode="cover"
+        />
+      ) : null}
+      {mainPhoto ? (
+        <Image
+          source={{ uri: mainPhoto }}
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          resizeMode="cover"
+        />
+      ) : (
+        <View className="absolute inset-0 bg-fill-stronger items-center justify-center" />
+      )}
+    </>
+  );
+}
+
 function MountainCard({ card, onPress }: { card: MountainCard; onPress: () => void }) {
   return (
     <TouchableOpacity className="flex-1 gap-1" onPress={onPress}>
       {/* 이미지 */}
       <View className="self-stretch h-[88px] rounded-[10px] overflow-hidden flex-col items-end p-2 gap-2.5">
-        {card.imageUri ? (
-          <Image
-            source={{ uri: card.imageUri }}
-            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
-            resizeMode="cover"
-          />
-        ) : (
-          <View className="absolute inset-0 bg-fill-stronger items-center justify-center">
-          </View>
-        )}
+        <MountainCardThumbnail mountainId={card.mountainId} />
         {/* 뱃지 */}
         <View className="w-7 h-7 rounded-full bg-label-normal items-center justify-center z-10">
           <Text className="typo-body-3-semi-bold text-common-100 text-center">{card.badgeCount}</Text>

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -178,7 +178,10 @@ export default function BottomSheet({
 
 function MountainCardThumbnail({ mountainId }: { mountainId: number }) {
   const { data: records = [] } = useMyMountainRecords(mountainId);
-  const latestSessionId = records[0]?.sessionId ?? null;
+  const sorted = [...records].sort((a, b) =>
+    new Date(b.hikedAt ?? 0).getTime() - new Date(a.hikedAt ?? 0).getTime()
+  );
+  const latestSessionId = sorted[0]?.sessionId ?? null;
   const { data: photos = [] } = useClivePhotos(latestSessionId);
 
   const mainPhoto = photos[photos.length - 1];

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -119,16 +119,16 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     }));
 
     const myMountainImageMap = Object.fromEntries(
-      myMountains.map((m) => [m.mountainId, m.imageUrl])
+      myMountains.map((m) => [m.mountainId, m.imageUrls?.[0]])
     );
 
     const visitedCards = myMountains.map((m) => ({
       id: String(m.mountainId),
+      mountainId: m.mountainId ?? 0,
       name: m.mountainName ?? "",
       trailNumber: m.hikingCount ?? 1,
       daysAgo: getDaysAgo(m.lastHikedAt),
       badgeCount: m.hikingCount ?? 1,
-      imageUri: m.imageUrl,
     }));
 
     return (

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -690,7 +690,7 @@ export type ApiResponsePageResponseGetUserHikingMountainRecordResponse = {
 export type GetUserHikingMountainRecordResponse = {
   mountainId?: number;
   mountainName?: string;
-  imageUrl?: string;
+  imageUrls?: string[];
   hikingCount?: number;
   lastHikedAt?: string;
 };


### PR DESCRIPTION
# **Summary**
- 다녀온 산 카드 썸네일을 트래킹 실제 사진으로 변경
- 홈 바텀시트 스크롤 안 되는 문제 수정
- 클라이브 사진 로딩 속도 개선

# **Changes**
산 카드 썸네일 개선 (components/bottom-sheet.tsx, features/home/components/map-home-view.tsx)
  - 각 카드에서 useMyMountainRecords → useClivePhotos 순으로 fetch
  - hikedAt 기준 최신 세션의 마지막 사진을 대표 썸네일, 두 번째 마지막 사진을 배경 썸네일로 사용

바텀시트 스크롤 수정 (components/bottom-sheet-shell.tsx)
  - react-native ScrollView → react-native-gesture-handler ScrollView 교체로 pan 제스처 충돌 해결

클라이브 사진 프리페치 (app/record/[id].tsx)
  - 사진 URL 로드 즉시 expo-image prefetch 호출로 SvgImage 렌더 시 캐시 히트 → 로딩 속도 개선