### PR TITLE
fix/home-qa : 홈 화면 QA 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,10 @@
 {
+  "semi": true,
+  "singleQuote": false,
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "printWidth": 80,
+  "endOfLine": "lf",
   "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1220,7 +1220,9 @@ export default function TrackingScreen() {
 
       {/* 난이도 체감 모달 */}
       <DifficultyRatingModal
-        mountainId={nearbyData?.mountain?.mountainId}
+        mountainId={
+          mountainIdParameter ? Number(mountainIdParameter) : undefined
+        }
         visible={showDifficultyRating}
         course={selectedCourse}
         mountainName={nearbyData?.mountain?.name ?? ""}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1221,7 +1221,9 @@ export default function TrackingScreen() {
       {/* 난이도 체감 모달 */}
       <DifficultyRatingModal
         mountainId={
-          mountainIdParameter ? Number(mountainIdParameter) : undefined
+          mountainIdParameter
+            ? Number(mountainIdParameter)
+            : nearbyData?.mountain?.mountainId
         }
         visible={showDifficultyRating}
         course={selectedCourse}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1,6 +1,7 @@
-import * as Sentry from "@sentry/react-native";
 import { LocationIcon } from "@/components/icons/location-icon";
+import { PinMarkerIcon } from "@/components/icons/pin-marker-icon";
 import { isLiveActivityEnabled } from "@/constants/platform";
+import { useProfile } from "@/features/mypage/hooks/use-profile";
 import { CollapsedCourseCard } from "@/features/tracking/components/collapsed-course-card";
 import { CountdownOverlay } from "@/features/tracking/components/countdown-overlay";
 import { CourseSelectSheet } from "@/features/tracking/components/course-select-sheet";
@@ -12,7 +13,6 @@ import { SummitSheet } from "@/features/tracking/components/summit-sheet";
 import { TrackingCourseCard } from "@/features/tracking/components/tracking-course-card";
 import { TrackingSheet } from "@/features/tracking/components/tracking-sheet";
 import { TrailAvatarMarker } from "@/features/tracking/components/trail-avatar-marker";
-import { PinMarkerIcon } from "@/components/icons/pin-marker-icon";
 import {
   COLLAPSED_PEEK_HEIGHT,
   Course,
@@ -33,29 +33,31 @@ import {
 import { useActiveTrackingSession } from "@/features/tracking/hooks/use-active-tracking-session";
 import { useCompleteTrackingSession } from "@/features/tracking/hooks/use-complete-tracking-session";
 import { useCourseDetail } from "@/features/tracking/hooks/use-course-detail";
+import { useLiveActivityCourse } from "@/features/tracking/hooks/use-live-activity-course";
 import { useNearbyMountain } from "@/features/tracking/hooks/use-nearby-mountain";
-import { useProfile } from "@/features/mypage/hooks/use-profile";
 import { usePauseTrackingSession } from "@/features/tracking/hooks/use-pause-tracking-session";
 import { useResumeTrackingSession } from "@/features/tracking/hooks/use-resume-tracking-session";
+import { useSaveDifficultyFeedback } from "@/features/tracking/hooks/use-save-difficulty-feedback";
 import { useSaveTrackingPhoto } from "@/features/tracking/hooks/use-save-tracking-photo";
 import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tracking-session";
-import { useSaveDifficultyFeedback } from "@/features/tracking/hooks/use-save-difficulty-feedback";
 import { useTrackingFcm } from "@/features/tracking/hooks/use-tracking-fcm";
 import {
   PhotoWindowPayload,
   useTrackingSocket,
 } from "@/features/tracking/hooks/use-tracking-socket";
-import { parseCoursePolyline } from "@/features/tracking/utils/parse-course-polyline";
+import { calcCourseProgress } from "@/features/tracking/modules/course-progress";
 import {
   setLocationTaskCallback,
   startLocationTask,
   stopLocationTask,
 } from "@/features/tracking/tasks/location-task";
+import { parseCoursePolyline } from "@/features/tracking/utils/parse-course-polyline";
 import { uploadTrackingPhoto } from "@/features/tracking/utils/upload-tracking-photo";
-import { LiveActivity, addLiveActivityControlListener } from "@/modules/live-activity";
-import { useLiveActivityCourse } from "@/features/tracking/hooks/use-live-activity-course";
-import { calcCourseProgress } from "@/features/tracking/modules/course-progress";
 import { useAppState } from "@/hooks/use-app-state";
+import {
+  LiveActivity,
+  addLiveActivityControlListener,
+} from "@/modules/live-activity";
 import {
   NaverMapMarkerOverlay,
   NaverMapPathOverlay,
@@ -63,7 +65,7 @@ import {
   type NaverMapViewRef,
 } from "@mj-studio/react-native-naver-map";
 import { useFocusEffect } from "@react-navigation/native";
-import { Circle, Path, Svg } from "react-native-svg";
+import * as Sentry from "@sentry/react-native";
 import * as ImagePicker from "expo-image-picker";
 import { LinearGradient } from "expo-linear-gradient";
 import * as Location from "expo-location";
@@ -75,20 +77,24 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { Circle, Path, Svg } from "react-native-svg";
 
 const DIFFICULTY_KO: Record<string, Difficulty> = {
-  EASY: '초급',
-  NORMAL: '중급',
-  HARD: '고급',
+  EASY: "초급",
+  NORMAL: "중급",
+  HARD: "고급",
 };
 
 export default function TrackingScreen() {
-  const { collapse: collapseParameter, courseId: courseIdParameter, mountainId: mountainIdParameter } =
-    useLocalSearchParams<{
-      collapse?: string;
-      courseId?: string;
-      mountainId?: string;
-    }>();
+  const {
+    collapse: collapseParameter,
+    courseId: courseIdParameter,
+    mountainId: mountainIdParameter,
+  } = useLocalSearchParams<{
+    collapse?: string;
+    courseId?: string;
+    mountainId?: string;
+  }>();
   const [selectedCourseId, setSelectedCourseId] = useState<string | null>(
     courseIdParameter ?? null,
   );
@@ -110,7 +116,9 @@ export default function TrackingScreen() {
   const [sessionId, setSessionId] = useState<number | null>(null);
   const [hikingRecordId, setHikingRecordId] = useState<number | null>(null);
   const [hasSummited, setHasSummited] = useState(false);
-  const [photoWindow, setPhotoWindow] = useState<PhotoWindowPayload | null>(null);
+  const [photoWindow, setPhotoWindow] = useState<PhotoWindowPayload | null>(
+    null,
+  );
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
@@ -131,12 +139,19 @@ export default function TrackingScreen() {
     longitude: number;
   } | null>(null);
   // 자유기록 실시간 경로 누적 (회색 polyline)
-  const [recordedCoords, setRecordedCoords] = useState<{ latitude: number; longitude: number }[]>([]);
+  const [recordedCoords, setRecordedCoords] = useState<
+    { latitude: number; longitude: number }[]
+  >([]);
   const backgroundedAtRef = useRef<number | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
   const isMountedRef = useRef(true);
-  useEffect(() => () => { isMountedRef.current = false; }, []);
+  useEffect(
+    () => () => {
+      isMountedRef.current = false;
+    },
+    [],
+  );
 
   useEffect(() => {
     if (courseIdParameter) setSelectedCourseId(courseIdParameter);
@@ -232,18 +247,22 @@ export default function TrackingScreen() {
       connectSocket(activeSession.sessionId);
       // GPS 추적 재시작 — 백그라운드 포함
       const sid = activeSession.sessionId;
-      setLocationTaskCallback(({ latitude, longitude, altitude, timestamp }) => {
-        setUserLocation({ latitude, longitude, altitude });
-        setMarkerCoord({ latitude, longitude });
-        setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
-        publishGps(sid, {
-          lat: latitude,
-          lng: longitude,
-          altitude,
-          recordedAt: new Date(timestamp).toISOString(),
-        });
-      });
-      startLocationTask().catch((err) => console.warn("[Location] 백그라운드 위치 재시작 실패:", err));
+      setLocationTaskCallback(
+        ({ latitude, longitude, altitude, timestamp }) => {
+          setUserLocation({ latitude, longitude, altitude });
+          setMarkerCoord({ latitude, longitude });
+          setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
+          publishGps(sid, {
+            lat: latitude,
+            lng: longitude,
+            altitude,
+            recordedAt: new Date(timestamp).toISOString(),
+          });
+        },
+      );
+      startLocationTask().catch((err) =>
+        console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
+      );
       setElapsedSeconds(0);
     }
   }, [activeSession]);
@@ -251,8 +270,12 @@ export default function TrackingScreen() {
   const selectedCourseId_num = selectedCourseId
     ? Number(selectedCourseId)
     : null;
-  const { data: courseDetail } = useCourseDetail(isFreeMode ? null : selectedCourseId_num);
-  const { data: liveActivityCourse } = useLiveActivityCourse(isFreeMode ? null : selectedCourseId);
+  const { data: courseDetail } = useCourseDetail(
+    isFreeMode ? null : selectedCourseId_num,
+  );
+  const { data: liveActivityCourse } = useLiveActivityCourse(
+    isFreeMode ? null : selectedCourseId,
+  );
   const courseCoords = useMemo(
     () => parseCoursePolyline(courseDetail?.polyline),
     [courseDetail?.polyline],
@@ -265,22 +288,30 @@ export default function TrackingScreen() {
   // 코스 진행 상태 — GPS 기반 실시간 (markerRatio + 남은 거리/시간 통합)
   const courseProgressState = useMemo(() => {
     // ── 1순위: liveActivityCourse + Haversine 실측 거리 계산 ──────────────
-    if (liveActivityCourse && userLocation && liveActivityCourse.totalDistance > 0) {
+    if (
+      liveActivityCourse &&
+      userLocation &&
+      liveActivityCourse.totalDistance > 0
+    ) {
       const result = calcCourseProgress(
         userLocation,
         liveActivityCourse.coordinates,
         liveActivityCourse.totalDistance,
       );
       // 분/m 페이스 (전체 코스 기준 일정 속도 가정)
-      const paceMinPerM = liveActivityCourse.estimatedTime / liveActivityCourse.totalDistance;
-      const traveledM = liveActivityCourse.totalDistance - result.remainingMeters;
+      const paceMinPerM =
+        liveActivityCourse.estimatedTime / liveActivityCourse.totalDistance;
+      const traveledM =
+        liveActivityCourse.totalDistance - result.remainingMeters;
 
       if (hasSummited) {
         // 하산 중: 코스 끝까지 남은 거리/시간
         return {
           markerRatio: 0.0,
           remainingDistanceM: Math.round(result.remainingMeters),
-          remainingDurationMin: Math.round(result.remainingMeters * paceMinPerM),
+          remainingDurationMin: Math.round(
+            result.remainingMeters * paceMinPerM,
+          ),
         };
       }
 
@@ -301,7 +332,11 @@ export default function TrackingScreen() {
 
     if (hasSummited) {
       if (!markerCoord || courseCoords.length < 2) {
-        return { markerRatio: 0.0, remainingDistanceM: halfDistanceM, remainingDurationMin: halfDurationMinutes };
+        return {
+          markerRatio: 0.0,
+          remainingDistanceM: halfDistanceM,
+          remainingDurationMin: halfDurationMinutes,
+        };
       }
       let closestIdx = summitIdx;
       let minDist = Infinity;
@@ -309,12 +344,19 @@ export default function TrackingScreen() {
         const dLat = courseCoords[i].latitude - markerCoord.latitude;
         const dLng = courseCoords[i].longitude - markerCoord.longitude;
         const dist = dLat * dLat + dLng * dLng;
-        if (dist < minDist) { minDist = dist; closestIdx = i; }
+        if (dist < minDist) {
+          minDist = dist;
+          closestIdx = i;
+        }
       }
       const descentTotal = totalIdx - summitIdx;
-      const ratio = descentTotal > 0
-        ? Math.max(0, Math.min(1, 1 - (closestIdx - summitIdx) / descentTotal))
-        : 0;
+      const ratio =
+        descentTotal > 0
+          ? Math.max(
+              0,
+              Math.min(1, 1 - (closestIdx - summitIdx) / descentTotal),
+            )
+          : 0;
       return {
         markerRatio: 0.0,
         remainingDistanceM: Math.round(halfDistanceM * ratio),
@@ -323,7 +365,11 @@ export default function TrackingScreen() {
     }
 
     if (!markerCoord || courseCoords.length < 2) {
-      return { markerRatio: 1.0, remainingDistanceM: halfDistanceM, remainingDurationMin: halfDurationMinutes };
+      return {
+        markerRatio: 1.0,
+        remainingDistanceM: halfDistanceM,
+        remainingDurationMin: halfDurationMinutes,
+      };
     }
 
     let closestIdx = 0;
@@ -332,7 +378,10 @@ export default function TrackingScreen() {
       const dLat = courseCoords[i].latitude - markerCoord.latitude;
       const dLng = courseCoords[i].longitude - markerCoord.longitude;
       const dist = dLat * dLat + dLng * dLng;
-      if (dist < minDist) { minDist = dist; closestIdx = i; }
+      if (dist < minDist) {
+        minDist = dist;
+        closestIdx = i;
+      }
     }
     const progress = summitIdx > 0 ? closestIdx / summitIdx : 0;
     const remaining = Math.max(0, 1 - progress);
@@ -341,143 +390,183 @@ export default function TrackingScreen() {
       remainingDistanceM: Math.round(halfDistanceM * remaining),
       remainingDurationMin: Math.round(halfDurationMinutes * remaining),
     };
-  }, [markerCoord, courseCoords, hasSummited, halfDistanceM, halfDurationMinutes, liveActivityCourse, userLocation]);
+  }, [
+    markerCoord,
+    courseCoords,
+    hasSummited,
+    halfDistanceM,
+    halfDurationMinutes,
+    liveActivityCourse,
+    userLocation,
+  ]);
 
-  const { markerRatio, remainingDistanceM, remainingDurationMin } = courseProgressState;
+  const { markerRatio, remainingDistanceM, remainingDurationMin } =
+    courseProgressState;
 
   // altitudes 문자열에서 최고 고도(m) 파싱
   const peakAltitudeM = useMemo(() => {
     const raw = courseDetail?.altitudes;
-    console.log('[Altitudes] raw type:', typeof raw, 'isArray:', Array.isArray(raw), 'value:', raw == null ? 'NULL' : String(raw).slice(0, 50));
+    console.log(
+      "[Altitudes] raw type:",
+      typeof raw,
+      "isArray:",
+      Array.isArray(raw),
+      "value:",
+      raw == null ? "NULL" : String(raw).slice(0, 50),
+    );
     if (!raw) return null;
     try {
       const values: number[] = Array.isArray(raw)
         ? (raw as number[]).filter((n) => !isNaN(n) && n > 0)
-        : String(raw).replace(/^\[|\]$/g, '').split(',').map(Number).filter((n) => !isNaN(n) && n > 0);
-      console.log('[Altitudes] values.length:', values.length, 'max:', values.length > 0 ? Math.max(...values) : 'N/A');
+        : String(raw)
+            .replace(/^\[|\]$/g, "")
+            .split(",")
+            .map(Number)
+            .filter((n) => !isNaN(n) && n > 0);
+      console.log(
+        "[Altitudes] values.length:",
+        values.length,
+        "max:",
+        values.length > 0 ? Math.max(...values) : "N/A",
+      );
       if (values.length > 0) return Math.round(Math.max(...values));
     } catch (e) {
-      console.warn('[Altitudes] 파싱 실패:', e);
+      console.warn("[Altitudes] 파싱 실패:", e);
     }
     return null;
   }, [courseDetail?.altitudes]);
 
-  const selectedCourse = useMemo((): Course => ({
-    id: String(courseDetail?.id ?? ''),
-    name: courseDetail?.name ?? '',
-    difficulty: DIFFICULTY_KO[courseDetail?.difficulty ?? ''] ?? '중급',
-    altitudeNm: peakAltitudeM,
-    distanceKm: Math.round((courseDetail?.distance ?? 0) / 100) / 10,
-    summitDistanceM: halfDistanceM,
-    descentDistanceM: halfDistanceM,
-    durationHours: Math.floor((courseDetail?.duration ?? 0) / 60),
-    durationMinutes: (courseDetail?.duration ?? 0) % 60,
-    coordinates: [],
-    centerLatitude: 0,
-    centerLongitude: 0,
-    zoom: 14,
-  }), [courseDetail, peakAltitudeM, halfDistanceM]);
+  const selectedCourse = useMemo(
+    (): Course => ({
+      id: String(courseDetail?.id ?? ""),
+      name: courseDetail?.name ?? "",
+      difficulty: DIFFICULTY_KO[courseDetail?.difficulty ?? ""] ?? "중급",
+      altitudeNm: peakAltitudeM,
+      distanceKm: Math.round((courseDetail?.distance ?? 0) / 100) / 10,
+      summitDistanceM: halfDistanceM,
+      descentDistanceM: halfDistanceM,
+      durationHours: Math.floor((courseDetail?.duration ?? 0) / 60),
+      durationMinutes: (courseDetail?.duration ?? 0) % 60,
+      coordinates: [],
+      centerLatitude: 0,
+      centerLongitude: 0,
+      zoom: 14,
+    }),
+    [courseDetail, peakAltitudeM, halfDistanceM],
+  );
 
-  const timeToTarget = remainingDurationMin > 0
-    ? `${Math.floor(remainingDurationMin / 60) > 0 ? `${Math.floor(remainingDurationMin / 60)}h ` : ''}${remainingDurationMin % 60 > 0 ? `${remainingDurationMin % 60}m` : ''}`
-    : '-';
-  const distanceToTarget = remainingDistanceM >= 1000
-    ? `${(remainingDistanceM / 1000).toFixed(1)}km`
-    : remainingDistanceM > 0 ? `${remainingDistanceM}m` : '-';
+  const timeToTarget =
+    remainingDurationMin > 0
+      ? `${Math.floor(remainingDurationMin / 60) > 0 ? `${Math.floor(remainingDurationMin / 60)}h ` : ""}${remainingDurationMin % 60 > 0 ? `${remainingDurationMin % 60}m` : ""}`
+      : "-";
+  const distanceToTarget =
+    remainingDistanceM >= 1000
+      ? `${(remainingDistanceM / 1000).toFixed(1)}km`
+      : remainingDistanceM > 0
+        ? `${remainingDistanceM}m`
+        : "-";
 
   // 정적 맵 오버레이 — markerCoord 변경 시 리렌더 방지
-  const staticMapOverlays = useMemo(() => (
-    <>
-      {/* 코스 경로 — API polyline */}
-      {courseCoords.length > 1 && (
-        <>
-          <NaverMapPathOverlay
-            coords={courseCoords}
-            width={6}
-            color="#ffd40d"
-            outlineWidth={1}
-            outlineColor="#eab308"
-          />
-          <NaverMapMarkerOverlay
-            latitude={courseCoords[0].latitude}
-            longitude={courseCoords[0].longitude}
-            width={34}
-            height={45}
-            anchor={{ x: 0.5, y: 1 }}
-          >
-            <PinMarkerIcon fill="#507EF4" stroke="#2563EB" label="출발" />
-          </NaverMapMarkerOverlay>
-          <NaverMapMarkerOverlay
-            latitude={courseCoords[courseCoords.length - 1].latitude}
-            longitude={courseCoords[courseCoords.length - 1].longitude}
-            width={34}
-            height={45}
-            anchor={{ x: 0.5, y: 1 }}
-          >
-            <PinMarkerIcon fill="#FF5249" stroke="#DC2626" label="도착" />
-          </NaverMapMarkerOverlay>
-          {/* 정상 마커 — 코스 거리의 1/2 지점 */}
-          <NaverMapMarkerOverlay
-            latitude={courseCoords[Math.floor(courseCoords.length / 2)].latitude}
-            longitude={courseCoords[Math.floor(courseCoords.length / 2)].longitude}
-            width={34}
-            height={45}
-            anchor={{ x: 0.5, y: 1 }}
-          >
-            <PinMarkerIcon fill="#00D864" stroke="#16A34A" label="정상" />
-          </NaverMapMarkerOverlay>
-        </>
-      )}
-
-      {/* 자유기록 실시간 경로 — 회색 polyline + 출발/도착 마커 */}
-      {isFreeMode && recordedCoords.length > 0 && (
-        <>
-          {recordedCoords.length > 1 && (
+  const staticMapOverlays = useMemo(
+    () => (
+      <>
+        {/* 코스 경로 — API polyline */}
+        {courseCoords.length > 1 && (
+          <>
             <NaverMapPathOverlay
-              coords={recordedCoords}
+              coords={courseCoords}
               width={6}
-              color="#9CA3AF"
+              color="#ffd40d"
               outlineWidth={1}
-              outlineColor="#6B7280"
+              outlineColor="#eab308"
             />
-          )}
-          <NaverMapMarkerOverlay
-            latitude={recordedCoords[0].latitude}
-            longitude={recordedCoords[0].longitude}
-            width={34}
-            height={45}
-            anchor={{ x: 0.5, y: 1 }}
-          >
-            <PinMarkerIcon fill="#507EF4" stroke="#2563EB" label="출발" />
-          </NaverMapMarkerOverlay>
-          {/* 도착 마커 — 트래킹 종료 후에만 표시 */}
-          {!isTracking && recordedCoords.length > 1 && (
             <NaverMapMarkerOverlay
-              latitude={recordedCoords[recordedCoords.length - 1].latitude}
-              longitude={recordedCoords[recordedCoords.length - 1].longitude}
+              latitude={courseCoords[0].latitude}
+              longitude={courseCoords[0].longitude}
+              width={34}
+              height={45}
+              anchor={{ x: 0.5, y: 1 }}
+            >
+              <PinMarkerIcon fill="#507EF4" stroke="#2563EB" label="출발" />
+            </NaverMapMarkerOverlay>
+            <NaverMapMarkerOverlay
+              latitude={courseCoords[courseCoords.length - 1].latitude}
+              longitude={courseCoords[courseCoords.length - 1].longitude}
               width={34}
               height={45}
               anchor={{ x: 0.5, y: 1 }}
             >
               <PinMarkerIcon fill="#FF5249" stroke="#DC2626" label="도착" />
             </NaverMapMarkerOverlay>
-          )}
-          {/* 자유기록 정상 마커 — nearbyData 산 좌표 사용 */}
-          {nearbyData?.mountain?.latitude != null && nearbyData.mountain.longitude != null && (
+            {/* 정상 마커 — 코스 거리의 1/2 지점 */}
             <NaverMapMarkerOverlay
-              latitude={nearbyData.mountain.latitude}
-              longitude={nearbyData.mountain.longitude}
+              latitude={
+                courseCoords[Math.floor(courseCoords.length / 2)].latitude
+              }
+              longitude={
+                courseCoords[Math.floor(courseCoords.length / 2)].longitude
+              }
               width={34}
               height={45}
               anchor={{ x: 0.5, y: 1 }}
             >
               <PinMarkerIcon fill="#00D864" stroke="#16A34A" label="정상" />
             </NaverMapMarkerOverlay>
-          )}
-        </>
-      )}
-    </>
-  ), [courseCoords, isFreeMode, recordedCoords, isTracking, nearbyData]);
+          </>
+        )}
+
+        {/* 자유기록 실시간 경로 — 회색 polyline + 출발/도착 마커 */}
+        {isFreeMode && recordedCoords.length > 0 && (
+          <>
+            {recordedCoords.length > 1 && (
+              <NaverMapPathOverlay
+                coords={recordedCoords}
+                width={6}
+                color="#9CA3AF"
+                outlineWidth={1}
+                outlineColor="#6B7280"
+              />
+            )}
+            <NaverMapMarkerOverlay
+              latitude={recordedCoords[0].latitude}
+              longitude={recordedCoords[0].longitude}
+              width={34}
+              height={45}
+              anchor={{ x: 0.5, y: 1 }}
+            >
+              <PinMarkerIcon fill="#507EF4" stroke="#2563EB" label="출발" />
+            </NaverMapMarkerOverlay>
+            {/* 도착 마커 — 트래킹 종료 후에만 표시 */}
+            {!isTracking && recordedCoords.length > 1 && (
+              <NaverMapMarkerOverlay
+                latitude={recordedCoords[recordedCoords.length - 1].latitude}
+                longitude={recordedCoords[recordedCoords.length - 1].longitude}
+                width={34}
+                height={45}
+                anchor={{ x: 0.5, y: 1 }}
+              >
+                <PinMarkerIcon fill="#FF5249" stroke="#DC2626" label="도착" />
+              </NaverMapMarkerOverlay>
+            )}
+            {/* 자유기록 정상 마커 — nearbyData 산 좌표 사용 */}
+            {nearbyData?.mountain?.latitude != null &&
+              nearbyData.mountain.longitude != null && (
+                <NaverMapMarkerOverlay
+                  latitude={nearbyData.mountain.latitude}
+                  longitude={nearbyData.mountain.longitude}
+                  width={34}
+                  height={45}
+                  anchor={{ x: 0.5, y: 1 }}
+                >
+                  <PinMarkerIcon fill="#00D864" stroke="#16A34A" label="정상" />
+                </NaverMapMarkerOverlay>
+              )}
+          </>
+        )}
+      </>
+    ),
+    [courseCoords, isFreeMode, recordedCoords, isTracking, nearbyData],
+  );
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
 
@@ -539,7 +628,9 @@ export default function TrackingScreen() {
 
       // 트래킹 세션 시작 API 호출
       // mountainId 우선순위: URL 파라미터(코스 상세에서 진입) > nearbyData(현재 위치 기반)
-      const mountainId = mountainIdParameter ? Number(mountainIdParameter) : nearbyData?.mountain?.mountainId;
+      const mountainId = mountainIdParameter
+        ? Number(mountainIdParameter)
+        : nearbyData?.mountain?.mountainId;
       if (mountainId != null) {
         startSession(
           {
@@ -559,17 +650,22 @@ export default function TrackingScreen() {
                 connectSocket(sid);
                 // GPS 추적 시작 — 백그라운드 포함
                 setRecordedCoords([]);
-                setLocationTaskCallback(({ latitude, longitude, altitude, timestamp }) => {
-                  setUserLocation({ latitude, longitude, altitude });
-                  setMarkerCoord({ latitude, longitude });
-                  setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
-                  publishGps(sid, {
-                    lat: latitude,
-                    lng: longitude,
-                    altitude,
-                    recordedAt: new Date(timestamp).toISOString(),
-                  });
-                });
+                setLocationTaskCallback(
+                  ({ latitude, longitude, altitude, timestamp }) => {
+                    setUserLocation({ latitude, longitude, altitude });
+                    setMarkerCoord({ latitude, longitude });
+                    setRecordedCoords((prev) => [
+                      ...prev,
+                      { latitude, longitude },
+                    ]);
+                    publishGps(sid, {
+                      lat: latitude,
+                      lng: longitude,
+                      altitude,
+                      recordedAt: new Date(timestamp).toISOString(),
+                    });
+                  },
+                );
                 startLocationTask().catch((err) => {
                   console.warn("[Location] 백그라운드 위치 시작 실패:", err);
                 });
@@ -606,10 +702,12 @@ export default function TrackingScreen() {
       if (isFreeMode) {
         LiveActivity.start({ mode: "free" }).catch(() => {});
       } else {
-        const totalMeters = liveActivityCourse?.totalDistance
-          ?? Math.round(selectedCourse.distanceKm * 1000);
-        const totalMinutes = liveActivityCourse?.estimatedTime
-          ?? (selectedCourse.durationHours * 60 + selectedCourse.durationMinutes);
+        const totalMeters =
+          liveActivityCourse?.totalDistance ??
+          Math.round(selectedCourse.distanceKm * 1000);
+        const totalMinutes =
+          liveActivityCourse?.estimatedTime ??
+          selectedCourse.durationHours * 60 + selectedCourse.durationMinutes;
         LiveActivity.start({
           mode: "course",
           remainingMinutes: totalMinutes,
@@ -668,17 +766,24 @@ export default function TrackingScreen() {
           const result = calcCourseProgress(
             userLocation,
             liveActivityCourse.coordinates,
-            liveActivityCourse.totalDistance
+            liveActivityCourse.totalDistance,
           );
           progress = result.progress;
           remainingMeters = Math.round(result.remainingMeters);
-          remainingMinutes = Math.ceil(liveActivityCourse.estimatedTime * (1 - progress));
+          remainingMinutes = Math.ceil(
+            liveActivityCourse.estimatedTime * (1 - progress),
+          );
         } else {
           const totalSeconds =
-            (selectedCourse.durationHours * 60 + selectedCourse.durationMinutes) * 60;
+            (selectedCourse.durationHours * 60 +
+              selectedCourse.durationMinutes) *
+            60;
           const totalMeters = Math.round(selectedCourse.distanceKm * 1000);
-          progress = totalSeconds > 0 ? Math.min(elapsedSeconds / totalSeconds, 1) : 0;
-          remainingMinutes = Math.ceil(Math.max(0, totalSeconds - elapsedSeconds) / 60);
+          progress =
+            totalSeconds > 0 ? Math.min(elapsedSeconds / totalSeconds, 1) : 0;
+          remainingMinutes = Math.ceil(
+            Math.max(0, totalSeconds - elapsedSeconds) / 60,
+          );
           remainingMeters = Math.round(totalMeters * (1 - progress));
         }
 
@@ -692,7 +797,14 @@ export default function TrackingScreen() {
         }).catch(() => {});
       }
     }
-  }, [elapsedSeconds, isPaused, isFreeMode, selectedCourse, liveActivityCourse, userLocation]);
+  }, [
+    elapsedSeconds,
+    isPaused,
+    isFreeMode,
+    selectedCourse,
+    liveActivityCourse,
+    userLocation,
+  ]);
 
   const pauseTracking = () => {
     setIsPaused(true);
@@ -729,7 +841,7 @@ export default function TrackingScreen() {
   useEffect(() => {
     if (!isLiveActivityEnabled || !isTracking) return;
     const sub = addLiveActivityControlListener((action) => {
-      if (action === 'pause') pauseTrackingRef.current();
+      if (action === "pause") pauseTrackingRef.current();
       else resumeTrackingRef.current();
     });
     return () => sub.remove();
@@ -754,7 +866,11 @@ export default function TrackingScreen() {
 
     const isWindowOpen = photoWindow?.status === "OPEN";
     // 정상 인증 후에는 summitPhotoWindowRef에 저장된 photoWindow 사용
-    const activeWindow = isWindowOpen ? photoWindow : (hasSummited ? summitPhotoWindowRef.current : null);
+    const activeWindow = isWindowOpen
+      ? photoWindow
+      : hasSummited
+        ? summitPhotoWindowRef.current
+        : null;
 
     if (activeWindow != null && sessionId != null) {
       try {
@@ -789,7 +905,8 @@ export default function TrackingScreen() {
     if (sessionId != null) {
       completeSession(sessionId, {
         onSuccess: (data) => {
-          if (data.hikingRecordId != null) setHikingRecordId(data.hikingRecordId);
+          if (data.hikingRecordId != null)
+            setHikingRecordId(data.hikingRecordId);
         },
         onError: (err) => {
           console.warn("[Tracking] 세션 종료 실패:", err);
@@ -801,17 +918,20 @@ export default function TrackingScreen() {
   };
 
   const DIFFICULTY_COMPARISON = {
-    similar: 'SIMILAR',
-    easier: 'EASIER',
-    harder: 'HARDER',
+    similar: "SIMILAR",
+    easier: "EASIER",
+    harder: "HARDER",
   } as const;
 
   /** 난이도 체감 완료 후 피드백 저장 + 상태 초기화 */
-  const completeTracking = (option: 'similar' | 'easier' | 'harder' | null) => {
+  const completeTracking = (option: "similar" | "easier" | "harder" | null) => {
     if (hikingRecordId != null && option != null) {
       saveDifficultyFeedback(
         { hikingRecordId, comparison: DIFFICULTY_COMPARISON[option] },
-        { onError: (err) => console.warn("[Tracking] 난이도 피드백 저장 실패:", err) },
+        {
+          onError: (err) =>
+            console.warn("[Tracking] 난이도 피드백 저장 실패:", err),
+        },
       );
     }
     if (isLiveActivityEnabled) LiveActivity.stop().catch(() => {});
@@ -861,13 +981,17 @@ export default function TrackingScreen() {
             zoom: 12,
           }}
           mapPadding={{
-            bottom: isTracking ? trackingSheetHeight : collapsed ? COLLAPSED_PEEK_HEIGHT : 448,
+            bottom: isTracking
+              ? trackingSheetHeight
+              : collapsed
+                ? COLLAPSED_PEEK_HEIGHT
+                : 448,
             top: 0,
             left: 0,
             right: 0,
           }}
           onCameraChanged={({ reason }) => {
-            if (reason === 'Gesture') setIsFollowingUser(false);
+            if (reason === "Gesture") setIsFollowingUser(false);
           }}
         >
           {staticMapOverlays}
@@ -885,12 +1009,30 @@ export default function TrackingScreen() {
               {/* 총 높이: 삼각형 9 + 원 28 - 겹침 3 = 34 */}
               <View collapsable={false} style={{ width: 28, height: 34 }}>
                 {/* 원 SVG — top: 6 (삼각형 9 - 겹침 3) */}
-                <Svg width={28} height={28} viewBox="0 0 28 28" fill="none" style={{ position: 'absolute', top: 6, left: 0 }}>
+                <Svg
+                  width={28}
+                  height={28}
+                  viewBox="0 0 28 28"
+                  fill="none"
+                  style={{ position: "absolute", top: 6, left: 0 }}
+                >
                   <Circle cx={14} cy={10} r={7} fill="#00D864" />
-                  <Circle cx={14} cy={10} r={8.5} stroke="white" strokeWidth={3} />
+                  <Circle
+                    cx={14}
+                    cy={10}
+                    r={8.5}
+                    stroke="white"
+                    strokeWidth={3}
+                  />
                 </Svg>
                 {/* 삼각형 SVG — top: 0, 가로 중앙 */}
-                <Svg width={11} height={9} viewBox="0 0 11 9" fill="none" style={{ position: 'absolute', top: 0, left: (28 - 11) / 2 }}>
+                <Svg
+                  width={11}
+                  height={9}
+                  viewBox="0 0 11 9"
+                  fill="none"
+                  style={{ position: "absolute", top: 0, left: (28 - 11) / 2 }}
+                >
                   <Path
                     d="M4.28833 0.918945C4.68715 0.360597 5.51646 0.360596 5.91528 0.918945L9.51685 5.95996L9.5686 6.04004C9.80428 6.44189 9.70042 6.89069 9.48657 7.18262C9.25971 7.49219 8.83304 7.73339 8.34985 7.60645C7.44144 7.36779 6.26488 7.13965 5.10181 7.13965C3.93873 7.13965 2.76217 7.36779 1.85376 7.60645C1.37058 7.73339 0.943901 7.49219 0.717041 7.18262C0.488937 6.87123 0.386039 6.38098 0.686768 5.95996L4.28833 0.918945Z"
                     fill="#00D864"
@@ -903,9 +1045,20 @@ export default function TrackingScreen() {
         </NaverMapView>
 
         {/* 사진 윈도우 배너 — 지도 위 오버레이 */}
-        {isTracking && photoWindow?.status === 'OPEN' && (
-          <View style={{ position: 'absolute', top: 124, left: 0, right: 0, alignItems: 'center', zIndex: 10 }}>
-            <PhotoWindowBanner milestoneDistance={photoWindow.milestoneDistance} />
+        {isTracking && photoWindow?.status === "OPEN" && (
+          <View
+            style={{
+              position: "absolute",
+              top: 124,
+              left: 0,
+              right: 0,
+              alignItems: "center",
+              zIndex: 10,
+            }}
+          >
+            <PhotoWindowBanner
+              milestoneDistance={photoWindow.milestoneDistance}
+            />
           </View>
         )}
 
@@ -937,7 +1090,9 @@ export default function TrackingScreen() {
               <TrailAvatarMarker
                 left={TRAIL_MARKER_LEFT}
                 centerY={barLayout.top + barLayout.height * markerRatio}
-                imageSource={profile?.profileUrl ? { uri: profile.profileUrl } : undefined}
+                imageSource={
+                  profile?.profileUrl ? { uri: profile.profileUrl } : undefined
+                }
               />
             )}
           </>
@@ -1065,6 +1220,7 @@ export default function TrackingScreen() {
 
       {/* 난이도 체감 모달 */}
       <DifficultyRatingModal
+        mountainId={nearbyData?.mountain?.mountainId}
         visible={showDifficultyRating}
         course={selectedCourse}
         mountainName={nearbyData?.mountain?.name ?? ""}

--- a/app/mountain-info.tsx
+++ b/app/mountain-info.tsx
@@ -1,30 +1,46 @@
-import { useLocalSearchParams } from 'expo-router';
-import { LinearGradient } from 'expo-linear-gradient';
-import { Image as ExpoImage } from 'expo-image';
-import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import Animated, { interpolate, useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   HomeBottomSheetContainer,
   SNAP_COLLAPSED,
   SNAP_DEFAULT,
   SNAP_EXPANDED_WITH_RECORDS,
-} from '@/components/home-bottom-sheet-container';
-import { BellIcon } from '@/components/icons/bell-icon';
-import { CrosshairIcon } from '@/components/icons/crosshair-icon';
-import { ImagePlaceholderIcon } from '@/components/icons/image-placeholder-icon';
-import { SemosanLogo } from '@/components/icons/semosan-logo';
-import { UnvisitedMountainPillMarker } from '@/components/map-markers/unvisited-mountain-pill-marker';
+} from "@/components/home-bottom-sheet-container";
+import { BellIcon } from "@/components/icons/bell-icon";
+import { CrosshairIcon } from "@/components/icons/crosshair-icon";
+import { ImagePlaceholderIcon } from "@/components/icons/image-placeholder-icon";
+import { SemosanLogo } from "@/components/icons/semosan-logo";
+import { UnvisitedMountainPillMarker } from "@/components/map-markers/unvisited-mountain-pill-marker";
+import { Image as ExpoImage } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
+import { useLocalSearchParams } from "expo-router";
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-const TABS = ['코스', '교통 정보', '편의시설', '주변 맛집', '등산 후기'] as const;
+const TABS = [
+  "코스",
+  "교통 정보",
+  "편의시설",
+  "주변 맛집",
+  "등산 후기",
+] as const;
 const MAP_BG_URI =
-  'https://www.figma.com/api/mcp/asset/290712df-c28e-4d6b-b1b7-48d12eb7313f';
+  "https://www.figma.com/api/mcp/asset/290712df-c28e-4d6b-b1b7-48d12eb7313f";
 const COURSES = [
-  { level: '초급', levelType: 'green', title: '타이틀' },
-  { level: '중급', levelType: 'blue', title: '타이틀' },
-  { level: '상급', levelType: 'red', title: '타이틀' },
-  { level: '상급', levelType: 'red', title: '타이틀' },
-  { level: '초급', levelType: 'green', title: '타이틀' },
+  { level: "초급", levelType: "green", title: "타이틀" },
+  { level: "중급", levelType: "blue", title: "타이틀" },
+  { level: "상급", levelType: "red", title: "타이틀" },
+  { level: "상급", levelType: "red", title: "타이틀" },
+  { level: "초급", levelType: "green", title: "타이틀" },
 ] as const;
 
 export default function MountainInfoScreen() {
@@ -36,16 +52,16 @@ export default function MountainInfoScreen() {
     elevation?: string;
   }>();
 
-  const title = name ?? '관악산';
-  const levelText = difficulty ?? '난이도 상';
-  const elevationText = elevation ?? '632m';
+  const title = name ?? "관악산";
+  const levelText = difficulty ?? "난이도 상";
+  const elevationText = elevation ?? "632m";
   const locationButtonStyle = useAnimatedStyle(() => ({
     bottom: sheetHeight.value + 12,
     opacity: interpolate(
       sheetHeight.value,
       [SNAP_COLLAPSED, SNAP_DEFAULT, SNAP_EXPANDED_WITH_RECORDS],
       [1, 1, 0],
-      'clamp'
+      "clamp",
     ),
   }));
 
@@ -58,17 +74,17 @@ export default function MountainInfoScreen() {
           contentFit="cover"
         />
         <LinearGradient
-          colors={['rgba(255,255,255,1)', 'rgba(255,255,255,0)']}
+          colors={["rgba(255,255,255,1)", "rgba(255,255,255,0)"]}
           start={{ x: 0, y: 0 }}
           end={{ x: 0, y: 1 }}
           style={styles.mapTopGradient}
         />
 
         <View style={[styles.overlay, { paddingTop: top }]}>
-          <View className="flex-row items-center justify-between px-5 h-14">
+          <View className="h-14 flex-row items-center justify-between px-5">
             <SemosanLogo />
             <TouchableOpacity
-              className="w-12 h-12 rounded-full bg-fill-normal items-center justify-center"
+              className="h-12 w-12 items-center justify-center rounded-full bg-fill-normal"
               style={styles.shadowBtn}
               hitSlop={8}
             >
@@ -78,14 +94,17 @@ export default function MountainInfoScreen() {
         </View>
 
         <View style={styles.markerWrap}>
-          <UnvisitedMountainPillMarker name={title} variant="visited" selected />
+          <UnvisitedMountainPillMarker
+            name={title}
+            variant="visited"
+            selected
+          />
         </View>
-
       </View>
 
       <Animated.View style={[styles.locationButton, locationButtonStyle]}>
         <TouchableOpacity
-          className="w-12 h-12 rounded-full bg-fill-normal items-center justify-center"
+          className="h-12 w-12 items-center justify-center rounded-full bg-fill-normal"
           style={styles.crosshairBtn}
           hitSlop={8}
         >
@@ -98,76 +117,122 @@ export default function MountainInfoScreen() {
         snapExpanded={SNAP_EXPANDED_WITH_RECORDS}
         renderContent={({ scrollEnabled, snapState }) => (
           <View style={styles.sheetContent}>
-            {snapState === 'collapsed' ? (
+            {snapState === "collapsed" ? (
               <View style={styles.collapsedHeaderRow}>
                 <View className="flex-row items-end gap-3">
-                  <Text className="typo-title-2-bold text-label-strong">{title}</Text>
-                  <Text className="typo-body-2-normal-regular text-label-subtler">경기 과천시 중앙동</Text>
+                  <Text className="text-label-strong typo-title-2-bold">
+                    {title}
+                  </Text>
+                  <Text className="text-label-subtler typo-body-2-normal-regular">
+                    경기 과천시 중앙동
+                  </Text>
                 </View>
                 <Text className="text-[24px] text-label-subtle">♡</Text>
               </View>
             ) : (
               <>
-            <View style={[styles.sheetHeader, snapState === 'expanded' && styles.sheetHeaderExpanded]}>
-              <View className="flex-row items-end justify-between">
-                <View className="flex-row items-end gap-3">
-                  <Text className="typo-title-2-bold text-label-strong">{title}</Text>
-                  <Text className="typo-body-2-normal-regular text-label-subtler">경기 과천시 중앙동</Text>
-                </View>
-                <Text className="text-[24px] text-label-subtle">♡</Text>
-              </View>
-
-              <View className="flex-row items-center gap-2 mt-1">
-                <Text className="typo-body-2-normal-medium text-label-subtle">고도 {elevationText}</Text>
-                <View className="w-0.5 h-0.5 rounded-full bg-label-subtler" />
-                <Text className="typo-body-2-normal-semi-bold text-status-negative-normal">{levelText}</Text>
-              </View>
-            </View>
-
-            <View style={[styles.sunCard, snapState === 'expanded' && styles.sunCardExpanded]}>
-              <Text className="typo-body-3-medium text-label-subtle">오늘</Text>
-              <View className="flex-row items-center gap-3">
-                <Text className="typo-body-3-medium text-label-subtle">☼ 일출 05:01</Text>
-                <Text className="typo-body-3-medium text-label-subtle">☼ 일몰 19:01</Text>
-              </View>
-              <Text style={styles.caretDown}>⌄</Text>
-            </View>
-
-            <View style={[styles.tabsSection, snapState === 'expanded' && styles.tabsSectionExpanded]}>
-              <ScrollView
-                style={styles.tabsScroll}
-                horizontal
-                showsHorizontalScrollIndicator={false}
-                contentContainerStyle={styles.tabsWrap}
-              >
-                {TABS.map((tab, index) => (
-                  <View key={tab} style={[styles.tabItem, index === 0 && styles.tabActive]}>
-                    <Text style={[styles.tabText, index === 0 && styles.tabTextActive]}>{tab}</Text>
+                <View
+                  style={[
+                    styles.sheetHeader,
+                    snapState === "expanded" && styles.sheetHeaderExpanded,
+                  ]}
+                >
+                  <View className="flex-row items-end justify-between">
+                    <View className="flex-row items-end gap-3">
+                      <Text className="text-label-strong typo-title-2-bold">
+                        {title}
+                      </Text>
+                      <Text className="text-label-subtler typo-body-2-normal-regular">
+                        경기 과천시 중앙동
+                      </Text>
+                    </View>
+                    <Text className="text-[24px] text-label-subtle">♡</Text>
                   </View>
-                ))}
-              </ScrollView>
-            </View>
 
-            {snapState === 'expanded' ? (
-              <ScrollView
-                style={styles.courseList}
-                contentContainerStyle={styles.courseListContentExpanded}
-                showsVerticalScrollIndicator={false}
-                scrollEnabled={scrollEnabled}
-              >
-                {COURSES.map((item, idx) => (
-                  <CourseRow key={`${item.level}-${idx}`} item={item} />
-                ))}
-              </ScrollView>
-            ) : (
-              <View style={styles.courseListDefaultPanel}>
-                <View style={styles.courseListDefault}>
-                  {COURSES.map((item, idx) => (
-                    <CourseRow key={`${item.level}-${idx}`} item={item} />
-                  ))}
+                  <View className="mt-1 flex-row items-center gap-2">
+                    <Text className="text-label-subtle typo-body-2-normal-medium">
+                      고도 {elevationText}
+                    </Text>
+                    <View className="h-0.5 w-0.5 rounded-full bg-label-subtler" />
+                    <Text className="text-status-negative-normal typo-body-2-normal-semi-bold">
+                      난이도 {levelText}
+                    </Text>
+                  </View>
                 </View>
-              </View>
-            )}
+
+                <View
+                  style={[
+                    styles.sunCard,
+                    snapState === "expanded" && styles.sunCardExpanded,
+                  ]}
+                >
+                  <Text className="text-label-subtle typo-body-3-medium">
+                    오늘
+                  </Text>
+                  <View className="flex-row items-center gap-3">
+                    <Text className="text-label-subtle typo-body-3-medium">
+                      ☼ 일출 05:01
+                    </Text>
+                    <Text className="text-label-subtle typo-body-3-medium">
+                      ☼ 일몰 19:01
+                    </Text>
+                  </View>
+                  <Text style={styles.caretDown}>⌄</Text>
+                </View>
+
+                <View
+                  style={[
+                    styles.tabsSection,
+                    snapState === "expanded" && styles.tabsSectionExpanded,
+                  ]}
+                >
+                  <ScrollView
+                    style={styles.tabsScroll}
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={styles.tabsWrap}
+                  >
+                    {TABS.map((tab, index) => (
+                      <View
+                        key={tab}
+                        style={[
+                          styles.tabItem,
+                          index === 0 && styles.tabActive,
+                        ]}
+                      >
+                        <Text
+                          style={[
+                            styles.tabText,
+                            index === 0 && styles.tabTextActive,
+                          ]}
+                        >
+                          {tab}
+                        </Text>
+                      </View>
+                    ))}
+                  </ScrollView>
+                </View>
+
+                {snapState === "expanded" ? (
+                  <ScrollView
+                    style={styles.courseList}
+                    contentContainerStyle={styles.courseListContentExpanded}
+                    showsVerticalScrollIndicator={false}
+                    scrollEnabled={scrollEnabled}
+                  >
+                    {COURSES.map((item, idx) => (
+                      <CourseRow key={`${item.level}-${idx}`} item={item} />
+                    ))}
+                  </ScrollView>
+                ) : (
+                  <View style={styles.courseListDefaultPanel}>
+                    <View style={styles.courseListDefault}>
+                      {COURSES.map((item, idx) => (
+                        <CourseRow key={`${item.level}-${idx}`} item={item} />
+                      ))}
+                    </View>
+                  </View>
+                )}
               </>
             )}
           </View>
@@ -180,56 +245,56 @@ export default function MountainInfoScreen() {
 const styles = StyleSheet.create({
   mapArea: {
     flex: 1,
-    backgroundColor: '#EEF2E8',
-    position: 'relative',
-    overflow: 'hidden',
+    backgroundColor: "#EEF2E8",
+    position: "relative",
+    overflow: "hidden",
   },
   mapBackground: {
     ...StyleSheet.absoluteFillObject,
   },
   mapTopGradient: {
-    position: 'absolute',
+    position: "absolute",
     left: 0,
     right: 0,
     top: 0,
     height: 154,
   },
   overlay: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: 0,
     right: 0,
   },
   markerWrap: {
-    position: 'absolute',
+    position: "absolute",
     top: 238,
     left: 154,
   },
   shadowBtn: {
-    boxShadow: '0px 2px 2px 0px rgba(0, 0, 0, 0.1)',
+    boxShadow: "0px 2px 2px 0px rgba(0, 0, 0, 0.1)",
   },
   crosshairBtn: {
     width: 48,
     height: 48,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: '#D1D5DB',
-    boxShadow: '0px 2px 4px 0px rgba(0, 0, 0, 0.15)',
+    borderColor: "#D1D5DB",
+    boxShadow: "0px 2px 4px 0px rgba(0, 0, 0, 0.15)",
   },
   locationButton: {
-    position: 'absolute',
+    position: "absolute",
     right: 20,
   },
   sheetContent: {
     flex: 1,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
   },
   collapsedHeaderRow: {
     height: 44,
     paddingHorizontal: 20,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   sheetHeader: {
     paddingHorizontal: 20,
@@ -245,16 +310,16 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingHorizontal: 16,
     paddingVertical: 10,
-    backgroundColor: '#F9FAFB',
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+    backgroundColor: "#F9FAFB",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   sunCardExpanded: {
     marginTop: 16,
   },
   caretDown: {
-    color: '#A4ABC0',
+    color: "#A4ABC0",
     fontSize: 18,
     lineHeight: 18,
     marginTop: -2,
@@ -262,7 +327,7 @@ const styles = StyleSheet.create({
   tabsSection: {
     marginTop: 20,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: "#E5E7EB",
   },
   tabsSectionExpanded: {
     marginTop: 20,
@@ -280,27 +345,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
     borderBottomWidth: 2,
-    borderBottomColor: 'transparent',
+    borderBottomColor: "transparent",
   },
   tabActive: {
-    borderBottomColor: '#1A1B1F',
+    borderBottomColor: "#1A1B1F",
   },
   tabText: {
-    fontFamily: 'Pretendard',
+    fontFamily: "Pretendard",
     fontSize: 16,
-    fontWeight: '500',
-    color: '#73798C',
+    fontWeight: "500",
+    color: "#73798C",
   },
   tabTextActive: {
-    fontWeight: '600',
-    color: '#1A1B1F',
+    fontWeight: "600",
+    color: "#1A1B1F",
   },
   courseList: {
     flex: 1,
   },
   courseListDefaultPanel: {
     height: 245,
-    overflow: 'hidden',
+    overflow: "hidden",
   },
   courseListDefault: {
     paddingHorizontal: 20,
@@ -314,19 +379,19 @@ const styles = StyleSheet.create({
     gap: 16,
   },
   courseRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: "row",
+    alignItems: "center",
     gap: 16,
   },
   courseThumb: {
     width: 64,
     height: 72,
     borderRadius: 10,
-    backgroundColor: '#F5F6F8',
+    backgroundColor: "#F5F6F8",
     borderWidth: 1,
-    borderColor: '#ECEEF2',
-    alignItems: 'center',
-    justifyContent: 'center',
+    borderColor: "#ECEEF2",
+    alignItems: "center",
+    justifyContent: "center",
   },
   courseInfo: {
     flex: 1,
@@ -337,23 +402,23 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   levelBadgeText: {
-    fontFamily: 'Pretendard',
+    fontFamily: "Pretendard",
     fontSize: 14,
-    fontWeight: '500',
+    fontWeight: "500",
     lineHeight: 21,
   },
-  levelGreenBg: { backgroundColor: '#DCFCE7' },
-  levelGreenText: { color: '#16A34A' },
-  levelBlueBg: { backgroundColor: '#EFF6FF' },
-  levelBlueText: { color: '#507EF4' },
-  levelRedBg: { backgroundColor: '#FEF2F2' },
-  levelRedText: { color: '#FF5249' },
+  levelGreenBg: { backgroundColor: "#DCFCE7" },
+  levelGreenText: { color: "#16A34A" },
+  levelBlueBg: { backgroundColor: "#EFF6FF" },
+  levelBlueText: { color: "#507EF4" },
+  levelRedBg: { backgroundColor: "#FEF2F2" },
+  levelRedText: { color: "#FF5249" },
 });
 
 function CourseRow({
   item,
 }: {
-  item: { level: string; levelType: 'green' | 'blue' | 'red'; title: string };
+  item: { level: string; levelType: "green" | "blue" | "red"; title: string };
 }) {
   return (
     <View style={styles.courseRow}>
@@ -365,9 +430,9 @@ function CourseRow({
           <View
             style={[
               styles.levelBadge,
-              item.levelType === 'green'
+              item.levelType === "green"
                 ? styles.levelGreenBg
-                : item.levelType === 'blue'
+                : item.levelType === "blue"
                   ? styles.levelBlueBg
                   : styles.levelRedBg,
             ]}
@@ -375,9 +440,9 @@ function CourseRow({
             <Text
               style={[
                 styles.levelBadgeText,
-                item.levelType === 'green'
+                item.levelType === "green"
                   ? styles.levelGreenText
-                  : item.levelType === 'blue'
+                  : item.levelType === "blue"
                     ? styles.levelBlueText
                     : styles.levelRedText,
               ]}
@@ -385,9 +450,13 @@ function CourseRow({
               {item.level}
             </Text>
           </View>
-          <Text className="typo-body-1-normal-semi-bold text-label-strong">{item.title}</Text>
+          <Text className="text-label-strong typo-body-1-normal-semi-bold">
+            {item.title}
+          </Text>
         </View>
-        <Text className="typo-caption-1-medium text-label-subtler">10km · 3시간</Text>
+        <Text className="text-label-subtler typo-caption-1-medium">
+          10km · 3시간
+        </Text>
       </View>
     </View>
   );

--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/react-native";
 import Clive1Svg from "@/assets/clive1.svg";
 import { CliveBottomBar } from "@/components/clive-bottom-bar";
 import { CheckCircleIcon } from "@/components/icons/check-circle-icon";
@@ -13,6 +12,7 @@ import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
 import { uploadImage } from "@/hooks/use-upload-image";
 import { api } from "@/lib/api";
 import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
+import * as Sentry from "@sentry/react-native";
 import { useQueryClient } from "@tanstack/react-query";
 import { Image as ExpoImage, Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
@@ -212,7 +212,7 @@ export default function RecordScreen() {
       const semoFeedId = await ensureSemoFeed(activeTab);
       if (!semoFeedId) return;
 
-      togglePublicMutateAsync(semoFeedId);
+      await togglePublicMutateAsync(semoFeedId);
 
       const nextPublic = !activeTabPublic;
       setIsPublicByTab((prev) => ({ ...prev, [activeTab]: nextPublic }));

--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react-native";
 import Clive1Svg from "@/assets/clive1.svg";
 import { CliveBottomBar } from "@/components/clive-bottom-bar";
 import { CheckCircleIcon } from "@/components/icons/check-circle-icon";
@@ -72,7 +73,7 @@ export default function RecordScreen() {
   const durationSec = duration ? parseInt(duration) : null;
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { mutate: togglePublicMutate, isPending: isToggling } =
+  const { mutateAsync: togglePublicMutateAsync, isPending: isToggling } =
     useToggleSemofeedPublic();
   const { top } = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<RecordTab>("클라이브");
@@ -211,7 +212,7 @@ export default function RecordScreen() {
       const semoFeedId = await ensureSemoFeed(activeTab);
       if (!semoFeedId) return;
 
-      togglePublicMutate(semoFeedId);
+      togglePublicMutateAsync(semoFeedId);
 
       const nextPublic = !activeTabPublic;
       setIsPublicByTab((prev) => ({ ...prev, [activeTab]: nextPublic }));
@@ -244,6 +245,7 @@ export default function RecordScreen() {
       }
     } catch (error) {
       console.error("[SemoFeed] public toggle failed", error);
+      Sentry.captureException(error);
       return;
     }
   };

--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -1,16 +1,23 @@
-import { useLocalSearchParams, useRouter, useFocusEffect } from "expo-router";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import Svg, {
-  Defs,
-  LinearGradient as SvgLinearGradient,
-  Stop,
-  Mask,
-  Rect as SvgRect,
-  Image as SvgImage,
-} from "react-native-svg";
-import { LinearGradient } from "expo-linear-gradient";
+import Clive1Svg from "@/assets/clive1.svg";
+import { CliveBottomBar } from "@/components/clive-bottom-bar";
+import { CheckCircleIcon } from "@/components/icons/check-circle-icon";
+import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
+import { PencilSimpleIcon } from "@/components/icons/pencil-simple-icon";
+import { XIcon } from "@/components/icons/x-icon";
+import { useHikingRecordDetail } from "@/features/home/hooks/use-hiking-record-detail";
+import { useToggleSemofeedPublic } from "@/features/home/hooks/use-toggle-semofeed-public";
+import { useHikingSummary } from "@/features/mypage/hooks/use-hiking-summary";
+import { getPhotoReportState } from "@/features/photo-report/photo-report-state";
+import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
+import { uploadImage } from "@/hooks/use-upload-image";
+import { api } from "@/lib/api";
+import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
+import { useQueryClient } from "@tanstack/react-query";
 import { Image as ExpoImage, Image } from "expo-image";
+import { LinearGradient } from "expo-linear-gradient";
 import * as MediaLibrary from "expo-media-library";
+import { useFocusEffect, useLocalSearchParams, useRouter } from "expo-router";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ScrollView,
   StyleSheet,
@@ -19,10 +26,15 @@ import {
   View,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Svg, {
+  Defs,
+  Mask,
+  Stop,
+  Image as SvgImage,
+  LinearGradient as SvgLinearGradient,
+  Rect as SvgRect,
+} from "react-native-svg";
 import ViewShot from "react-native-view-shot";
-import Clive1Svg from "@/assets/clive1.svg";
-import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
-import { PencilSimpleIcon } from "@/components/icons/pencil-simple-icon";
 const ALTITUDE_LABELS = ["400m", "800m", "1200m", "1600m"];
 const CLIVE_CARD_HEIGHT = 596;
 
@@ -35,57 +47,73 @@ function formatDuration(seconds: number | null): string {
   return `${h}시간 ${m}분`;
 }
 
-
 const PhotoReportBg = require("@/assets/photo-report-bg.png");
 const OVERLAY_STATS = [
   require("@/assets/overlay-stats-1.png"),
   require("@/assets/overlay-stats-2.png"),
   require("@/assets/overlay-stats-3.png"),
 ];
-import { CheckCircleIcon } from "@/components/icons/check-circle-icon";
-import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
-import { XIcon } from "@/components/icons/x-icon";
-import { CliveBottomBar } from "@/components/clive-bottom-bar";
-import { getPhotoReportState } from "@/features/photo-report/photo-report-state";
-import { useHikingSummary } from "@/features/mypage/hooks/use-hiking-summary";
-import { useHikingRecordDetail } from "@/features/home/hooks/use-hiking-record-detail";
-import { uploadImage } from "@/hooks/use-upload-image";
-import { useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api";
-import { ENDPOINTS, SemoFeedResponse } from "@/types/api.generated";
-
 type RecordTab = "클라이브" | "포토 리포트";
 
 export default function RecordScreen() {
-  const { id, hikingRecordId, name, courseName, imageUri, distance, duration } = useLocalSearchParams<{
-    id: string;
-    hikingRecordId?: string;
-    name: string;
-    courseName?: string;
-    imageUri?: string;
-    distance?: string;
-    duration?: string;
-  }>();
+  const { id, hikingRecordId, name, courseName, imageUri, distance, duration } =
+    useLocalSearchParams<{
+      id: string;
+      hikingRecordId?: string;
+      name: string;
+      courseName?: string;
+      imageUri?: string;
+      distance?: string;
+      duration?: string;
+    }>();
   const sessionId = id ? parseInt(id) : null;
   const hikingRecordIdNum = hikingRecordId ? parseInt(hikingRecordId) : null;
   const distanceKm = distance ? parseFloat(distance) / 1000 : null;
   const durationSec = duration ? parseInt(duration) : null;
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { mutate: togglePublicMutate, isPending: isToggling } =
+    useToggleSemofeedPublic();
   const { top } = useSafeAreaInsets();
   const [activeTab, setActiveTab] = useState<RecordTab>("클라이브");
   const [showSaveToast, setShowSaveToast] = useState(false);
   const [showPublicToast, setShowPublicToast] = useState(false);
   const [showPrivateToast, setShowPrivateToast] = useState(false);
-  const [isPublicByTab, setIsPublicByTab] = useState<Record<RecordTab, boolean>>(() => ({
-    클라이브: queryClient.getQueryData<{ id: number; isPublic: boolean }>(['record-semofeed', sessionId, '클라이브'])?.isPublic ?? false,
-    "포토 리포트": queryClient.getQueryData<{ id: number; isPublic: boolean }>(['record-semofeed', sessionId, '포토 리포트'])?.isPublic ?? false,
+  const [isPublicByTab, setIsPublicByTab] = useState<
+    Record<RecordTab, boolean>
+  >(() => ({
+    클라이브:
+      queryClient.getQueryData<{ id: number; isPublic: boolean }>([
+        "record-semofeed",
+        sessionId,
+        "클라이브",
+      ])?.isPublic ?? false,
+    "포토 리포트":
+      queryClient.getQueryData<{ id: number; isPublic: boolean }>([
+        "record-semofeed",
+        sessionId,
+        "포토 리포트",
+      ])?.isPublic ?? false,
   }));
-  const [semoFeedIdByTab, setSemoFeedIdByTab] = useState<Record<RecordTab, number | null>>(() => ({
-    클라이브: queryClient.getQueryData<{ id: number; isPublic: boolean }>(['record-semofeed', sessionId, '클라이브'])?.id ?? null,
-    "포토 리포트": queryClient.getQueryData<{ id: number; isPublic: boolean }>(['record-semofeed', sessionId, '포토 리포트'])?.id ?? null,
+  const [semoFeedIdByTab, setSemoFeedIdByTab] = useState<
+    Record<RecordTab, number | null>
+  >(() => ({
+    클라이브:
+      queryClient.getQueryData<{ id: number; isPublic: boolean }>([
+        "record-semofeed",
+        sessionId,
+        "클라이브",
+      ])?.id ?? null,
+    "포토 리포트":
+      queryClient.getQueryData<{ id: number; isPublic: boolean }>([
+        "record-semofeed",
+        sessionId,
+        "포토 리포트",
+      ])?.id ?? null,
   }));
-  const [photoReportSource, setPhotoReportSource] = useState<number | { uri: string } | null>(null);
+  const [photoReportSource, setPhotoReportSource] = useState<
+    number | { uri: string } | null
+  >(null);
   const [photoReportTemplate, setPhotoReportTemplate] = useState(0);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const publicTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -113,7 +141,7 @@ export default function RecordScreen() {
     const imageUrl = await uploadImage(
       imageUri,
       `semo-feed-${tab}-${Date.now()}.jpg`,
-      "semofeed"
+      "semofeed",
     );
     const res = await api.post<SemoFeedResponse>({
       path: ENDPOINTS.SEMOFEED,
@@ -126,7 +154,10 @@ export default function RecordScreen() {
     const isPublic = !!res.data?.isPublic;
     setSemoFeedIdByTab((prev) => ({ ...prev, [tab]: createdFeedId }));
     setIsPublicByTab((prev) => ({ ...prev, [tab]: isPublic }));
-    queryClient.setQueryData(['record-semofeed', sessionId, tab], { id: createdFeedId, isPublic });
+    queryClient.setQueryData(["record-semofeed", sessionId, tab], {
+      id: createdFeedId,
+      isPublic,
+    });
     return createdFeedId;
   };
 
@@ -135,7 +166,7 @@ export default function RecordScreen() {
       const { photoSource, templateIndex } = getPhotoReportState();
       if (photoSource !== null) setPhotoReportSource(photoSource);
       setPhotoReportTemplate(templateIndex);
-    }, [])
+    }, []),
   );
 
   // 클라이브 사진 프리페치 + 포토리포트 기본 사진 = 마지막 사진(정상)
@@ -180,13 +211,14 @@ export default function RecordScreen() {
       const semoFeedId = await ensureSemoFeed(activeTab);
       if (!semoFeedId) return;
 
-      await api.patch<boolean>({
-        path: ENDPOINTS.SEMOFEED_BY_SEMOFEEDID_PUBLIC(semoFeedId),
-      });
+      togglePublicMutate(semoFeedId);
 
       const nextPublic = !activeTabPublic;
       setIsPublicByTab((prev) => ({ ...prev, [activeTab]: nextPublic }));
-      queryClient.setQueryData(['record-semofeed', sessionId, activeTab], { id: semoFeedId, isPublic: nextPublic });
+      queryClient.setQueryData(["record-semofeed", sessionId, activeTab], {
+        id: semoFeedId,
+        isPublic: nextPublic,
+      });
       queryClient.invalidateQueries({ queryKey: [ENDPOINTS.SEMOFEED] });
 
       if (nextPublic) {
@@ -195,27 +227,32 @@ export default function RecordScreen() {
 
         setShowPublicToast(true);
         if (publicTimerRef.current) clearTimeout(publicTimerRef.current);
-        publicTimerRef.current = setTimeout(() => setShowPublicToast(false), 3000);
+        publicTimerRef.current = setTimeout(
+          () => setShowPublicToast(false),
+          3000,
+        );
       } else {
         setShowPublicToast(false);
         if (publicTimerRef.current) clearTimeout(publicTimerRef.current);
 
         setShowPrivateToast(true);
         if (privateTimerRef.current) clearTimeout(privateTimerRef.current);
-        privateTimerRef.current = setTimeout(() => setShowPrivateToast(false), 3000);
+        privateTimerRef.current = setTimeout(
+          () => setShowPrivateToast(false),
+          3000,
+        );
       }
     } catch (error) {
       console.error("[SemoFeed] public toggle failed", error);
       return;
     }
-
   };
 
   return (
     <View className="flex-1 bg-fill-normal">
       {/* 헤더 */}
       <View style={{ paddingTop: top }} className="bg-fill-normal">
-        <View className="flex-row items-center justify-between px-5 h-14">
+        <View className="h-14 flex-row items-center justify-between px-5">
           <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
             <ChevronLeftIcon size={24} />
           </TouchableOpacity>
@@ -229,11 +266,11 @@ export default function RecordScreen() {
           <View style={styles.mountainIconCircle}>
             <View style={styles.mountainIconInner} />
           </View>
-          <Text className="typo-body-1-normal-semi-bold text-label-normal">
+          <Text className="text-label-normal typo-body-1-normal-semi-bold">
             {name ?? "관악산"}
           </Text>
           <Text
-            className="typo-body-1-normal-medium text-label-subtle"
+            className="text-label-subtle typo-body-1-normal-medium"
             numberOfLines={1}
           >
             {courseName ?? ""}
@@ -243,10 +280,7 @@ export default function RecordScreen() {
 
       <ScrollView showsVerticalScrollIndicator={false}>
         {/* 거리 */}
-        <View
-          className="flex-row items-end px-5 pt-4 pb-3"
-          style={{ gap: 4 }}
-        >
+        <View className="flex-row items-end px-5 pb-3 pt-4" style={{ gap: 4 }}>
           <Text style={styles.distanceNumber}>
             {distanceKm != null ? distanceKm.toFixed(2) : "--"}
           </Text>
@@ -255,7 +289,7 @@ export default function RecordScreen() {
 
         {/* 루트 지도 */}
         <View
-          className="mx-5 rounded-xl overflow-hidden"
+          className="mx-5 overflow-hidden rounded-xl"
           style={styles.mapContainer}
         >
           {typeof Clive1Svg === "number" ? (
@@ -270,11 +304,36 @@ export default function RecordScreen() {
         </View>
 
         {/* 통계 */}
-        <View style={{ flexDirection: "row", marginHorizontal: 20, marginTop: 16, marginBottom: 16, gap: 4 }}>
+        <View
+          style={{
+            flexDirection: "row",
+            marginHorizontal: 20,
+            marginTop: 16,
+            marginBottom: 16,
+            gap: 4,
+          }}
+        >
           {[
-            { label: "소요시간", value: formatDuration(recordDetail?.durationSeconds ?? durationSec) },
-            { label: "고도", value: recordDetail?.ascentMeters != null ? `${Math.round(recordDetail.ascentMeters)}Nm` : "--" },
-            { label: "칼로리", value: recordDetail?.calories != null ? `${recordDetail.calories}kcal` : "--" },
+            {
+              label: "소요시간",
+              value: formatDuration(
+                recordDetail?.durationSeconds ?? durationSec,
+              ),
+            },
+            {
+              label: "고도",
+              value:
+                recordDetail?.ascentMeters != null
+                  ? `${Math.round(recordDetail.ascentMeters)}Nm`
+                  : "--",
+            },
+            {
+              label: "칼로리",
+              value:
+                recordDetail?.calories != null
+                  ? `${recordDetail.calories}kcal`
+                  : "--",
+            },
           ].map((stat) => (
             <View key={stat.label} style={styles.statItem}>
               <Text style={styles.statLabel}>{stat.label}</Text>
@@ -287,7 +346,7 @@ export default function RecordScreen() {
         <View style={styles.divider} />
 
         {/* 탭 */}
-        <View className="flex-row items-center px-5 pt-5 pb-4 gap-4">
+        <View className="flex-row items-center gap-4 px-5 pb-4 pt-5">
           {(["클라이브", "포토 리포트"] as RecordTab[]).map((tab) => (
             <TouchableOpacity key={tab} onPress={() => setActiveTab(tab)}>
               <Text
@@ -305,7 +364,11 @@ export default function RecordScreen() {
         {/* 클라이브 */}
         {activeTab === "클라이브" && (
           <View className="pb-10 pt-2">
-            <ViewShot ref={cliveShotRef} options={{ format: "jpg", quality: 1 }} style={{ width: 335, alignSelf: "center" }}>
+            <ViewShot
+              ref={cliveShotRef}
+              options={{ format: "jpg", quality: 1 }}
+              style={{ width: 335, alignSelf: "center" }}
+            >
               <View style={styles.cardWrap}>
                 {/* 왼쪽 그라디언트 바 — 정상 완료: 빨강까지 full */}
                 <LinearGradient
@@ -316,119 +379,161 @@ export default function RecordScreen() {
                   style={styles.gradientBar}
                 />
 
-                {displayPhotos.length > 0 ? (() => {
-                  const photoHeight = CLIVE_CARD_HEIGHT / displayPhotos.length;
-                  const BLEND = 30; // 경계 블렌딩 픽셀
+                {displayPhotos.length > 0 ? (
+                  (() => {
+                    const photoHeight =
+                      CLIVE_CARD_HEIGHT / displayPhotos.length;
+                    const BLEND = 30; // 경계 블렌딩 픽셀
 
-                  const maskDefs = displayPhotos.map((_, i) => {
-                    const hasTop = i > 0;
-                    const hasBottom = i < displayPhotos.length - 1;
-                    const yStart = i * photoHeight - (hasTop ? BLEND : 0);
-                    const totalH = photoHeight + (hasTop ? BLEND : 0) + (hasBottom ? BLEND : 0);
-                    const stops: { offset: string; op: string }[] = [];
-                    if (hasTop) {
-                      stops.push({ offset: "0", op: "0" });
-                      stops.push({ offset: (BLEND / totalH).toFixed(3), op: "1" });
-                    } else {
-                      stops.push({ offset: "0", op: "1" });
-                    }
-                    if (hasBottom) {
-                      stops.push({ offset: ((totalH - BLEND) / totalH).toFixed(3), op: "1" });
-                      stops.push({ offset: "1", op: "0" });
-                    } else {
-                      stops.push({ offset: "1", op: "1" });
-                    }
-                    return { i, yStart, totalH, stops };
-                  });
+                    const maskDefs = displayPhotos.map((_, i) => {
+                      const hasTop = i > 0;
+                      const hasBottom = i < displayPhotos.length - 1;
+                      const yStart = i * photoHeight - (hasTop ? BLEND : 0);
+                      const totalH =
+                        photoHeight +
+                        (hasTop ? BLEND : 0) +
+                        (hasBottom ? BLEND : 0);
+                      const stops: { offset: string; op: string }[] = [];
+                      if (hasTop) {
+                        stops.push({ offset: "0", op: "0" });
+                        stops.push({
+                          offset: (BLEND / totalH).toFixed(3),
+                          op: "1",
+                        });
+                      } else {
+                        stops.push({ offset: "0", op: "1" });
+                      }
+                      if (hasBottom) {
+                        stops.push({
+                          offset: ((totalH - BLEND) / totalH).toFixed(3),
+                          op: "1",
+                        });
+                        stops.push({ offset: "1", op: "0" });
+                      } else {
+                        stops.push({ offset: "1", op: "1" });
+                      }
+                      return { i, yStart, totalH, stops };
+                    });
 
-                  return (
-                    <>
-                      <Svg
-                        width={335}
-                        height={CLIVE_CARD_HEIGHT}
-                        style={StyleSheet.absoluteFill}
-                      >
-                        <Defs>
-                          {maskDefs.flatMap((d) => [
-                            <SvgLinearGradient
-                              key={`grad-${d.i}`}
-                              id={`fade-${d.i}`}
-                              x1="0" y1={d.yStart}
-                              x2="0" y2={d.yStart + d.totalH}
-                              gradientUnits="userSpaceOnUse"
-                            >
-                              {d.stops.map((s, j) => (
-                                <Stop key={j} offset={s.offset} stopColor="white" stopOpacity={s.op} />
-                              ))}
-                            </SvgLinearGradient>,
-                            <Mask
-                              key={`mask-${d.i}`}
-                              id={`mask-${d.i}`}
-                              x={0} y={d.yStart}
-                              width={335} height={d.totalH}
-                              maskUnits="userSpaceOnUse"
-                            >
-                              <SvgRect
-                                x={0} y={d.yStart}
-                                width={335} height={d.totalH}
-                                fill={`url(#fade-${d.i})`}
+                    return (
+                      <>
+                        <Svg
+                          width={335}
+                          height={CLIVE_CARD_HEIGHT}
+                          style={StyleSheet.absoluteFill}
+                        >
+                          <Defs>
+                            {maskDefs.flatMap((d) => [
+                              <SvgLinearGradient
+                                key={`grad-${d.i}`}
+                                id={`fade-${d.i}`}
+                                x1="0"
+                                y1={d.yStart}
+                                x2="0"
+                                y2={d.yStart + d.totalH}
+                                gradientUnits="userSpaceOnUse"
+                              >
+                                {d.stops.map((s, j) => (
+                                  <Stop
+                                    key={j}
+                                    offset={s.offset}
+                                    stopColor="white"
+                                    stopOpacity={s.op}
+                                  />
+                                ))}
+                              </SvgLinearGradient>,
+                              <Mask
+                                key={`mask-${d.i}`}
+                                id={`mask-${d.i}`}
+                                x={0}
+                                y={d.yStart}
+                                width={335}
+                                height={d.totalH}
+                                maskUnits="userSpaceOnUse"
+                              >
+                                <SvgRect
+                                  x={0}
+                                  y={d.yStart}
+                                  width={335}
+                                  height={d.totalH}
+                                  fill={`url(#fade-${d.i})`}
+                                />
+                              </Mask>,
+                            ])}
+                          </Defs>
+                          {/* 역순 렌더링: 위쪽 사진(summit)이 z-order 최상단 */}
+                          {[...displayPhotos].reverse().map((url, revIdx) => {
+                            const i = displayPhotos.length - 1 - revIdx;
+                            const d = maskDefs[i];
+                            return (
+                              <SvgImage
+                                key={url}
+                                href={{ uri: url }}
+                                x={0}
+                                y={d.yStart}
+                                width={335}
+                                height={d.totalH}
+                                preserveAspectRatio="xMidYMid slice"
+                                mask={`url(#mask-${i})`}
                               />
-                            </Mask>,
-                          ])}
-                        </Defs>
-                        {/* 역순 렌더링: 위쪽 사진(summit)이 z-order 최상단 */}
-                        {[...displayPhotos].reverse().map((url, revIdx) => {
-                          const i = displayPhotos.length - 1 - revIdx;
-                          const d = maskDefs[i];
+                            );
+                          })}
+                        </Svg>
+
+                        {/* 스탬프 오버레이 */}
+                        {displayPhotos.map((url, displayIndex) => {
+                          const originalIndex =
+                            clivePhotos.length - 1 - displayIndex;
+                          const isSummit =
+                            originalIndex === clivePhotos.length - 1;
+                          const altitudeLabel =
+                            ALTITUDE_LABELS[originalIndex] ?? "";
                           return (
-                            <SvgImage
-                              key={url}
-                              href={{ uri: url }}
-                              x={0}
-                              y={d.yStart}
-                              width={335}
-                              height={d.totalH}
-                              preserveAspectRatio="xMidYMid slice"
-                              mask={`url(#mask-${i})`}
-                            />
+                            <View
+                              key={url + "-stamp"}
+                              style={{
+                                position: "absolute",
+                                top: displayIndex * photoHeight,
+                                left: 0,
+                                right: 0,
+                                height: photoHeight,
+                              }}
+                            >
+                              {isSummit ? (
+                                <View
+                                  style={[
+                                    StyleSheet.absoluteFill,
+                                    styles.stampSummitContainer,
+                                  ]}
+                                >
+                                  <View style={styles.summitBadge}>
+                                    <Text style={styles.summitBadgeText}>
+                                      정상
+                                    </Text>
+                                  </View>
+                                  <Text style={styles.altitudeText}>
+                                    {altitudeLabel}
+                                  </Text>
+                                </View>
+                              ) : (
+                                <View
+                                  style={[
+                                    StyleSheet.absoluteFill,
+                                    styles.stampCenterContainer,
+                                  ]}
+                                >
+                                  <Text style={styles.altitudeText}>
+                                    {altitudeLabel}
+                                  </Text>
+                                </View>
+                              )}
+                            </View>
                           );
                         })}
-                      </Svg>
-
-                      {/* 스탬프 오버레이 */}
-                      {displayPhotos.map((url, displayIndex) => {
-                        const originalIndex = clivePhotos.length - 1 - displayIndex;
-                        const isSummit = originalIndex === clivePhotos.length - 1;
-                        const altitudeLabel = ALTITUDE_LABELS[originalIndex] ?? "";
-                        return (
-                          <View
-                            key={url + "-stamp"}
-                            style={{
-                              position: "absolute",
-                              top: displayIndex * photoHeight,
-                              left: 0,
-                              right: 0,
-                              height: photoHeight,
-                            }}
-                          >
-                            {isSummit ? (
-                              <View style={[StyleSheet.absoluteFill, styles.stampSummitContainer]}>
-                                <View style={styles.summitBadge}>
-                                  <Text style={styles.summitBadgeText}>정상</Text>
-                                </View>
-                                <Text style={styles.altitudeText}>{altitudeLabel}</Text>
-                              </View>
-                            ) : (
-                              <View style={[StyleSheet.absoluteFill, styles.stampCenterContainer]}>
-                                <Text style={styles.altitudeText}>{altitudeLabel}</Text>
-                              </View>
-                            )}
-                          </View>
-                        );
-                      })}
-                    </>
-                  );
-                })() : (
+                      </>
+                    );
+                  })()
+                ) : (
                   <View style={styles.cardImagePlaceholder} />
                 )}
               </View>
@@ -436,6 +541,7 @@ export default function RecordScreen() {
 
             <CliveBottomBar
               isPublic={activeTabPublic}
+              isToggling={isToggling}
               onTogglePublic={handleTogglePublic}
               onSave={handleSavePress}
             />
@@ -446,7 +552,10 @@ export default function RecordScreen() {
         {activeTab === "포토 리포트" && (
           <View className="pb-10 pt-2">
             <View style={{ width: 335, alignSelf: "center" }}>
-              <ViewShot ref={photoReportShotRef} options={{ format: "jpg", quality: 1 }}>
+              <ViewShot
+                ref={photoReportShotRef}
+                options={{ format: "jpg", quality: 1 }}
+              >
                 <View style={styles.cardWrap}>
                   {/* 배경 사진 */}
                   <ExpoImage
@@ -457,7 +566,9 @@ export default function RecordScreen() {
 
                   {/* 스탯 오버레이 */}
                   <ExpoImage
-                    source={OVERLAY_STATS[photoReportTemplate] ?? OVERLAY_STATS[0]}
+                    source={
+                      OVERLAY_STATS[photoReportTemplate] ?? OVERLAY_STATS[0]
+                    }
                     style={StyleSheet.absoluteFill}
                     contentFit="cover"
                     pointerEvents="none"
@@ -467,9 +578,17 @@ export default function RecordScreen() {
 
               {/* 편집하기 버튼 — ViewShot 밖에 위치해 캡처에서 제외 */}
               <TouchableOpacity
-                style={[styles.editChip, { position: "absolute", top: 16, right: 16 }]}
+                style={[
+                  styles.editChip,
+                  { position: "absolute", top: 16, right: 16 },
+                ]}
                 activeOpacity={0.7}
-                onPress={() => router.push({ pathname: "/record/photo-report-edit", params: { sessionId: String(sessionId ?? "") } })}
+                onPress={() =>
+                  router.push({
+                    pathname: "/record/photo-report-edit",
+                    params: { sessionId: String(sessionId ?? "") },
+                  })
+                }
               >
                 <PencilSimpleIcon size={16} color="#FFFFFF" />
                 <Text style={styles.editChipText}>편집하기</Text>
@@ -478,6 +597,7 @@ export default function RecordScreen() {
 
             <CliveBottomBar
               isPublic={activeTabPublic}
+              isToggling={isToggling}
               onTogglePublic={handleTogglePublic}
               onSave={handleSavePress}
             />

--- a/components/bottom-sheet-shell.tsx
+++ b/components/bottom-sheet-shell.tsx
@@ -1,9 +1,9 @@
-import { ReactNode } from 'react';
-import { ScrollView } from 'react-native-gesture-handler';
-import { Text, View } from 'react-native';
+import { ReactNode } from "react";
+import { Text, View } from "react-native";
+import { ScrollView } from "react-native-gesture-handler";
 
 type Props = {
-  title: string;
+  title?: string;
   titleCount?: number;
   titleSuffix?: ReactNode;
   header?: ReactNode;
@@ -12,14 +12,22 @@ type Props = {
   scrollEnabled?: boolean;
 };
 
-export default function BottomSheetShell({ title, titleCount, titleSuffix, header, aboveTitle, children, scrollEnabled = false }: Props) {
+export default function BottomSheetShell({
+  title,
+  titleCount,
+  titleSuffix,
+  header,
+  aboveTitle,
+  children,
+  scrollEnabled = false,
+}: Props) {
   return (
-    <View className="flex-1 w-full">
+    <View className="w-full flex-1">
       {/* 탭바 등 헤더 슬롯 */}
       {header && <View className="w-full">{header}</View>}
 
       <ScrollView
-        className="flex-1 w-full"
+        className="w-full flex-1"
         contentContainerClassName="w-full px-4 pt-3 flex-grow"
         showsVerticalScrollIndicator={false}
         scrollEnabled={scrollEnabled}
@@ -30,9 +38,13 @@ export default function BottomSheetShell({ title, titleCount, titleSuffix, heade
 
           {/* 섹션 타이틀 */}
           <View className="flex-row items-center gap-1">
-            <Text className="typo-headline-1-semi-bold text-label-normal">{title}</Text>
+            <Text className="text-label-normal typo-headline-1-semi-bold">
+              {title}
+            </Text>
             {titleCount !== undefined && (
-              <Text className="typo-headline-1-semi-bold text-secondary-normal">{titleCount}</Text>
+              <Text className="text-secondary-normal typo-headline-1-semi-bold">
+                {titleCount}
+              </Text>
             )}
             {titleSuffix}
           </View>

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -71,6 +71,7 @@ export default function BottomSheet({
       <BottomSheetShell
         title={selectedCard.mountainName}
         titleCount={selectedCard.hikingCount}
+        scrollEnabled
       >
         <View className="pt-2.5">
           <CourseBottomSheet

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -1,49 +1,34 @@
-import { useMyMountainRecords } from '@/features/home/hooks/use-my-mountain-records';
-import { useClivePhotos } from '@/features/tracking/hooks/use-clive-photos';
-import { useRouter } from 'expo-router';
-import { useEffect, useState } from 'react';
-import { Image, Text, TouchableOpacity, View } from 'react-native';
-import BottomSheetShell from './bottom-sheet-shell';
-import CourseBottomSheet, { type Course } from './course-bottom-sheet';
-import { HikingStatsCard } from './hiking-stats-card';
-import { InfoIcon } from './icons/info-icon';
+import { useMyMountainRecords } from "@/features/home/hooks/use-my-mountain-records";
+import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
+import { GetUserHikingMountainRecordResponse } from "@/types/api.generated";
+import { useRouter } from "expo-router";
+import { useEffect, useState } from "react";
+import { Image, Text, TouchableOpacity, View } from "react-native";
+import BottomSheetShell from "./bottom-sheet-shell";
+import CourseBottomSheet from "./course-bottom-sheet";
+import { HikingStatsCard } from "./hiking-stats-card";
+import { InfoIcon } from "./icons/info-icon";
 
-export type Tab = '내 기록' | '큐레이션';
-
-type MountainCard = {
-  id: string;
-  mountainId: number;
-  name: string;
-  trailNumber: number;
-  daysAgo: number;
-  badgeCount: number;
-};
+export type Tab = "내 기록" | "큐레이션";
 
 type Props = {
-  cards?: MountainCard[];
+  cards?: GetUserHikingMountainRecordResponse[];
   title?: string;
   titleCount?: number;
   activeTab?: Tab;
   onTabChange?: (tab: Tab) => void;
-  onCardSelect?: (id: string) => void;
+  onCardSelect?: (id: number) => void;
   showTabs?: boolean;
   scrollEnabled?: boolean;
   onDetailOpenChange?: (isOpen: boolean) => void;
   closeSelectedToken?: number;
 };
 
-const TABS: Tab[] = ['내 기록', '큐레이션'];
-
-const MOCK_CARDS: MountainCard[] = [
-  { id: '1', mountainId: 1, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '2', mountainId: 2, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '3', mountainId: 3, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-  { id: '4', mountainId: 4, name: '산 이름', trailNumber: 1, daysAgo: 1, badgeCount: 1 },
-];
+const TABS: Tab[] = ["내 기록", "큐레이션"];
 
 export default function BottomSheet({
-  cards = MOCK_CARDS,
-  title = '타이틀',
+  cards,
+  title = "타이틀",
   titleCount = 1,
   activeTab: activeTabProp,
   onTabChange,
@@ -54,13 +39,14 @@ export default function BottomSheet({
   closeSelectedToken,
 }: Props) {
   const router = useRouter();
-  const [internalTab, setInternalTab] = useState<Tab>('내 기록');
+  const [internalTab, setInternalTab] = useState<Tab>("내 기록");
   const activeTab = activeTabProp ?? internalTab;
   const setActiveTab = (tab: Tab) => {
     setInternalTab(tab);
     onTabChange?.(tab);
   };
-  const [selectedCard, setSelectedCard] = useState<MountainCard | null>(null);
+  const [selectedCard, setSelectedCard] =
+    useState<GetUserHikingMountainRecordResponse | null>(null);
 
   useEffect(() => {
     onDetailOpenChange?.(selectedCard !== null);
@@ -72,42 +58,39 @@ export default function BottomSheet({
     }
   }, [closeSelectedToken]);
 
-  const { data: mountainRecords = [] } = useMyMountainRecords(
-    selectedCard ? Number(selectedCard.id) : null
-  );
+  const {
+    data: mountainRecords,
+    isPending,
+    isError,
+  } = useMyMountainRecords(selectedCard?.mountainId);
 
-  const selectedCardCourses: Course[] = mountainRecords.map((record) => ({
-    id: String(record.hikingRecordId),
-    name: record.courseName ?? '',
-    distanceKm: record.distance ?? 0,
-    durationHours: record.duration ?? 0,
-    date: formatHikedAt(record.hikedAt),
-    imageUris: record.imageUrls ?? [],
-  }));
+  if (isPending) return null;
+  if (isError) return null;
+  if (!cards) return null;
 
   if (selectedCard) {
     return (
       <BottomSheetShell
-        title={selectedCard.name}
-        titleCount={selectedCard.badgeCount}
+        title={selectedCard.mountainName}
+        titleCount={selectedCard.hikingCount}
       >
         <View className="pt-2.5">
           <CourseBottomSheet
-            courses={selectedCardCourses}
+            courses={mountainRecords}
             onCoursePress={(courseId) => {
               const record = mountainRecords.find(
-                (r) => String(r.hikingRecordId) === courseId
+                (r) => r.hikingRecordId === courseId,
               );
               router.push({
-                pathname: '/record/[id]',
+                pathname: "/record/[id]",
                 params: {
                   id: String(record?.sessionId ?? courseId),
-                  hikingRecordId: String(record?.hikingRecordId ?? ''),
-                  name: selectedCard.name,
-                  courseName: record?.courseName ?? '',
-                  imageUri: '',
-                  distance: String(record?.distance ?? ''),
-                  duration: String(record?.duration ?? ''),
+                  hikingRecordId: String(record?.hikingRecordId ?? ""),
+                  name: selectedCard.mountainName,
+                  courseName: record?.courseName ?? "",
+                  imageUri: "",
+                  distance: String(record?.distance ?? ""),
+                  duration: String(record?.duration ?? ""),
                 },
               });
             }}
@@ -117,9 +100,13 @@ export default function BottomSheet({
     );
   }
 
-  const tabTitle = showTabs && activeTab === '큐레이션' ? '큐레이션' : title;
-  const tabTitleCount = showTabs && activeTab === '큐레이션' ? undefined : titleCount;
-  const tabTitleSuffix = showTabs && activeTab === '큐레이션' ? <InfoIcon size={16.25} /> : undefined;
+  const tabTitle = showTabs && activeTab === "큐레이션" ? "큐레이션" : title;
+  const tabTitleCount =
+    showTabs && activeTab === "큐레이션" ? undefined : titleCount;
+  const tabTitleSuffix =
+    showTabs && activeTab === "큐레이션" ? (
+      <InfoIcon size={16.25} />
+    ) : undefined;
 
   return (
     <BottomSheetShell
@@ -127,59 +114,68 @@ export default function BottomSheet({
       titleCount={tabTitleCount}
       titleSuffix={tabTitleSuffix}
       scrollEnabled={scrollEnabled}
-      aboveTitle={activeTab === '내 기록' ? <HikingStatsCard /> : undefined}
-      header={showTabs ? (
-        <View className="flex-row items-center bg-fill-stronger rounded-[10px] p-1 gap-1 mx-4 mb-4">
-          {TABS.map((tab) => (
-            <TouchableOpacity
-              key={tab}
-              className={`flex-1 items-center py-2 rounded-[10px] ${
-                activeTab === tab ? 'bg-fill-normal' : ''
-              }`}
-              onPress={() => setActiveTab(tab)}
-            >
-              <Text
-                className={`typo-label-medium ${
-                  activeTab === tab ? 'text-label-normal' : 'text-label-subtler'
+      aboveTitle={activeTab === "내 기록" ? <HikingStatsCard /> : undefined}
+      header={
+        showTabs ? (
+          <View className="mx-4 mb-4 flex-row items-center gap-1 rounded-[10px] bg-fill-stronger p-1">
+            {TABS.map((tab) => (
+              <TouchableOpacity
+                key={tab}
+                className={`flex-1 items-center rounded-[10px] py-2 ${
+                  activeTab === tab ? "bg-fill-normal" : ""
                 }`}
+                onPress={() => setActiveTab(tab)}
               >
-                {tab}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      ) : undefined}
+                <Text
+                  className={`typo-label-medium ${
+                    activeTab === tab
+                      ? "text-label-normal"
+                      : "text-label-subtler"
+                  }`}
+                >
+                  {tab}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        ) : undefined
+      }
     >
-      {activeTab === '내 기록' && (
+      {activeTab === "내 기록" && (
         <View className="w-full gap-y-4">
-          {Array.from({ length: Math.ceil(cards.length / 2) }).map((_, rowIdx) => {
-            const rowCards = cards.slice(rowIdx * 2, rowIdx * 2 + 2);
-            return (
-              <View key={rowIdx} className="flex-row gap-x-[9px]">
-                {rowCards.map((card) => (
-                  <MountainCard key={card.id} card={card} onPress={() => {
-                    onCardSelect?.(card.id);
-                    setSelectedCard(card);
-                  }} />
-                ))}
-                {rowCards.length === 1 && <View className="flex-1" />}
-              </View>
-            );
-          })}
+          {Array.from({ length: Math.ceil(cards.length / 2) }).map(
+            (_, rowIdx) => {
+              const rowCards = cards.slice(rowIdx * 2, rowIdx * 2 + 2);
+              return (
+                <View key={rowIdx} className="flex-row gap-x-[9px]">
+                  {rowCards.map((card) => (
+                    <MountainCard
+                      key={card.mountainId}
+                      card={card}
+                      onPress={() => {
+                        onCardSelect?.(card.mountainId ?? 0);
+                        setSelectedCard(card);
+                      }}
+                    />
+                  ))}
+                  {rowCards.length === 1 && <View className="flex-1" />}
+                </View>
+              );
+            },
+          )}
         </View>
       )}
 
-      {activeTab === '큐레이션' && (
-        <View />
-      )}
+      {activeTab === "큐레이션" && <View />}
     </BottomSheetShell>
   );
 }
 
-function MountainCardThumbnail({ mountainId }: { mountainId: number }) {
+function MountainCardThumbnail({ mountainId }: { mountainId?: number }) {
   const { data: records = [] } = useMyMountainRecords(mountainId);
-  const sorted = [...records].sort((a, b) =>
-    new Date(b.hikedAt ?? 0).getTime() - new Date(a.hikedAt ?? 0).getTime()
+  const sorted = [...records].sort(
+    (a, b) =>
+      new Date(b.hikedAt ?? 0).getTime() - new Date(a.hikedAt ?? 0).getTime(),
   );
   const latestSessionId = sorted[0]?.sessionId ?? null;
   const { data: photos = [] } = useClivePhotos(latestSessionId);
@@ -192,53 +188,55 @@ function MountainCardThumbnail({ mountainId }: { mountainId: number }) {
       {bgPhoto ? (
         <Image
           source={{ uri: bgPhoto }}
-          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
           resizeMode="cover"
         />
       ) : null}
       {mainPhoto ? (
         <Image
           source={{ uri: mainPhoto }}
-          style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
           resizeMode="cover"
         />
       ) : (
-        <View className="absolute inset-0 bg-fill-stronger items-center justify-center" />
+        <View className="absolute inset-0 items-center justify-center bg-fill-stronger" />
       )}
     </>
   );
 }
 
-function MountainCard({ card, onPress }: { card: MountainCard; onPress: () => void }) {
+function MountainCard({
+  card,
+  onPress,
+}: {
+  card: GetUserHikingMountainRecordResponse;
+  onPress: () => void;
+}) {
   return (
     <TouchableOpacity className="flex-1 gap-1" onPress={onPress}>
       {/* 이미지 */}
-      <View className="self-stretch h-[88px] rounded-[10px] overflow-hidden flex-col items-end p-2 gap-2.5">
+      <View className="h-[88px] flex-col items-end gap-2.5 self-stretch overflow-hidden rounded-[10px] p-2">
         <MountainCardThumbnail mountainId={card.mountainId} />
         {/* 뱃지 */}
-        <View className="w-7 h-7 rounded-full bg-label-normal items-center justify-center z-10">
-          <Text className="typo-body-3-semi-bold text-common-100 text-center">{card.badgeCount}</Text>
+        <View className="z-10 h-7 w-7 items-center justify-center rounded-full bg-label-normal">
+          <Text className="text-center text-common-100 typo-body-3-semi-bold">
+            {card.hikingCount}
+          </Text>
         </View>
       </View>
 
       {/* 텍스트 */}
       <View className="gap-0.5 px-1">
-        <Text className="typo-body-1-normal-semi-bold text-label-normal" numberOfLines={1}>
-          {card.name}
+        <Text
+          className="text-label-normal typo-body-1-normal-semi-bold"
+          numberOfLines={1}
+        >
+          {card.mountainName}
         </Text>
-        <Text className="typo-caption-1-medium text-label-subtler">
-          {card.trailNumber}번 등산 · {card.daysAgo}일 전
+        <Text className="text-label-subtler typo-caption-1-medium">
+          {card.hikingCount}번 등산 · {card.lastHikedAt}일 전
         </Text>
       </View>
     </TouchableOpacity>
   );
-}
-
-function formatHikedAt(dateStr?: string): string {
-  if (!dateStr) return '';
-  const d = new Date(dateStr);
-  const yy = String(d.getFullYear()).slice(2);
-  const mm = d.getMonth() + 1;
-  const dd = d.getDate();
-  return `${yy}년 ${mm}월 ${dd}일`;
 }

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -1,6 +1,6 @@
 import { useMyMountainRecords } from "@/features/home/hooks/use-my-mountain-records";
-import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
 import { GetUserHikingMountainRecordResponse } from "@/types/api.generated";
+import { getDaysAgo } from "@/utils/get-days-ago";
 import { useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import { Image, Text, TouchableOpacity, View } from "react-native";
@@ -45,6 +45,7 @@ export default function BottomSheet({
     setInternalTab(tab);
     onTabChange?.(tab);
   };
+
   const [selectedCard, setSelectedCard] =
     useState<GetUserHikingMountainRecordResponse | null>(null);
 
@@ -58,17 +59,13 @@ export default function BottomSheet({
     }
   }, [closeSelectedToken]);
 
-  const {
-    data: mountainRecords,
-    isPending,
-    isError,
-  } = useMyMountainRecords(selectedCard?.mountainId);
+  const { data: mountainRecords } = useMyMountainRecords(
+    selectedCard?.mountainId,
+  );
 
-  if (isPending) return null;
-  if (isError) return null;
   if (!cards) return null;
 
-  if (selectedCard) {
+  if (selectedCard && mountainRecords) {
     return (
       <BottomSheetShell
         title={selectedCard.mountainName}
@@ -171,17 +168,9 @@ export default function BottomSheet({
   );
 }
 
-function MountainCardThumbnail({ mountainId }: { mountainId?: number }) {
-  const { data: records = [] } = useMyMountainRecords(mountainId);
-  const sorted = [...records].sort(
-    (a, b) =>
-      new Date(b.hikedAt ?? 0).getTime() - new Date(a.hikedAt ?? 0).getTime(),
-  );
-  const latestSessionId = sorted[0]?.sessionId ?? null;
-  const { data: photos = [] } = useClivePhotos(latestSessionId);
-
-  const mainPhoto = photos[photos.length - 1];
-  const bgPhoto = photos[photos.length - 2];
+function MountainCardThumbnail({ imageUrls }: { imageUrls?: string[] }) {
+  const mainPhoto = imageUrls?.[0];
+  const bgPhoto = imageUrls?.[1];
 
   return (
     <>
@@ -216,7 +205,7 @@ function MountainCard({
     <TouchableOpacity className="flex-1 gap-1" onPress={onPress}>
       {/* 이미지 */}
       <View className="h-[88px] flex-col items-end gap-2.5 self-stretch overflow-hidden rounded-[10px] p-2">
-        <MountainCardThumbnail mountainId={card.mountainId} />
+        <MountainCardThumbnail imageUrls={card.imageUrls} />
         {/* 뱃지 */}
         <View className="z-10 h-7 w-7 items-center justify-center rounded-full bg-label-normal">
           <Text className="text-center text-common-100 typo-body-3-semi-bold">
@@ -234,7 +223,10 @@ function MountainCard({
           {card.mountainName}
         </Text>
         <Text className="text-label-subtler typo-caption-1-medium">
-          {card.hikingCount}번 등산 · {card.lastHikedAt}일 전
+          {card.hikingCount}번 등산 ·{" "}
+          {getDaysAgo(card.lastHikedAt) === 0
+            ? "오늘"
+            : `${getDaysAgo(card.lastHikedAt)}일 전`}
         </Text>
       </View>
     </TouchableOpacity>

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -1,9 +1,10 @@
 import { useMyMountainRecords } from "@/features/home/hooks/use-my-mountain-records";
+import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import { GetUserHikingMountainRecordResponse } from "@/types/api.generated";
 import { getDaysAgo } from "@/utils/get-days-ago";
 import { useRouter } from "expo-router";
 import { useEffect, useState } from "react";
-import { Image, Text, TouchableOpacity, View } from "react-native";
+import { Image, Pressable, Text, TouchableOpacity, View } from "react-native";
 import BottomSheetShell from "./bottom-sheet-shell";
 import CourseBottomSheet from "./course-bottom-sheet";
 import { HikingStatsCard } from "./hiking-stats-card";
@@ -74,6 +75,7 @@ export default function BottomSheet({
         <View className="pt-2.5">
           <CourseBottomSheet
             courses={mountainRecords}
+            mountainId={selectedCard.mountainId}
             onCoursePress={(courseId) => {
               const record = mountainRecords.find(
                 (r) => r.hikingRecordId === courseId,
@@ -168,29 +170,26 @@ export default function BottomSheet({
   );
 }
 
-function MountainCardThumbnail({ imageUrls }: { imageUrls?: string[] }) {
-  const mainPhoto = imageUrls?.[0];
-  const bgPhoto = imageUrls?.[1];
+function MountainCardThumbnail({
+  mountainId,
+  imageUrls,
+}: {
+  mountainId?: number;
+  imageUrls?: string[];
+}) {
+  const { data: detail } = useMountainDetail(mountainId ?? 0);
+  const resolvedUrls =
+    imageUrls && imageUrls.length > 0 ? imageUrls : detail?.mountain?.imageUrls;
+  const photo = resolvedUrls?.[0];
 
-  return (
-    <>
-      {bgPhoto ? (
-        <Image
-          source={{ uri: bgPhoto }}
-          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
-          resizeMode="cover"
-        />
-      ) : null}
-      {mainPhoto ? (
-        <Image
-          source={{ uri: mainPhoto }}
-          style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
-          resizeMode="cover"
-        />
-      ) : (
-        <View className="absolute inset-0 items-center justify-center bg-fill-stronger" />
-      )}
-    </>
+  return photo ? (
+    <Image
+      source={{ uri: photo }}
+      style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+      resizeMode="cover"
+    />
+  ) : (
+    <View className="absolute inset-0 items-center justify-center bg-fill-stronger" />
   );
 }
 
@@ -202,10 +201,13 @@ function MountainCard({
   onPress: () => void;
 }) {
   return (
-    <TouchableOpacity className="flex-1 gap-1" onPress={onPress}>
+    <Pressable className="flex-1 gap-1" onPress={onPress}>
       {/* 이미지 */}
       <View className="h-[88px] flex-col items-end gap-2.5 self-stretch overflow-hidden rounded-[10px] p-2">
-        <MountainCardThumbnail imageUrls={card.imageUrls} />
+        <MountainCardThumbnail
+          mountainId={card.mountainId}
+          imageUrls={card.imageUrls}
+        />
         {/* 뱃지 */}
         <View className="z-10 h-7 w-7 items-center justify-center rounded-full bg-label-normal">
           <Text className="text-center text-common-100 typo-body-3-semi-bold">
@@ -229,6 +231,6 @@ function MountainCard({
             : `${getDaysAgo(card.lastHikedAt)}일 전`}
         </Text>
       </View>
-    </TouchableOpacity>
+    </Pressable>
   );
 }

--- a/components/clive-bottom-bar.tsx
+++ b/components/clive-bottom-bar.tsx
@@ -1,60 +1,66 @@
 import { DownloadSimpleIcon } from "@/components/icons/download-simple-icon";
 import { GlobeSimpleIcon } from "@/components/icons/globe-simple-icon";
 import { LockIcon } from "@/components/icons/lock-icon";
-import { Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
 
 type Props = {
   isPublic: boolean;
+  isToggling?: boolean;
   onTogglePublic: () => void;
   onSave: () => void;
 };
 
-export function CliveBottomBar({ isPublic, onTogglePublic, onSave }: Props) {
+export function CliveBottomBar({
+  isPublic,
+  isToggling = false,
+  onTogglePublic,
+  onSave,
+}: Props) {
   return (
     <View
       className="flex-row items-center justify-end"
       style={{ height: 38, paddingHorizontal: 24, gap: 12, marginTop: 12 }}
     >
-      <TouchableOpacity
-        className="flex-row items-center"
-        style={{ width: 125, height: 38, gap: 8 }}
-        hitSlop={8}
-        onPress={onTogglePublic}
-      >
+      <View className="flex-row items-center" style={{ gap: 8 }}>
         <Text className="typo-body-2-normal-medium text-label-subtle">
           {isPublic ? "전체 공개" : "나만 보기"}
         </Text>
-        <View
-          style={{
-            width: 68,
-            height: 38,
-            borderRadius: 999,
-            backgroundColor: isPublic ? "#2F323A" : "#D1D5DB",
-            padding: 3,
-            justifyContent: "center",
-          }}
-        >
+        <Pressable hitSlop={8} onPress={onTogglePublic} disabled={isToggling}>
           <View
             style={{
-              width: 32,
-              height: 32,
+              width: 68,
+              height: 38,
               borderRadius: 999,
-              backgroundColor: "#FFFFFF",
-              alignItems: "center",
+              backgroundColor: isPublic ? "#2F323A" : "#D1D5DB",
+              opacity: isToggling ? 0.5 : 1,
+              padding: 3,
               justifyContent: "center",
-              alignSelf: isPublic ? "flex-end" : "flex-start",
             }}
           >
-            {isPublic ? (
-              <GlobeSimpleIcon size={16} color="#1A1B1F" />
-            ) : (
-              <LockIcon size={16} color="#73798C" />
-            )}
+            <View
+              style={{
+                width: 32,
+                height: 32,
+                borderRadius: 999,
+                backgroundColor: "#FFFFFF",
+                alignItems: "center",
+                justifyContent: "center",
+                alignSelf: isPublic ? "flex-end" : "flex-start",
+              }}
+            >
+              {isToggling ? (
+                <ActivityIndicator size="small" color="#1A1B1F" />
+              ) : isPublic ? (
+                <GlobeSimpleIcon size={16} color="#1A1B1F" />
+              ) : (
+                <LockIcon size={16} color="#73798C" />
+              )}
+            </View>
           </View>
-        </View>
-      </TouchableOpacity>
+        </Pressable>
+      </View>
 
-      <TouchableOpacity
+      <Pressable
         style={{
           width: 38,
           height: 38,
@@ -67,7 +73,7 @@ export function CliveBottomBar({ isPublic, onTogglePublic, onSave }: Props) {
         onPress={onSave}
       >
         <DownloadSimpleIcon size={20} color="#1A1B1F" />
-      </TouchableOpacity>
+      </Pressable>
     </View>
   );
 }

--- a/components/course-bottom-sheet.tsx
+++ b/components/course-bottom-sheet.tsx
@@ -1,5 +1,15 @@
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { ChevronRightIcon } from './icons/chevron-right-icon';
+import { GetUserHikingRecordResponse } from "@/types/api.generated";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { ChevronRightIcon } from "./icons/chevron-right-icon";
+
+function formatHikedAt(dateStr?: string): string {
+  if (!dateStr) return "";
+  const d = new Date(dateStr);
+  const yy = String(d.getFullYear()).slice(2);
+  const mm = d.getMonth() + 1;
+  const dd = d.getDate();
+  return `${yy}년 ${mm}월 ${dd}일`;
+}
 
 function formatDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600);
@@ -19,21 +29,43 @@ export type Course = {
 };
 
 export const MOCK_COURSES: Course[] = [
-  { id: '1', name: '코스이름', distanceKm: 10, durationHours: 3, date: '24년 9월 5일' },
-  { id: '2', name: '코스이름', distanceKm: 10, durationHours: 3, date: '24년 9월 5일' },
-  { id: '3', name: '코스이름', distanceKm: 10, durationHours: 3, date: '24년 9월 5일' },
+  {
+    id: "1",
+    name: "코스이름",
+    distanceKm: 10,
+    durationHours: 3,
+    date: "24년 9월 5일",
+  },
+  {
+    id: "2",
+    name: "코스이름",
+    distanceKm: 10,
+    durationHours: 3,
+    date: "24년 9월 5일",
+  },
+  {
+    id: "3",
+    name: "코스이름",
+    distanceKm: 10,
+    durationHours: 3,
+    date: "24년 9월 5일",
+  },
 ];
 
 type Props = {
-  courses?: Course[];
-  onCoursePress?: (courseId: string) => void;
+  courses: GetUserHikingRecordResponse[];
+  onCoursePress?: (courseId?: number) => void;
 };
 
-export default function CourseBottomSheet({ courses = MOCK_COURSES, onCoursePress }: Props) {
+export default function CourseBottomSheet({ courses, onCoursePress }: Props) {
   return (
     <View className="gap-2.5">
       {courses.map((course) => (
-        <CourseItem key={course.id} course={course} onPress={() => onCoursePress?.(course.id)} />
+        <CourseItem
+          key={course.courseId}
+          course={course}
+          onPress={() => onCoursePress?.(course.courseId)}
+        />
       ))}
     </View>
   );
@@ -45,8 +77,22 @@ function StackedThumbnail({ imageUris = [] }: { imageUris?: string[] }) {
   const n = imageUris.length;
 
   const cards = [
-    { isFront: false, uri: imageUris[n - 2], rotate: '6deg', translateX: 6.2, translateY: 0, zIndex: 1 },
-    { isFront: true,  uri: imageUris[n - 1], rotate: '0deg', translateX: 0,   translateY: 8, zIndex: 2 },
+    {
+      isFront: false,
+      uri: imageUris[n - 2],
+      rotate: "6deg",
+      translateX: 6.2,
+      translateY: 0,
+      zIndex: 1,
+    },
+    {
+      isFront: true,
+      uri: imageUris[n - 1],
+      rotate: "0deg",
+      translateX: 0,
+      translateY: 8,
+      zIndex: 2,
+    },
   ];
 
   return (
@@ -54,8 +100,8 @@ function StackedThumbnail({ imageUris = [] }: { imageUris?: string[] }) {
       {cards.map((card, i) => (
         <View
           key={i}
-          className={`absolute rounded-[10px] overflow-hidden ${
-            card.isFront ? 'bg-fill-strong' : 'bg-fill-neutral'
+          className={`absolute overflow-hidden rounded-[10px] ${
+            card.isFront ? "bg-fill-strong" : "bg-fill-neutral"
           }`}
           style={{
             width: W,
@@ -71,37 +117,50 @@ function StackedThumbnail({ imageUris = [] }: { imageUris?: string[] }) {
           {card.uri ? (
             <Image
               source={{ uri: card.uri }}
-              className="w-full h-full"
+              className="h-full w-full"
               resizeMode="cover"
             />
           ) : null}
-          {!card.isFront && (
-            <View className="absolute inset-0 bg-black/20" />
-          )}
+          {!card.isFront && <View className="absolute inset-0 bg-black/20" />}
         </View>
       ))}
     </View>
   );
 }
 
-function CourseItem({ course, onPress }: { course: Course; onPress?: () => void }) {
+function CourseItem({
+  course,
+  onPress,
+}: {
+  course: GetUserHikingRecordResponse;
+  onPress?: () => void;
+}) {
   return (
     <TouchableOpacity
-      className="flex-row items-center justify-between w-full"
+      className="w-full flex-row items-center justify-between"
       onPress={onPress}
       activeOpacity={0.85}
     >
       <View className="flex-row items-center" style={styles.leftGroup}>
         {/* 스택 썸네일 */}
-        <StackedThumbnail imageUris={course.imageUris} />
+        <StackedThumbnail imageUris={course.imageUrls} />
 
         {/* 텍스트 */}
         <View style={styles.textGroup}>
-          <Text className="typo-body-1-normal-semi-bold text-common-0" numberOfLines={1}>
-            {course.name}
+          <Text
+            className="text-common-0 typo-body-1-normal-semi-bold"
+            numberOfLines={1}
+          >
+            {course.courseName}
           </Text>
-          <Text className="typo-caption-1-medium text-label-subtler">
-            {(course.distanceKm / 1000).toFixed(1)}km · {formatDuration(course.durationHours)} · {course.date}
+          <Text className="text-label-subtler typo-caption-1-medium">
+            {course.distance && <>{(course.distance / 1000).toFixed(1)}km · </>}
+            {course.duration && (
+              <>
+                {formatDuration(course.duration)} ·{" "}
+                {formatHikedAt(course.hikedAt)}
+              </>
+            )}
           </Text>
         </View>
       </View>
@@ -129,8 +188,8 @@ const styles = StyleSheet.create({
     width: 32,
     height: 32,
     borderRadius: 999,
-    backgroundColor: '#FFFFFF',
-    alignItems: 'center',
-    justifyContent: 'center',
+    backgroundColor: "#FFFFFF",
+    alignItems: "center",
+    justifyContent: "center",
   },
 });

--- a/components/course-bottom-sheet.tsx
+++ b/components/course-bottom-sheet.tsx
@@ -1,3 +1,4 @@
+import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import { GetUserHikingRecordResponse } from "@/types/api.generated";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ChevronRightIcon } from "./icons/chevron-right-icon";
@@ -54,16 +55,22 @@ export const MOCK_COURSES: Course[] = [
 
 type Props = {
   courses: GetUserHikingRecordResponse[];
+  mountainId?: number;
   onCoursePress?: (courseId?: number) => void;
 };
 
-export default function CourseBottomSheet({ courses, onCoursePress }: Props) {
+export default function CourseBottomSheet({
+  courses,
+  mountainId,
+  onCoursePress,
+}: Props) {
   return (
     <View className="gap-2.5">
       {courses.map((course) => (
         <CourseItem
-          key={course.courseId}
+          key={course.hikingRecordId}
           course={course}
+          mountainId={mountainId}
           onPress={() => onCoursePress?.(course.courseId)}
         />
       ))}
@@ -71,23 +78,36 @@ export default function CourseBottomSheet({ courses, onCoursePress }: Props) {
   );
 }
 
-function StackedThumbnail({ imageUris = [] }: { imageUris?: string[] }) {
+function StackedThumbnail({
+  imageUris = [],
+  mountainId,
+}: {
+  imageUris?: string[];
+  mountainId?: number;
+}) {
+  const { data: detail } = useMountainDetail(mountainId ?? 0);
+  const resolvedUris =
+    imageUris.length > 0 ? imageUris : (detail?.mountain?.imageUrls ?? []);
   const W = 64;
   const H = 72;
-  const n = imageUris.length;
+  const n = resolvedUris.length;
 
   const cards = [
-    {
-      isFront: false,
-      uri: imageUris[n - 2],
-      rotate: "6deg",
-      translateX: 6.2,
-      translateY: 0,
-      zIndex: 1,
-    },
+    ...(n >= 2
+      ? [
+          {
+            isFront: false,
+            uri: resolvedUris[n - 2],
+            rotate: "6deg",
+            translateX: 6.2,
+            translateY: 0,
+            zIndex: 1,
+          },
+        ]
+      : []),
     {
       isFront: true,
-      uri: imageUris[n - 1],
+      uri: resolvedUris[n - 1],
       rotate: "0deg",
       translateX: 0,
       translateY: 8,
@@ -130,9 +150,11 @@ function StackedThumbnail({ imageUris = [] }: { imageUris?: string[] }) {
 
 function CourseItem({
   course,
+  mountainId,
   onPress,
 }: {
   course: GetUserHikingRecordResponse;
+  mountainId?: number;
   onPress?: () => void;
 }) {
   return (
@@ -143,7 +165,7 @@ function CourseItem({
     >
       <View className="flex-row items-center" style={styles.leftGroup}>
         {/* 스택 썸네일 */}
-        <StackedThumbnail imageUris={course.imageUrls} />
+        <StackedThumbnail imageUris={course.imageUrls} mountainId={mountainId} />
 
         {/* 텍스트 */}
         <View style={styles.textGroup}>

--- a/components/course-bottom-sheet.tsx
+++ b/components/course-bottom-sheet.tsx
@@ -165,7 +165,10 @@ function CourseItem({
     >
       <View className="flex-row items-center" style={styles.leftGroup}>
         {/* 스택 썸네일 */}
-        <StackedThumbnail imageUris={course.imageUrls} mountainId={mountainId} />
+        <StackedThumbnail
+          imageUris={course.imageUrls}
+          mountainId={mountainId}
+        />
 
         {/* 텍스트 */}
         <View style={styles.textGroup}>
@@ -176,8 +179,10 @@ function CourseItem({
             {course.courseName}
           </Text>
           <Text className="text-label-subtler typo-caption-1-medium">
-            {course.distance && <>{(course.distance / 1000).toFixed(1)}km · </>}
-            {course.duration && (
+            {!!course.distance && (
+              <>{(course.distance / 1000).toFixed(1)}km · </>
+            )}
+            {!!course.duration && (
               <>
                 {formatDuration(course.duration)} ·{" "}
                 {formatHikedAt(course.hikedAt)}

--- a/components/hiking-stats-card.tsx
+++ b/components/hiking-stats-card.tsx
@@ -1,16 +1,25 @@
-import { Text, View } from "react-native";
 import { useHikingSummary } from "@/features/mypage/hooks/use-hiking-summary";
+import { Text, View } from "react-native";
 
 export function HikingStatsCard() {
   const { data } = useHikingSummary();
 
   return (
-    <View className="bg-fill-strong rounded-2xl px-2 py-[22px] flex-row mb-3">
-      <StatItem label="누적 등산 횟수" value={`${data?.totalHikingCount ?? 0}회`} />
+    <View className="mb-3 flex-row rounded-2xl bg-fill-strong px-2 py-[22px]">
+      <StatItem
+        label="누적 등산 횟수"
+        value={`${data?.totalHikingCount ?? 0}회`}
+      />
       <Divider />
-      <StatItem label="정복한 산" value={`${data?.conqueredMountainCount ?? 0}개`} />
+      <StatItem
+        label="정복한 산"
+        value={`${data?.conqueredMountainCount ?? 0}개`}
+      />
       <Divider />
-      <StatItem label="누적 등산 고도" value={`${Math.round(data?.totalAltitude ?? 0)}Nm`} />
+      <StatItem
+        label="누적 등산 고도"
+        value={`${Math.round(data?.totalAltitude ?? 0)}m`}
+      />
     </View>
   );
 }
@@ -18,12 +27,16 @@ export function HikingStatsCard() {
 function StatItem({ label, value }: { label: string; value: string }) {
   return (
     <View className="flex-1 items-center gap-1">
-      <Text className="typo-caption-1-medium text-label-alternative">{label}</Text>
-      <Text className="typo-headline-1-semi-bold text-label-normal">{value}</Text>
+      <Text className="text-label-alternative typo-caption-1-medium">
+        {label}
+      </Text>
+      <Text className="text-label-normal typo-headline-1-semi-bold">
+        {value}
+      </Text>
     </View>
   );
 }
 
 function Divider() {
-  return <View className="w-px bg-line-subtle self-stretch opacity-50" />;
+  return <View className="w-px self-stretch bg-line-subtle opacity-50" />;
 }

--- a/components/home-bottom-sheet-container.tsx
+++ b/components/home-bottom-sheet-container.tsx
@@ -27,7 +27,7 @@ const SNAP_TIMING_EXPAND = {
 };
 
 function snapNearest(projected: number, snapExpanded: number): number {
-  'worklet';
+  "worklet";
   const snaps = [SNAP_COLLAPSED, SNAP_DEFAULT, snapExpanded];
   return snaps.reduce((a, b) =>
     Math.abs(a - projected) < Math.abs(b - projected) ? a : b,
@@ -51,7 +51,10 @@ type Props = {
 };
 
 export const HomeBottomSheetContainer = forwardRef<HomeBottomSheetRef, Props>(
-  function HomeBottomSheetContainer({ renderContent, heightSharedValue, snapExpanded }, ref) {
+  function HomeBottomSheetContainer(
+    { renderContent, heightSharedValue, snapExpanded },
+    ref,
+  ) {
     const internalHeight = useSharedValue(SNAP_DEFAULT);
     const height = heightSharedValue ?? internalHeight;
     const startH = useSharedValue(SNAP_DEFAULT);
@@ -80,16 +83,28 @@ export const HomeBottomSheetContainer = forwardRef<HomeBottomSheetRef, Props>(
         .onUpdate((e) => {
           height.value = Math.max(
             SNAP_COLLAPSED,
-            Math.min(snapExpanded, startH.value - e.translationY)
+            Math.min(snapExpanded, startH.value - e.translationY),
           );
         })
         .onEnd((e) => {
-          const target = snapNearest(height.value - e.velocityY * 0.15, snapExpanded);
-          height.value = withTiming(target, target === SNAP_COLLAPSED ? SNAP_TIMING_COLLAPSE : SNAP_TIMING_EXPAND);
+          const target = snapNearest(
+            height.value - e.velocityY * 0.15,
+            snapExpanded,
+          );
+          height.value = withTiming(
+            target,
+            target === SNAP_COLLAPSED
+              ? SNAP_TIMING_COLLAPSE
+              : SNAP_TIMING_EXPAND,
+          );
           // 기본 높이(디폴트)에서는 스크롤 비활성, 최대 높이에서만 스크롤 활성
           runOnJS(setScrollEnabled)(target === snapExpanded);
           runOnJS(setSnapState)(
-            target === SNAP_COLLAPSED ? 'collapsed' : target === snapExpanded ? 'expanded' : 'default'
+            target === SNAP_COLLAPSED
+              ? "collapsed"
+              : target === snapExpanded
+                ? "expanded"
+                : "default",
           );
         });
 

--- a/components/location-permission-sheet.tsx
+++ b/components/location-permission-sheet.tsx
@@ -11,12 +11,9 @@ export function LocationPermissionSheet() {
   }
 
   async function handleConfirm(): Promise<void> {
-    const { status } = await requestForegroundPermissionsAsync();
-    if (status !== "granted") return;
-
+    await requestForegroundPermissionsAsync();
     AsyncStorage.setItem("permission_sheet_shown", "true");
     setVisible(false);
-    requestLocation();
   }
 
   useEffect(() => {

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -80,7 +80,7 @@ function CuratedCard({
   return (
     <TouchableOpacity
       activeOpacity={0.9}
-      className="h-[160px] w-[164px] overflow-hidden rounded-xl bg-neutral-200"
+      className="h-[164px] w-[164px] overflow-hidden rounded-xl bg-neutral-200"
       onPress={() =>
         router.push({
           pathname: "/mountains/[id]",

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -1,15 +1,16 @@
-import { LinearGradient } from 'expo-linear-gradient';
-import { useRouter } from 'expo-router';
-import { Image, ScrollView, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
-import { HikingStartBanner } from '@/components/icons/hiking-start-banner';
-import { InfoIcon } from '@/components/icons/info-icon';
-import { type MountainRecommendationItem, useMountainRecommendations } from '@/features/mountains/hooks/use-mountain-recommendations';
-
-const DIFFICULTY_LABEL: Record<MountainRecommendationItem["difficulty"], string> = {
-  EASY: '난이도 하',
-  NORMAL: '난이도 중',
-  HARD: '난이도 상',
-};
+import { HikingStartBanner } from "@/components/icons/hiking-start-banner";
+import { useMountainRecommendations } from "@/features/mountains/hooks/use-mountain-recommendations";
+import { MountainRecommendationResponse } from "@/types/api.generated";
+import { LinearGradient } from "expo-linear-gradient";
+import { useRouter } from "expo-router";
+import {
+  Image,
+  ScrollView,
+  Text,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+} from "react-native";
 
 type Props = {
   userName?: string;
@@ -18,15 +19,22 @@ type Props = {
   lng?: number;
 };
 
-export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled = false, lat = 0, lng = 0 }: Props) {
+export default function NoRecordBottomSheet({
+  userName = "맹쏘",
+  scrollEnabled = false,
+  lat,
+  lng,
+}: Props) {
   const { width: screenWidth } = useWindowDimensions();
   const bannerWidth = screenWidth - 32;
-  const bannerHeight = Math.round(90 * bannerWidth / 343);
-  const { data } = useMountainRecommendations(lat, lng);
-  const recommendations = data?.content ?? [];
+  const bannerHeight = Math.round((90 * bannerWidth) / 343);
+  const { data, isPending, isError } = useMountainRecommendations(lat, lng);
+
+  if (isPending) return null;
+  if (isError) return null;
 
   return (
-    <View className="flex-1 w-full">
+    <View className="w-full flex-1">
       {/* 섹션 1: 첫 등산 CTA */}
       <View style={{ marginHorizontal: 16, marginTop: 12 }}>
         <View>
@@ -36,10 +44,15 @@ export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled
 
       {/* 섹션 2: 레벨 맞는 산 추천 */}
       <View className="pt-4">
-        <View className="flex-row items-center gap-0.5 px-4 mb-3">
-          <Text className="typo-headline-1-semi-bold text-secondary-normal">{userName} </Text>
-          <Text className="typo-headline-1-semi-bold text-label-normal">님의 레벨에 맞는 산</Text>
-          <InfoIcon size={16.25} />
+        <View className="mb-3 flex-row items-center gap-0.5 px-4">
+          <Text className="text-secondary-normal typo-headline-1-semi-bold">
+            {userName}{" "}
+          </Text>
+          <Text className="text-label-normal typo-headline-1-semi-bold">
+            님의 레벨에 맞는 산
+          </Text>
+          {/* TODO : 인포 클릭 구현되면 추가 */}
+          {/* <InfoIcon size={16.25} /> */}
         </View>
 
         <ScrollView
@@ -48,7 +61,7 @@ export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled
           contentContainerClassName="px-4 gap-2"
           scrollEnabled={scrollEnabled}
         >
-          {recommendations.map((mountain) => (
+          {data.map((mountain) => (
             <CuratedCard key={mountain.mountainId} mountain={mountain} />
           ))}
         </ScrollView>
@@ -57,21 +70,27 @@ export default function NoRecordBottomSheet({ userName = '맹쏘', scrollEnabled
   );
 }
 
-function CuratedCard({ mountain }: { mountain: MountainRecommendationItem }) {
+function CuratedCard({
+  mountain,
+}: {
+  mountain: MountainRecommendationResponse;
+}) {
   const router = useRouter();
 
   return (
     <TouchableOpacity
       activeOpacity={0.9}
-      className="w-[164px] h-[160px] rounded-xl overflow-hidden bg-neutral-200"
+      className="h-[160px] w-[164px] overflow-hidden rounded-xl bg-neutral-200"
       onPress={() =>
         router.push({
-          pathname: '/mountain-info',
+          pathname: "/mountains/[id]",
           params: {
-            id: mountain.mountainId,
+            id: mountain.mountainId ?? 0,
             name: mountain.name,
-            difficulty: DIFFICULTY_LABEL[mountain.difficulty],
-            elevation: `${Math.round(mountain.altitude)}m`,
+            difficulty: mountain.difficultyLabel,
+            ...(mountain.mountainHeightM !== undefined && {
+              elevation: `${Math.round(mountain.mountainHeightM)}m`,
+            }),
           },
         })
       }
@@ -79,31 +98,40 @@ function CuratedCard({ mountain }: { mountain: MountainRecommendationItem }) {
       {mountain.imageUrl && (
         <Image
           source={{ uri: mountain.imageUrl }}
-          className="absolute inset-0 w-full h-full"
+          className="absolute inset-0 h-full w-full"
           resizeMode="cover"
         />
       )}
       <LinearGradient
-        colors={['rgba(0,0,0,0.05)', 'rgba(0,0,0,0.75)']}
+        colors={["rgba(0,0,0,0.09)", "rgba(0,0,0,0.90)"]}
         start={{ x: 0, y: 0 }}
         end={{ x: 0, y: 1 }}
-        className="absolute inset-0"
+        style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
       />
-      <View className="flex-1 justify-end p-3 gap-1">
-        <Text className="typo-heading-1-semi-bold text-common-100" numberOfLines={1}>
+      <View className="flex-1 justify-end gap-1 p-4">
+        <Text
+          className="text-common-100 typo-heading-1-semi-bold"
+          numberOfLines={1}
+        >
           {mountain.name}
         </Text>
         <View className="flex-row items-center gap-1.5">
-          <Text className="typo-caption-1-medium text-neutral-400">
-            {DIFFICULTY_LABEL[mountain.difficulty]}
-          </Text>
-          <View className="w-1 h-1 rounded-full bg-neutral-400" />
-          <Text className="typo-caption-1-medium text-neutral-400">
-            {Math.round(mountain.altitude)}m
-          </Text>
+          {mountain.difficultyLabel && (
+            <Text className="text-neutral-400 typo-caption-1-medium">
+              난이도 {mountain.difficultyLabel}
+            </Text>
+          )}
+          {mountain.difficultyLabel &&
+            mountain.mountainHeightM !== undefined && (
+              <View className="h-1 w-1 rounded-full bg-neutral-400" />
+            )}
+          {mountain.mountainHeightM !== undefined && (
+            <Text className="text-neutral-400 typo-caption-1-medium">
+              {Math.round(mountain.mountainHeightM)}m
+            </Text>
+          )}
         </View>
       </View>
     </TouchableOpacity>
   );
 }
-

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -11,6 +11,7 @@ import {
   useWindowDimensions,
   View,
 } from "react-native";
+import { LoadingSpinner } from "./loading-spinner";
 
 type Props = {
   userName?: string;
@@ -30,7 +31,7 @@ export default function NoRecordBottomSheet({
   const bannerHeight = Math.round((90 * bannerWidth) / 343);
   const { data, isPending, isError } = useMountainRecommendations(lat, lng);
 
-  if (isPending) return null;
+  if (isPending) return <LoadingSpinner fullScreen />;
   if (isError) return null;
 
   return (

--- a/components/no-record-bottom-sheet.tsx
+++ b/components/no-record-bottom-sheet.tsx
@@ -46,7 +46,7 @@ export default function NoRecordBottomSheet({
       <View className="pt-4">
         <View className="mb-3 flex-row items-center gap-0.5 px-4">
           <Text className="text-secondary-normal typo-headline-1-semi-bold">
-            {userName}{" "}
+            {userName}
           </Text>
           <Text className="text-label-normal typo-headline-1-semi-bold">
             님의 레벨에 맞는 산

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -245,7 +245,6 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
           </TouchableOpacity>
         </Animated.View>
 
-        {/* TODO : API 나오면 연동 */}
         {/* 바텀시트 - 절대 위치, 애니메이션 높이 */}
         <HomeBottomSheetContainer
           ref={sheetRef}

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -3,8 +3,8 @@ import {
   HomeBottomSheetContainer,
   HomeBottomSheetRef,
   SNAP_DEFAULT,
-  SNAP_EXPANDED_WITH_RECORDS,
   SNAP_EXPANDED_NO_RECORDS,
+  SNAP_EXPANDED_WITH_RECORDS,
 } from "@/components/home-bottom-sheet-container";
 import { CrosshairIcon } from "@/components/icons/crosshair-icon";
 import {
@@ -18,13 +18,13 @@ import {
   VisitedMarker,
 } from "@/components/map-markers/visited-marker";
 import NoRecordBottomSheet from "@/components/no-record-bottom-sheet";
-import { useMountains } from "@/features/mountains/hooks/use-mountains";
 import { useMyMountains } from "@/features/home/hooks/use-my-mountains";
-import { useProfile } from "@/features/mypage/hooks/use-profile";
+import { useMountains } from "@/features/mountains/hooks/use-mountains";
 import {
   BBox,
   useMountainsMap,
 } from "@/features/mountains/hooks/use-mountains-map";
+import { useProfile } from "@/features/mypage/hooks/use-profile";
 import {
   NaverMapMarkerOverlay,
   NaverMapView,
@@ -79,7 +79,9 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     );
     const { data: mapData } = useMountainsMap(bbox);
     const hasRecords = mapData?.hasHikingRecord ?? false;
-    const snapExpanded = hasRecords ? SNAP_EXPANDED_WITH_RECORDS : SNAP_EXPANDED_NO_RECORDS;
+    const snapExpanded = hasRecords
+      ? SNAP_EXPANDED_WITH_RECORDS
+      : SNAP_EXPANDED_NO_RECORDS;
     const { data, isPending, isError } = useMountains();
     const { data: myMountains = [] } = useMyMountains();
     const { data: profile } = useProfile();
@@ -119,7 +121,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     }));
 
     const myMountainImageMap = Object.fromEntries(
-      myMountains.map((m) => [m.mountainId, m.imageUrls?.[0]])
+      myMountains.map((m) => [m.mountainId, m.imageUrls?.[0]]),
     );
 
     const visitedCards = myMountains.map((m) => ({
@@ -155,54 +157,58 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
           }}
         >
           {hasRecords
-            ? mapData?.mountains?.filter((m) => m.visited).map((mountain) => (
-                <NaverMapMarkerOverlay
-                  key={`${mountain.id}-${activeTab}-${selectedMountainId}`}
-                  latitude={mountain.latitude}
-                  longitude={mountain.longitude}
-                  width={
-                    mountain.visited
-                      ? VISITED_MARKER_OVERLAY_WIDTH
-                      : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH
-                  }
-                  height={
-                    mountain.visited
-                      ? VISITED_MARKER_OVERLAY_HEIGHT
-                      : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT
-                  }
-                  anchor={
-                    mountain.visited ? { x: 0.2, y: 1 } : { x: 0.5, y: 0.5 }
-                  }
-                  onTap={() => router.push(`/mountains/${mountain.id}`)}
-                >
-                  <View
-                    collapsable={false}
-                    style={{
-                      width: mountain.visited
+            ? mapData?.mountains
+                ?.filter((m) => m.visited)
+                .map((mountain) => (
+                  <NaverMapMarkerOverlay
+                    key={`${mountain.id}-${activeTab}-${selectedMountainId}`}
+                    latitude={mountain.latitude}
+                    longitude={mountain.longitude}
+                    width={
+                      mountain.visited
                         ? VISITED_MARKER_OVERLAY_WIDTH
-                        : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
-                      height: mountain.visited
+                        : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH
+                    }
+                    height={
+                      mountain.visited
                         ? VISITED_MARKER_OVERLAY_HEIGHT
-                        : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
-                    }}
+                        : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT
+                    }
+                    anchor={
+                      mountain.visited ? { x: 0.2, y: 1 } : { x: 0.5, y: 0.5 }
+                    }
+                    onTap={() => router.push(`/mountains/${mountain.id}`)}
                   >
-                    {mountain.visited ? (
-                      <VisitedMarker
-                        name={mountain.name}
-                        visitCount={mountain.visitCount}
-                        imageUri={myMountainImageMap[mountain.id] ?? mountain.imageUrl}
-                        selected={mountain.id === selectedMountainId}
-                      />
-                    ) : (
-                      <UnvisitedMountainPillMarker
-                        name={mountain.name ?? ""}
-                        variant="trending"
-                        selected={mountain.id === selectedMountainId}
-                      />
-                    )}
-                  </View>
-                </NaverMapMarkerOverlay>
-              ))
+                    <View
+                      collapsable={false}
+                      style={{
+                        width: mountain.visited
+                          ? VISITED_MARKER_OVERLAY_WIDTH
+                          : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
+                        height: mountain.visited
+                          ? VISITED_MARKER_OVERLAY_HEIGHT
+                          : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
+                      }}
+                    >
+                      {mountain.visited ? (
+                        <VisitedMarker
+                          name={mountain.name}
+                          visitCount={mountain.visitCount}
+                          imageUri={
+                            myMountainImageMap[mountain.id] ?? mountain.imageUrl
+                          }
+                          selected={mountain.id === selectedMountainId}
+                        />
+                      ) : (
+                        <UnvisitedMountainPillMarker
+                          name={mountain.name ?? ""}
+                          variant="trending"
+                          selected={mountain.id === selectedMountainId}
+                        />
+                      )}
+                    </View>
+                  </NaverMapMarkerOverlay>
+                ))
             : mapData?.mountains?.map((mountain) => (
                 <NaverMapMarkerOverlay
                   key={`no-record-${mountain.id}`}
@@ -238,12 +244,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
         />
 
         {/* 현위치 버튼 - 바텀시트 높이에 따라 이동 */}
-        <Animated.View
-          style={[
-            styles.locationButton,
-            locationButtonStyle,
-          ]}
-        >
+        <Animated.View style={[styles.locationButton, locationButtonStyle]}>
           <TouchableOpacity
             style={{ flex: 1, alignItems: "center", justifyContent: "center" }}
             onPress={moveToCurrentLocation}

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -124,15 +124,6 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
       myMountains.map((m) => [m.mountainId, m.imageUrls?.[0]]),
     );
 
-    const visitedCards = myMountains.map((m) => ({
-      id: String(m.mountainId),
-      mountainId: m.mountainId ?? 0,
-      name: m.mountainName ?? "",
-      trailNumber: m.hikingCount ?? 1,
-      daysAgo: getDaysAgo(m.lastHikedAt),
-      badgeCount: m.hikingCount ?? 1,
-    }));
-
     return (
       <View className="w-full flex-1">
         <NaverMapView
@@ -264,8 +255,8 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
             hasRecords ? (
               <BottomSheet
                 title="다녀온 산"
-                titleCount={visitedCards.length}
-                cards={visitedCards}
+                titleCount={myMountains.length}
+                cards={myMountains}
                 showTabs={false}
                 scrollEnabled={scrollEnabled}
                 onCardSelect={(id) => setSelectedMountainId(Number(id))}

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/components/map-markers/visited-marker";
 import NoRecordBottomSheet from "@/components/no-record-bottom-sheet";
 import { useMyMountains } from "@/features/home/hooks/use-my-mountains";
-import { useMountains } from "@/features/mountains/hooks/use-mountains";
 import {
   BBox,
   useMountainsMap,
@@ -82,7 +81,6 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     const snapExpanded = hasRecords
       ? SNAP_EXPANDED_WITH_RECORDS
       : SNAP_EXPANDED_NO_RECORDS;
-    const { data, isPending, isError } = useMountains();
     const { data: myMountains = [] } = useMyMountains();
     const { data: profile } = useProfile();
 
@@ -276,12 +274,6 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     );
   },
 );
-
-function getDaysAgo(dateStr?: string): number {
-  if (!dateStr) return 0;
-  const diff = Date.now() - new Date(dateStr).getTime();
-  return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
-}
 
 const styles = StyleSheet.create({
   map: { flex: 1 },

--- a/features/home/hooks/use-my-mountain-records.ts
+++ b/features/home/hooks/use-my-mountain-records.ts
@@ -1,14 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import {
   ENDPOINTS,
+  GetUserHikingRecordResponse,
   PageResponseGetUserHikingRecordResponse,
 } from "@/types/api.generated";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
 
-export function useMyMountainRecords(mountainId: number | null) {
+export function useMyMountainRecords(
+  mountainId?: number,
+): UseQueryResult<GetUserHikingRecordResponse[]> {
   return useQuery({
-    queryKey: ["myMountainRecords", mountainId],
-    enabled: mountainId != null,
+    queryKey: [
+      ENDPOINTS.HIKING_RECORDS_ME_MOUNTAINS_BY_MOUNTAINID(mountainId!),
+    ],
+    enabled: mountainId !== undefined,
     queryFn: async () => {
       const res = await api.get<PageResponseGetUserHikingRecordResponse>({
         path: ENDPOINTS.HIKING_RECORDS_ME_MOUNTAINS_BY_MOUNTAINID(mountainId!),

--- a/features/home/hooks/use-my-mountains.ts
+++ b/features/home/hooks/use-my-mountains.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import {
   ENDPOINTS,
   PageResponseGetUserHikingMountainRecordResponse,
 } from "@/types/api.generated";
+import { useQuery } from "@tanstack/react-query";
 
 export function useMyMountains() {
   return useQuery({
-    queryKey: ["myMountains"],
+    queryKey: [ENDPOINTS.HIKING_RECORDS_ME_MOUNTAINS],
     queryFn: async () => {
       const res =
         await api.get<PageResponseGetUserHikingMountainRecordResponse>({

--- a/features/home/hooks/use-toggle-semofeed-public.ts
+++ b/features/home/hooks/use-toggle-semofeed-public.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useMutation, UseMutationResult } from "@tanstack/react-query";
+
+export function useToggleSemofeedPublic(): UseMutationResult<
+  Awaited<ReturnType<typeof api.patch<boolean>>>,
+  Error,
+  number
+> {
+  return useMutation({
+    mutationFn: (semoFeedId: number) =>
+      api.patch<boolean>({
+        path: ENDPOINTS.SEMOFEED_BY_SEMOFEEDID_PUBLIC(semoFeedId),
+      }),
+  });
+}

--- a/features/mountains/hooks/use-mountain-recommendations.ts
+++ b/features/mountains/hooks/use-mountain-recommendations.ts
@@ -1,39 +1,32 @@
 import { api } from "@/lib/api";
-import { useQuery } from "@tanstack/react-query";
-
-export type MountainRecommendationItem = {
-  mountainId: number;
-  name: string;
-  imageUrl?: string;
-  difficulty: "EASY" | "NORMAL" | "HARD";
-  altitude: number;
-  address: string;
-};
-
-type RecommendationsData = {
-  content: MountainRecommendationItem[];
-  page: number;
-  size: number;
-  totalElements: number;
-  totalPages: number;
-  last: boolean;
-};
+import {
+  ENDPOINTS,
+  MountainRecommendationResponse,
+} from "@/types/api.generated";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
 
 async function getMountainRecommendations(
   lat: number,
   lng: number,
-): Promise<RecommendationsData> {
-  const res = await api.get<RecommendationsData>({
-    path: "/api/mountains/recommendations",
+): Promise<MountainRecommendationResponse[]> {
+  const res = await api.get<MountainRecommendationResponse[]>({
+    path: ENDPOINTS.MOUNTAINS_RECOMMENDATIONS,
     params: { lat, lng },
   });
   return res.data;
 }
 
-export function useMountainRecommendations(lat: number, lng: number) {
+export function useMountainRecommendations(
+  lat: number | undefined,
+  lng: number | undefined,
+): UseQueryResult<MountainRecommendationResponse[]> {
   return useQuery({
-    queryKey: ["mountains/recommendations", lat, lng],
-    queryFn: () => getMountainRecommendations(lat, lng),
-    enabled: lat !== 0 && lng !== 0,
+    queryKey: [ENDPOINTS.MOUNTAINS_RECOMMENDATIONS, lat, lng],
+    queryFn: () => getMountainRecommendations(lat!, lng!),
+    enabled:
+      typeof lat === "number" &&
+      lat !== 0 &&
+      typeof lng === "number" &&
+      lng !== 0,
   });
 }

--- a/features/mountains/hooks/use-mountains-map.ts
+++ b/features/mountains/hooks/use-mountains-map.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 export type BBox = {
@@ -25,10 +26,15 @@ type MountainMapData = {
 
 async function getMountainsMap(bbox: BBox): Promise<MountainMapData> {
   const params: Record<string, number> = bbox
-    ? { swLat: bbox.swLat, swLng: bbox.swLng, neLat: bbox.neLat, neLng: bbox.neLng }
+    ? {
+        swLat: bbox.swLat,
+        swLng: bbox.swLng,
+        neLat: bbox.neLat,
+        neLng: bbox.neLng,
+      }
     : {};
   const res = await api.get<MountainMapData>({
-    path: "/api/mountains/map",
+    path: ENDPOINTS.MOUNTAINS_MAP,
     params,
   });
   return res.data;
@@ -36,7 +42,7 @@ async function getMountainsMap(bbox: BBox): Promise<MountainMapData> {
 
 export function useMountainsMap(bbox: BBox) {
   return useQuery({
-    queryKey: ["mountains/map", bbox],
+    queryKey: [ENDPOINTS.MOUNTAINS_MAP, bbox],
     queryFn: () => getMountainsMap(bbox),
     placeholderData: keepPreviousData,
   });

--- a/features/tracking/components/difficulty-rating-modal.tsx
+++ b/features/tracking/components/difficulty-rating-modal.tsx
@@ -44,6 +44,9 @@ export function DifficultyRatingModal({
 
   const handleComplete = () => {
     queryClient.invalidateQueries({ queryKey: [ENDPOINTS.MOUNTAINS_MAP] });
+    queryClient.invalidateQueries({
+      queryKey: [ENDPOINTS.HIKING_RECORDS_ME_MOUNTAINS],
+    });
     if (mountainId)
       queryClient.invalidateQueries({
         queryKey: [

--- a/features/tracking/components/difficulty-rating-modal.tsx
+++ b/features/tracking/components/difficulty-rating-modal.tsx
@@ -14,6 +14,7 @@ type DifficultyOption = "similar" | "easier" | "harder";
 type Props = {
   visible: boolean;
   course: Course;
+  mountainId?: number;
   mountainName: string;
   onClose: () => void;
   onComplete: (option: DifficultyOption | null) => void;
@@ -32,6 +33,7 @@ const OPTIONS: {
 export function DifficultyRatingModal({
   visible,
   course,
+  mountainId,
   mountainName,
   onClose,
   onComplete,
@@ -42,6 +44,12 @@ export function DifficultyRatingModal({
 
   const handleComplete = () => {
     queryClient.invalidateQueries({ queryKey: [ENDPOINTS.MOUNTAINS_MAP] });
+    if (mountainId)
+      queryClient.invalidateQueries({
+        queryKey: [
+          ENDPOINTS.HIKING_RECORDS_ME_MOUNTAINS_BY_MOUNTAINID(mountainId),
+        ],
+      });
     onComplete(selected);
     setSelected(null);
   };

--- a/features/tracking/components/difficulty-rating-modal.tsx
+++ b/features/tracking/components/difficulty-rating-modal.tsx
@@ -1,13 +1,15 @@
-import { CloseIcon } from '@/components/icons/close-icon';
-import { FaceHappyIcon } from '@/components/icons/face-happy-icon';
-import { FaceNeutralIcon } from '@/components/icons/face-neutral-icon';
-import { FaceSadIcon } from '@/components/icons/face-sad-icon';
-import { useState } from 'react';
-import { Modal, Text, TouchableOpacity, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Course, DIFFICULTY_BG, DIFFICULTY_TEXT_COLOR } from '../constants';
+import { CloseIcon } from "@/components/icons/close-icon";
+import { FaceHappyIcon } from "@/components/icons/face-happy-icon";
+import { FaceNeutralIcon } from "@/components/icons/face-neutral-icon";
+import { FaceSadIcon } from "@/components/icons/face-sad-icon";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { Modal, Text, TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Course, DIFFICULTY_BG, DIFFICULTY_TEXT_COLOR } from "../constants";
 
-type DifficultyOption = 'similar' | 'easier' | 'harder';
+type DifficultyOption = "similar" | "easier" | "harder";
 
 type Props = {
   visible: boolean;
@@ -22,9 +24,9 @@ const OPTIONS: {
   label: string;
   Icon: React.ComponentType<{ size?: number; color?: string }>;
 }[] = [
-  { key: 'similar', label: '비슷해요', Icon: FaceNeutralIcon },
-  { key: 'easier', label: '생각보다 쉬워요', Icon: FaceHappyIcon },
-  { key: 'harder', label: '더 어려워요', Icon: FaceSadIcon },
+  { key: "similar", label: "비슷해요", Icon: FaceNeutralIcon },
+  { key: "easier", label: "생각보다 쉬워요", Icon: FaceHappyIcon },
+  { key: "harder", label: "더 어려워요", Icon: FaceSadIcon },
 ];
 
 export function DifficultyRatingModal({
@@ -34,10 +36,12 @@ export function DifficultyRatingModal({
   onClose,
   onComplete,
 }: Props) {
+  const queryClient = useQueryClient();
   const [selected, setSelected] = useState<DifficultyOption | null>(null);
   const insets = useSafeAreaInsets();
 
   const handleComplete = () => {
+    queryClient.invalidateQueries({ queryKey: [ENDPOINTS.MOUNTAINS_MAP] });
     onComplete(selected);
     setSelected(null);
   };
@@ -48,93 +52,124 @@ export function DifficultyRatingModal({
   };
 
   return (
-    <Modal
-      visible={visible}
-      animationType="slide"
-      onRequestClose={handleClose}
-    >
-        <View style={{ flex: 1, paddingTop: insets.top }}>
-
-          {/* 닫기 버튼 */}
-          <View style={{ alignItems: 'flex-end', paddingRight: 24, paddingTop: 12 }}>
-            <TouchableOpacity
-              style={{ width: 40, height: 40, alignItems: 'center', justifyContent: 'center' }}
-              onPress={handleClose}
-              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            >
-              <CloseIcon size={24} color="#464A57" />
-            </TouchableOpacity>
-          </View>
-
-          {/* 타이틀 — 닫기 버튼과 40px 간격 */}
-          <View className="mt-10" style={{ paddingHorizontal: 66, marginBottom: 12, alignItems: 'center' }}>
-            <Text className="typo-heading-1-semi-bold text-label-normal" style={{ textAlign: 'center' }}>
-              안내 난이도랑 비교해 어땠나요?
-            </Text>
-          </View>
-
-          {/* 코스 정보 */}
-          <View style={{ paddingHorizontal: 66, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8 }}>
-            <View className={`rounded px-1 py-0.5 ${DIFFICULTY_BG[course.difficulty]}`}>
-              <Text className={`typo-caption-1-medium ${DIFFICULTY_TEXT_COLOR[course.difficulty]}`}>
-                {course.difficulty}
-              </Text>
-            </View>
-            <Text className="typo-body-1-normal-semi-bold text-label-normal">
-              {mountainName}
-            </Text>
-            <Text className="typo-body-1-normal-regular text-label-subtle" numberOfLines={1}>
-              {course.name}
-            </Text>
-          </View>
-
-          {/* 선택지 버튼들 — 코스 정보와 80px 간격 */}
-          <View className="mt-20" style={{ paddingHorizontal: 46, gap: 20, alignItems: 'center' }}>
-            {OPTIONS.map(({ key, label, Icon }) => {
-              const isSelected = selected === key;
-              return (
-                <TouchableOpacity
-                  key={key}
-                  className={`flex-row items-center justify-center bg-fill-normal rounded-[10px] gap-2 px-5 ${
-                    isSelected ? 'border-label-normal' : 'border-line-normal'
-                  }`}
-                  style={{
-                    minHeight: 48,
-                    maxHeight: 48,
-                    paddingVertical: 11,
-                    borderWidth: isSelected ? 1.5 : 1,
-                  }}
-                  activeOpacity={0.7}
-                  onPress={() => setSelected(key)}
-                >
-                  <Icon size={20} color={isSelected ? '#1a1b1f' : '#464A57'} />
-                  <Text
-                    className={`typo-body-1-normal-semi-bold ${
-                      isSelected ? 'text-label-normal' : 'text-label-subtle'
-                    }`}
-                  >
-                    {label}
-                  </Text>
-                </TouchableOpacity>
-              );
-            })}
-          </View>
-
-          {/* 버튼 아래 스페이서 */}
-          <View style={{ flex: 1 }} />
-
-          {/* 완료 버튼 */}
-          <View style={{ paddingHorizontal: 24, paddingBottom: insets.bottom + 35 }}>
-            <TouchableOpacity
-              className="bg-label-normal rounded-[10px] items-center justify-center"
-              style={{ height: 52 }}
-              onPress={handleComplete}
-            >
-              <Text className="typo-label-large text-common-100">완료</Text>
-            </TouchableOpacity>
-          </View>
-
+    <Modal visible={visible} animationType="slide" onRequestClose={handleClose}>
+      <View style={{ flex: 1, paddingTop: insets.top }}>
+        {/* 닫기 버튼 */}
+        <View
+          style={{ alignItems: "flex-end", paddingRight: 24, paddingTop: 12 }}
+        >
+          <TouchableOpacity
+            style={{
+              width: 40,
+              height: 40,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            onPress={handleClose}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <CloseIcon size={24} color="#464A57" />
+          </TouchableOpacity>
         </View>
+
+        {/* 타이틀 — 닫기 버튼과 40px 간격 */}
+        <View
+          className="mt-10"
+          style={{
+            paddingHorizontal: 66,
+            marginBottom: 12,
+            alignItems: "center",
+          }}
+        >
+          <Text
+            className="text-label-normal typo-heading-1-semi-bold"
+            style={{ textAlign: "center" }}
+          >
+            안내 난이도랑 비교해 어땠나요?
+          </Text>
+        </View>
+
+        {/* 코스 정보 */}
+        <View
+          style={{
+            paddingHorizontal: 66,
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 8,
+          }}
+        >
+          <View
+            className={`rounded px-1 py-0.5 ${DIFFICULTY_BG[course.difficulty]}`}
+          >
+            <Text
+              className={`typo-caption-1-medium ${DIFFICULTY_TEXT_COLOR[course.difficulty]}`}
+            >
+              {course.difficulty}
+            </Text>
+          </View>
+          <Text className="text-label-normal typo-body-1-normal-semi-bold">
+            {mountainName}
+          </Text>
+          <Text
+            className="text-label-subtle typo-body-1-normal-regular"
+            numberOfLines={1}
+          >
+            {course.name}
+          </Text>
+        </View>
+
+        {/* 선택지 버튼들 — 코스 정보와 80px 간격 */}
+        <View
+          className="mt-20"
+          style={{ paddingHorizontal: 46, gap: 20, alignItems: "center" }}
+        >
+          {OPTIONS.map(({ key, label, Icon }) => {
+            const isSelected = selected === key;
+            return (
+              <TouchableOpacity
+                key={key}
+                className={`flex-row items-center justify-center gap-2 rounded-[10px] bg-fill-normal px-5 ${
+                  isSelected ? "border-label-normal" : "border-line-normal"
+                }`}
+                style={{
+                  minHeight: 48,
+                  maxHeight: 48,
+                  paddingVertical: 11,
+                  borderWidth: isSelected ? 1.5 : 1,
+                }}
+                activeOpacity={0.7}
+                onPress={() => setSelected(key)}
+              >
+                <Icon size={20} color={isSelected ? "#1a1b1f" : "#464A57"} />
+                <Text
+                  className={`typo-body-1-normal-semi-bold ${
+                    isSelected ? "text-label-normal" : "text-label-subtle"
+                  }`}
+                >
+                  {label}
+                </Text>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+
+        {/* 버튼 아래 스페이서 */}
+        <View style={{ flex: 1 }} />
+
+        {/* 완료 버튼 */}
+        <View
+          style={{ paddingHorizontal: 24, paddingBottom: insets.bottom + 35 }}
+        >
+          <TouchableOpacity
+            className="items-center justify-center rounded-[10px] bg-label-normal"
+            style={{ height: 52 }}
+            onPress={handleComplete}
+          >
+            <Text className="text-common-100 typo-label-large">완료</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
     </Modal>
   );
 }

--- a/utils/get-days-ago.ts
+++ b/utils/get-days-ago.ts
@@ -1,0 +1,5 @@
+export function getDaysAgo(dateStr?: string): number {
+  if (!dateStr) return 0;
+  const diff = Date.now() - new Date(dateStr).getTime();
+  return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)));
+}


### PR DESCRIPTION
## Summary

- Prettier double quote 설정 통일 및 전반적인 포맷 정리
- `ENDPOINTS` 상수로 `queryKey` 통일, 함수 반환 타입 추가
- `/api/hiking-records/me/mountains` 훅 연동 (`useMyMountains`) 개선
- 산 썸네일 `imageUrls` 우선 표시, 없으면 `useMountainDetail` 폴백
- 이미지 1개일 때 뒤 카드 숨김
- `getDaysAgo` util 함수 분리, 0일이면 "오늘" 표시
- `MountainCard` `TouchableOpacity` → `Pressable` 교체
- 추천 산 카드 그라디언트 값 및 `LinearGradient` style 적용 수정
- 공개 토글 `useMutation` 훅(`useToggleSemofeedPublic`) 분리 및 로딩 UI 추가
- `mountainId` / `lat`, `lng` 없을 때 API 호출 방지
- 코스 목록 뷰 스크롤 활성화

## Test plan

- [ ] 홈 지도 화면 산 마커 정상 표시 확인
- [ ] 내 기록 바텀시트 카드 썸네일 이미지 표시 확인
- [ ] 공개 토글 로딩 스피너 표시 확인
- [ ] 코스 목록 스크롤 확인
- [ ] 추천 산 카드 그라디언트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)