### PR TITLE
fix: 클라이브 사진 demo API로 교체 및 기본 2개 요청

### DIFF
--- a/features/tracking/hooks/use-clive-photos.ts
+++ b/features/tracking/hooks/use-clive-photos.ts
@@ -2,27 +2,15 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { ENDPOINTS } from "@/types/api.generated";
 
-type ClivePhoto = {
-  photoId: number;
-  trackingSessionId: number;
-  milestoneIndex: number;
-  milestoneDistanceM: number;
-  imageUrl: string;
-  capturedAt: string;
-  lat: number;
-  lng: number;
-  altitude: number;
-};
-
 export function useClivePhotos(sessionId: number | null) {
   return useQuery({
     queryKey: ["clivePhotos", sessionId],
     enabled: sessionId != null,
     queryFn: async () => {
-      const res = await api.get<ClivePhoto[]>({
-        path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_PHOTOS(sessionId!),
+      const res = await api.get<string[]>({
+        path: `${ENDPOINTS.DEMO_TRACKING_SESSIONS_BY_SESSIONID_PHOTOS(sessionId!)}?count=2`,
       });
-      return (res.data ?? []).map((p) => p.imageUrl);
+      return res.data ?? [];
     },
   });
 }


### PR DESCRIPTION
## Summary
- `useClivePhotos` 엔드포인트를 실제 API에서 demo API로 교체
- `?count=2` 쿼리 파라미터로 기본 사진 2개 요청
- 응답 타입을 `ClivePhoto[]` → `string[]`으로 단순화