### PR TITLE
fix: 마커 이미지 렌더 및 세모피드 이미지 로드 성능 개선

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,7 +10,7 @@ import {
   FEED_SLIDE_UP_DISTANCE,
   HOME_TAB_TRANSITION_DURATION,
 } from "@/features/home/constants";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { View } from "react-native";
 import Animated, {
   Easing,
@@ -23,11 +23,22 @@ export default function HomeScreen() {
   const { setTabBarVariant, tabProgress } = useHomeStateContext();
   const [mapTab, setMapTab] = useState<MapTab>("map");
 
+  const [hasFeedMounted, setHasFeedMounted] = useState(false);
   const [isMountainRecordListOpen, setIsMountainRecordListOpen] =
     useState(false);
   const [closeSelectedToken, setCloseSelectedToken] = useState(0);
 
   const mapViewRef = useRef<MapHomeViewRef>(null);
+  const feedMountTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    feedMountTimerRef.current = setTimeout(() => {
+      setHasFeedMounted(true);
+    }, 3000);
+    return () => {
+      if (feedMountTimerRef.current) clearTimeout(feedMountTimerRef.current);
+    };
+  }, []);
   const mapAnimatedStyle = useAnimatedStyle(() => ({
     opacity: 1 - tabProgress.value,
   }));
@@ -52,6 +63,11 @@ export default function HomeScreen() {
     setMapTab(tab);
 
     if (tab === "feed") {
+      if (feedMountTimerRef.current) {
+        clearTimeout(feedMountTimerRef.current);
+        feedMountTimerRef.current = null;
+      }
+      setHasFeedMounted(true);
       mapViewRef.current?.collapseSheet();
       tabProgress.value = withTiming(1, {
         duration: HOME_TAB_TRANSITION_DURATION,
@@ -90,7 +106,7 @@ export default function HomeScreen() {
         style={[{ top: -FEED_SLIDE_UP_DISTANCE }, feedAnimatedStyle]}
         pointerEvents={mapTab === "feed" ? "auto" : "none"}
       >
-        <FeedHomeView />
+        {hasFeedMounted && <FeedHomeView />}
       </Animated.View>
 
       <HomeHeader

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -1,10 +1,15 @@
-import { useId } from 'react';
-import { StyleSheet, View } from 'react-native';
-import Svg, { ClipPath, Defs, G, Image as SvgImage, Path } from 'react-native-svg';
-import { MountainIcon } from '@/components/icons/mountain-icon';
-import { MountainMarkerTextBox } from '@/components/map-markers/mountain-marker-textbox';
+import { MountainMarkerTextBox } from "@/components/map-markers/mountain-marker-textbox";
+import { useId } from "react";
+import { StyleSheet, View } from "react-native";
+import Svg, {
+  ClipPath,
+  Defs,
+  G,
+  Path,
+  Image as SvgImage,
+} from "react-native-svg";
 
-const FALLBACK_IMAGE = require('@/assets/photo-thumb-1.jpg');
+const FALLBACK_IMAGE = require("@/assets/photo-thumb-1.jpg");
 
 type Props = {
   name: string;
@@ -17,9 +22,15 @@ type Props = {
 export const VISITED_MARKER_OVERLAY_WIDTH = 88;
 export const VISITED_MARKER_OVERLAY_HEIGHT = 52;
 
-const SELECTED_BG = '#464A57';
+const SELECTED_BG = "#464A57";
 
-export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864', selected = false }: Props) {
+export function VisitedMarker({
+  name,
+  visitCount,
+  imageUri,
+  flagColor = "#00D864",
+  selected = false,
+}: Props) {
   const clipIdOuter = useId();
   const clipIdInner = useId();
 
@@ -27,8 +38,18 @@ export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864
     <View style={styles.container} collapsable={false}>
       <View style={styles.contentWrap}>
         <View style={styles.imageGroup}>
-          <View style={[styles.flagPole, selected && { backgroundColor: SELECTED_BG }]} />
-          <View style={[styles.flag, { borderLeftColor: selected ? SELECTED_BG : flagColor }]} />
+          <View
+            style={[
+              styles.flagPole,
+              selected && { backgroundColor: SELECTED_BG },
+            ]}
+          />
+          <View
+            style={[
+              styles.flag,
+              { borderLeftColor: selected ? SELECTED_BG : flagColor },
+            ]}
+          />
 
           <View style={styles.imageShapeWrap}>
             <Svg width={28} height={25} viewBox="0 0 32 29">
@@ -43,7 +64,7 @@ export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864
 
               <Path
                 d="M13.7571 1.26472C14.7408 -0.421574 17.1773 -0.421574 18.161 1.26472L31.567 24.2465C32.5584 25.9459 31.3326 28.0802 29.3651 28.0802H2.55302C0.585586 28.0802 -0.640242 25.946 0.351092 24.2465L13.7571 1.26472Z"
-                fill={selected ? SELECTED_BG : '#FFFFFF'}
+                fill={selected ? SELECTED_BG : "#FFFFFF"}
               />
 
               <G clipPath={`url(#${clipIdInner})`}>
@@ -56,12 +77,7 @@ export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864
                   preserveAspectRatio="xMidYMid slice"
                 />
               </G>
-
             </Svg>
-          </View>
-
-          <View style={styles.imageIcon}>
-            <MountainIcon size={6} color="#ffffff" />
           </View>
         </View>
 
@@ -69,9 +85,12 @@ export function VisitedMarker({ name, visitCount, imageUri, flagColor = '#00D864
           <MountainMarkerTextBox
             name={name}
             suffix={visitCount}
-            nameColor={selected ? '#ffffff' : '#464A57'}
-            suffixColor={selected ? '#A4ABC0' : '#BFC4D1'}
-            style={[styles.textBox, selected ? { backgroundColor: SELECTED_BG } : undefined]}
+            nameColor={selected ? "#ffffff" : "#464A57"}
+            suffixColor={selected ? "#A4ABC0" : "#BFC4D1"}
+            style={[
+              styles.textBox,
+              selected ? { backgroundColor: SELECTED_BG } : undefined,
+            ]}
           />
         </View>
       </View>
@@ -85,19 +104,19 @@ const styles = StyleSheet.create({
     height: VISITED_MARKER_OVERLAY_HEIGHT,
   },
   contentWrap: {
-    position: 'absolute',
+    position: "absolute",
     left: 8,
     top: 8,
     width: 72,
     height: 36,
-    shadowColor: '#000',
+    shadowColor: "#000",
     shadowOffset: { width: 0, height: 1 },
     shadowOpacity: 0.2,
     shadowRadius: 4,
     elevation: 4,
   },
   imageGroup: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: -3,
     width: 28,
@@ -105,16 +124,16 @@ const styles = StyleSheet.create({
     zIndex: 2,
   },
   flagPole: {
-    position: 'absolute',
+    position: "absolute",
     left: 13,
     top: 0,
     width: 1.6,
     height: 16,
     borderRadius: 999,
-    backgroundColor: '#FFFFFF',
+    backgroundColor: "#FFFFFF",
   },
   flag: {
-    position: 'absolute',
+    position: "absolute",
     top: 0.5,
     left: 14.8,
     width: 0,
@@ -122,27 +141,27 @@ const styles = StyleSheet.create({
     borderTopWidth: 5,
     borderBottomWidth: 4,
     borderLeftWidth: 6.4,
-    borderTopColor: 'transparent',
-    borderBottomColor: 'transparent',
+    borderTopColor: "transparent",
+    borderBottomColor: "transparent",
   },
   imageShapeWrap: {
-    position: 'absolute',
+    position: "absolute",
     left: 0,
     top: 11,
     width: 28,
     height: 25,
   },
   imageIcon: {
-    position: 'absolute',
+    position: "absolute",
     top: 0,
     left: 15,
     width: 6,
     height: 9,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
   },
   textBoxWrap: {
-    position: 'absolute',
+    position: "absolute",
     left: 2,
     bottom: 0,
     zIndex: 1,
@@ -154,6 +173,6 @@ const styles = StyleSheet.create({
     paddingRight: 9,
     paddingTop: 2,
     paddingBottom: 2,
-    alignSelf: 'flex-start',
+    alignSelf: "flex-start",
   },
 });

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -17,6 +17,7 @@ type Props = {
   imageUri?: string;
   flagColor?: string;
   selected?: boolean;
+  onImageLoad?: () => void;
 };
 
 export const VISITED_MARKER_OVERLAY_WIDTH = 88;
@@ -30,6 +31,7 @@ export function VisitedMarker({
   imageUri,
   flagColor = "#00D864",
   selected = false,
+  onImageLoad,
 }: Props) {
   const clipIdOuter = useId();
   const clipIdInner = useId();
@@ -75,6 +77,7 @@ export function VisitedMarker({
                   width={32}
                   height={29}
                   preserveAspectRatio="xMidYMid slice"
+                  onLoad={onImageLoad}
                 />
               </G>
             </Svg>

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -1,4 +1,4 @@
-import BottomSheet, { type Tab } from "@/components/bottom-sheet";
+import BottomSheet from "@/components/bottom-sheet";
 import {
   HomeBottomSheetContainer,
   HomeBottomSheetRef,
@@ -21,6 +21,7 @@ import NoRecordBottomSheet from "@/components/no-record-bottom-sheet";
 import { useMyMountains } from "@/features/home/hooks/use-my-mountains";
 import {
   BBox,
+  MountainMapItem,
   useMountainsMap,
 } from "@/features/mountains/hooks/use-mountains-map";
 import { useProfile } from "@/features/mypage/hooks/use-profile";
@@ -36,7 +37,7 @@ import {
 import { router } from "expo-router";
 import {
   forwardRef,
-  useCallback,
+  memo,
   useImperativeHandle,
   useRef,
   useState,
@@ -60,6 +61,48 @@ const DEFAULT_REGION: Region = {
   zoom: 8,
 };
 
+type VisitedMarkerOverlayProps = {
+  mountain: MountainMapItem;
+  selected: boolean;
+  imageUri?: string;
+};
+
+const VisitedMarkerOverlay = memo(function VisitedMarkerOverlay({
+  mountain,
+  selected,
+  imageUri,
+}: VisitedMarkerOverlayProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <NaverMapMarkerOverlay
+      latitude={mountain.latitude}
+      longitude={mountain.longitude}
+      width={VISITED_MARKER_OVERLAY_WIDTH}
+      height={VISITED_MARKER_OVERLAY_HEIGHT}
+      anchor={{ x: 0.2, y: 1 }}
+      onTap={() => router.push(`/mountains/${mountain.id}`)}
+    >
+      <View
+        key={`${selected} ${isLoaded}`}
+        collapsable={false}
+        style={{
+          width: VISITED_MARKER_OVERLAY_WIDTH,
+          height: VISITED_MARKER_OVERLAY_HEIGHT,
+        }}
+      >
+        <VisitedMarker
+          name={mountain.name}
+          visitCount={mountain.visitCount}
+          imageUri={imageUri}
+          selected={selected}
+          onImageLoad={() => setIsLoaded(true)}
+        />
+      </View>
+    </NaverMapMarkerOverlay>
+  );
+});
+
 export type MapHomeViewRef = {
   collapseSheet: () => void;
   expandSheet: () => void;
@@ -78,16 +121,9 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     const sheetRef = useRef<HomeBottomSheetRef>(null);
     const [region, setRegion] = useState<Region>(DEFAULT_REGION);
     const [bbox, setBbox] = useState<BBox>(null);
-    const [activeTab, setActiveTab] = useState<Tab>("내 기록");
-    const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
+const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
       null,
     );
-    const [loadedMarkerImageIds, setLoadedMarkerImageIds] = useState<
-      Set<number>
-    >(new Set());
-    const handleMarkerImageLoad = useCallback((id: number): void => {
-      setLoadedMarkerImageIds((prev) => new Set([...prev, id]));
-    }, []);
     const { data: mapData } = useMountainsMap(bbox);
     const hasRecords = mapData?.hasHikingRecord ?? false;
     const snapExpanded = hasRecords
@@ -161,56 +197,14 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
             ? mapData?.mountains
                 ?.filter((m) => m.visited)
                 .map((mountain) => (
-                  <NaverMapMarkerOverlay
-                    key={`${mountain.id}-${activeTab}-${selectedMountainId}`}
-                    latitude={mountain.latitude}
-                    longitude={mountain.longitude}
-                    width={
-                      mountain.visited
-                        ? VISITED_MARKER_OVERLAY_WIDTH
-                        : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH
+                  <VisitedMarkerOverlay
+                    key={mountain.id}
+                    mountain={mountain}
+                    selected={mountain.id === selectedMountainId}
+                    imageUri={
+                      myMountainImageMap[mountain.id] ?? mountain.imageUrl
                     }
-                    height={
-                      mountain.visited
-                        ? VISITED_MARKER_OVERLAY_HEIGHT
-                        : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT
-                    }
-                    anchor={
-                      mountain.visited ? { x: 0.2, y: 1 } : { x: 0.5, y: 0.5 }
-                    }
-                    onTap={() => router.push(`/mountains/${mountain.id}`)}
-                  >
-                    <View
-                      key={`${mountain.visited} ${mountain.id === selectedMountainId} ${loadedMarkerImageIds.has(mountain.id)}`}
-                      collapsable={false}
-                      style={{
-                        width: mountain.visited
-                          ? VISITED_MARKER_OVERLAY_WIDTH
-                          : UNVISITED_MOUNTAIN_PILL_MARKER_WIDTH,
-                        height: mountain.visited
-                          ? VISITED_MARKER_OVERLAY_HEIGHT
-                          : UNVISITED_MOUNTAIN_PILL_MARKER_HEIGHT,
-                      }}
-                    >
-                      {mountain.visited ? (
-                        <VisitedMarker
-                          name={mountain.name}
-                          visitCount={mountain.visitCount}
-                          imageUri={
-                            myMountainImageMap[mountain.id] ?? mountain.imageUrl
-                          }
-                          selected={mountain.id === selectedMountainId}
-                          onImageLoad={() => handleMarkerImageLoad(mountain.id)}
-                        />
-                      ) : (
-                        <UnvisitedMountainPillMarker
-                          name={mountain.name ?? ""}
-                          variant="trending"
-                          selected={mountain.id === selectedMountainId}
-                        />
-                      )}
-                    </View>
-                  </NaverMapMarkerOverlay>
+                  />
                 ))
             : mapData?.mountains?.map((mountain) => (
                 <NaverMapMarkerOverlay

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -34,7 +34,13 @@ import {
   requestForegroundPermissionsAsync,
 } from "expo-location";
 import { router } from "expo-router";
-import { forwardRef, useImperativeHandle, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from "react";
 import { StyleSheet, TouchableOpacity, View } from "react-native";
 import Animated, {
   interpolate,
@@ -76,6 +82,12 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
     const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
       null,
     );
+    const [loadedMarkerImageIds, setLoadedMarkerImageIds] = useState<
+      Set<number>
+    >(new Set());
+    const handleMarkerImageLoad = useCallback((id: number): void => {
+      setLoadedMarkerImageIds((prev) => new Set([...prev, id]));
+    }, []);
     const { data: mapData } = useMountainsMap(bbox);
     const hasRecords = mapData?.hasHikingRecord ?? false;
     const snapExpanded = hasRecords
@@ -169,6 +181,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
                     onTap={() => router.push(`/mountains/${mountain.id}`)}
                   >
                     <View
+                      key={`${mountain.visited} ${mountain.id === selectedMountainId} ${loadedMarkerImageIds.has(mountain.id)}`}
                       collapsable={false}
                       style={{
                         width: mountain.visited
@@ -187,6 +200,7 @@ export const MapHomeView = forwardRef<MapHomeViewRef, MapHomeViewProps>(
                             myMountainImageMap[mountain.id] ?? mountain.imageUrl
                           }
                           selected={mountain.id === selectedMountainId}
+                          onImageLoad={() => handleMarkerImageLoad(mountain.id)}
                         />
                       ) : (
                         <UnvisitedMountainPillMarker


### PR DESCRIPTION
## Summary

- `VisitedMarker`의 `SvgImage` 이미지 로드 완료 시점에 `NaverMapMarkerOverlay`가 재스냅샷을 찍도록 `View` key 교체 로직 추가 — 이미지가 빠진 채 마커가 렌더되던 문제 수정
- 앱 진입 직후 `FeedHomeView` 마운트를 3초 지연해 뷰포트 이미지 요청과 피드 이미지 요청이 경쟁하던 문제 개선 (피드탭 진입 시 즉시 마운트)

## Test plan

- [ ] 정복지도 진입 후 마커 이미지가 정상 렌더되는지 확인
- [ ] 마커 이미지 로드 완료 후 마커가 이미지 포함해 업데이트되는지 확인
- [ ] 앱 진입 직후 3초간 세모피드 탭을 누르지 않았을 때 피드 관련 이미지 요청이 없는지 확인
- [ ] 세모피드 탭 진입 시 즉시 FeedHomeView 마운트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)