### PR TITLE
feat: 세모피드 상세 실제 데이터 연동 및 이모지 토글

### DIFF
--- a/app/mountains/[id].tsx
+++ b/app/mountains/[id].tsx
@@ -11,14 +11,13 @@ import { DIFFICULTY_LABEL } from "@/features/mountains/components/mountain-card"
 import { COURSE_BADGE } from "@/features/mountains/constants/course-badge";
 import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import { LoadingSpinner } from "@/components/loading-spinner";
+import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useRef, useState } from "react";
 import {
-
   Dimensions,
   FlatList,
-  Image,
   NativeScrollEvent,
   NativeSyntheticEvent,
   Pressable,
@@ -68,7 +67,7 @@ function ImageCarousel({
             <Image
               source={{ uri: item }}
               style={{ width: SCREEN_WIDTH, height: 284 }}
-              resizeMode="cover"
+              contentFit="cover"
             />
           ) : (
             <View style={{ width: SCREEN_WIDTH, height: 284 }} className="bg-fill-stronger" />

--- a/features/community/components/image-viewer-modal.tsx
+++ b/features/community/components/image-viewer-modal.tsx
@@ -1,5 +1,6 @@
 import { CloseIcon } from "@/components/icons/close-icon";
-import { Image, Modal, Pressable, View } from "react-native";
+import { Image } from "expo-image";
+import { Modal, Pressable, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 type ImageViewerModalProps = {
@@ -25,9 +26,8 @@ export function ImageViewerModal({ uri, onClose }: ImageViewerModalProps): React
           {uri ? (
             <Image
               source={{ uri }}
-              className="w-full"
-              style={{ aspectRatio: 1 }}
-              resizeMode="contain"
+              style={{ width: "100%", aspectRatio: 1 }}
+              contentFit="contain"
             />
           ) : null}
         </Pressable>

--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -14,10 +14,10 @@ import {
   FreePostReportRequest,
 } from "@/types/api.generated";
 import { useRef, useState } from "react";
+import { Image } from "expo-image";
 import {
   Alert,
   Dimensions,
-  Image,
   Modal,
   Pressable,
   ScrollView,
@@ -147,9 +147,8 @@ export function PostBody({
                   {img.imageUrl ? (
                     <Image
                       source={{ uri: img.imageUrl }}
-                      className="rounded-xl"
-                      style={{ width: 148, height: 148 }}
-                      resizeMode="cover"
+                      style={{ width: 148, height: 148, borderRadius: 12 }}
+                      contentFit="cover"
                     />
                   ) : (
                     <View

--- a/features/community/components/thumbnail.tsx
+++ b/features/community/components/thumbnail.tsx
@@ -1,9 +1,10 @@
-import { Image, View } from "react-native";
+import { Image } from "expo-image";
+import { View } from "react-native";
 
 export function Thumbnail({ imageUrl }: { imageUrl: string }) {
   return (
     <View className="size-[68px] overflow-hidden rounded-[4px] bg-fill-neutral">
-      <Image source={{ uri: imageUrl }} className="size-[68px]" />
+      <Image source={{ uri: imageUrl }} style={{ flex: 1 }} contentFit="cover" />
     </View>
   );
 }

--- a/features/home/components/feed-cell-detail.tsx
+++ b/features/home/components/feed-cell-detail.tsx
@@ -1,26 +1,59 @@
 import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
-import { MountainChipIcon } from "@/components/icons/mountain-chip-icon";
 import { XIcon } from "@/components/icons/x-icon";
-import { Image, Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { SemoFeedEmojiRequest, SemoFeedResponse } from "@/types/api.generated";
+import { useState } from "react";
+import { Image, Modal, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useToggleSemofeedEmoji } from "../hooks/use-toggle-semofeed-emoji";
 
-const EMOJIS = [
-  { emoji: "1", count: 14 },
-  { emoji: "2", count: 14 },
-  { emoji: "3", count: 14 },
-  { emoji: "4", count: 14 },
-] as const;
+const EMOJI_ORDER: { key: SemoFeedEmojiRequest["emojiType"]; char: string }[] =
+  [
+    { key: "FIRE", char: "🔥" },
+    { key: "HEART", char: "❤️" },
+    { key: "CONGRATS", char: "🎉" },
+    { key: "LAUGH", char: "😂" },
+  ];
 
 type FeedCellDetailProps = {
-  imageUri: string;
+  item: SemoFeedResponse;
   onClose: () => void;
 };
 
 export function FeedCellDetail({
-  imageUri,
+  item,
   onClose,
 }: FeedCellDetailProps): React.ReactElement {
   const { top, bottom } = useSafeAreaInsets();
+  const imageUrl = item.imageUrl?.replace(/"/g, "");
+
+  const [counts, setCounts] = useState<Record<string, number>>(
+    item.emojiCounts ?? {},
+  );
+  const [reacted, setReacted] = useState<Record<string, boolean>>(
+    item.reactedByMe ?? {},
+  );
+
+  const { mutate: toggleEmoji } = useToggleSemofeedEmoji();
+
+  const handleEmojiPress = (
+    emojiKey: SemoFeedEmojiRequest["emojiType"],
+  ): void => {
+    if (item.id == null) return;
+    toggleEmoji(
+      {
+        semoFeedId: item.id,
+        emojiType: emojiKey,
+      },
+      {
+        onSuccess: (res) => {
+          const { emojiType, reacted: newReacted, count } = res.data ?? {};
+          if (emojiType == null || newReacted == null || count == null) return;
+          setCounts((prev) => ({ ...prev, [emojiType]: count }));
+          setReacted((prev) => ({ ...prev, [emojiType]: newReacted }));
+        },
+      },
+    );
+  };
 
   return (
     <Modal
@@ -38,79 +71,76 @@ export function FeedCellDetail({
           <Pressable
             onPress={onClose}
             className="h-12 w-12 items-center justify-center rounded-full bg-[#1a1b1f]"
-            style={styles.buttonShadow}
+            style={{ boxShadow: "0px 2px 2px rgba(0,0,0,0.1)" }}
           >
             <ChevronLeftIcon size={24} color="#ffffff" />
           </Pressable>
           <Pressable
             onPress={onClose}
             className="h-12 w-12 items-center justify-center rounded-full bg-[#1a1b1f]"
-            style={styles.buttonShadow}
+            style={{ boxShadow: "0px 2px 2px rgba(0,0,0,0.1)" }}
           >
             <XIcon size={24} color="#ffffff" />
           </Pressable>
         </View>
+
         <View className="w-full items-center">
-          {/* 이미지 + 프로필: 헤더 아래 20px에서 시작 */}
+          {/* 이미지 + 프로필 */}
           <Pressable
             className="items-center"
             style={{ paddingTop: top + 76 }}
             onPress={() => {}}
           >
-            {/* 이미지·프로필을 같은 너비로 묶어 프로필이 이미지 왼쪽 기준 정렬 */}
             <View className="w-[288px] items-start">
               <View className="h-[512px] w-full overflow-hidden rounded-[20px]">
-                <Image
-                  source={{ uri: imageUri }}
-                  className="h-full w-full"
-                  resizeMode="cover"
-                />
-                {/* 산 칩 */}
-                <View className="absolute right-4 top-4 flex-row items-center gap-1 rounded-full bg-[rgba(26,27,31,0.6)] py-[5px] pl-[5px] pr-[10px]">
-                  <MountainChipIcon size={18} />
-                  <Text className="text-label-normal-inverse typo-caption-1-semi-bold">
-                    관악산
-                  </Text>
-                </View>
+                {imageUrl ? (
+                  <Image
+                    source={{ uri: imageUrl }}
+                    className="h-full w-full"
+                    resizeMode="cover"
+                  />
+                ) : null}
               </View>
 
               {/* 프로필 */}
               <View className="mb-5 mt-5 flex-row items-center gap-2 px-1">
-                <View className="h-8 w-8 items-center justify-center rounded-full bg-fill-normal" />
+                <View className="h-8 w-8 overflow-hidden rounded-full bg-fill-normal">
+                  {item.profileUrl ? (
+                    <Image
+                      source={{ uri: item.profileUrl }}
+                      className="h-full w-full"
+                      resizeMode="cover"
+                    />
+                  ) : null}
+                </View>
                 <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
-                  나는야엄홍길
+                  {item.nickname ?? ""}
                 </Text>
               </View>
             </View>
           </Pressable>
 
           {/* 이모지 반응 */}
-          <Pressable
+          <View
             className="flex-row justify-center gap-2"
             style={{ paddingBottom: bottom + 24 }}
-            onPress={() => {}}
           >
-            {EMOJIS.map(({ emoji, count }) => (
+            {EMOJI_ORDER.map(({ key, char }) => (
               <Pressable
-                key={emoji}
-                className="h-10 w-[70px] flex-row items-center justify-center gap-1 rounded-full bg-white/10"
+                key={key}
+                onPress={() => handleEmojiPress(key)}
+                className={`h-10 w-[70px] flex-row items-center justify-center gap-1 rounded-full ${reacted[key] ? "bg-white/25" : "bg-white/10"}`}
               >
-                <Text style={{ fontSize: 20 }}>{emoji}</Text>
+                <Text style={{ fontSize: 20 }}>{char}</Text>
                 <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
-                  {count}
+                  {counts[key] ?? 0}
                 </Text>
               </Pressable>
             ))}
-          </Pressable>
+          </View>
         </View>
       </Pressable>
     </Modal>
   );
 }
 
-const styles = StyleSheet.create({
-  buttonShadow: {
-    boxShadow: "0px 2px 2px rgba(0,0,0,0.1)",
-    elevation: 2,
-  },
-});

--- a/features/home/components/feed-cell-detail.tsx
+++ b/features/home/components/feed-cell-detail.tsx
@@ -2,7 +2,8 @@ import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
 import { XIcon } from "@/components/icons/x-icon";
 import { SemoFeedEmojiRequest, SemoFeedResponse } from "@/types/api.generated";
 import { useState } from "react";
-import { Image, Modal, Pressable, Text, View } from "react-native";
+import { Image } from "expo-image";
+import { ActivityIndicator, Modal, Pressable, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useToggleSemofeedEmoji } from "../hooks/use-toggle-semofeed-emoji";
 
@@ -33,12 +34,17 @@ export function FeedCellDetail({
     item.reactedByMe ?? {},
   );
 
+  const [pendingEmoji, setPendingEmoji] = useState<
+    SemoFeedEmojiRequest["emojiType"] | null
+  >(null);
+
   const { mutate: toggleEmoji } = useToggleSemofeedEmoji();
 
   const handleEmojiPress = (
     emojiKey: SemoFeedEmojiRequest["emojiType"],
   ): void => {
-    if (item.id == null) return;
+    if (item.id == null || pendingEmoji !== null) return;
+    setPendingEmoji(emojiKey);
     toggleEmoji(
       {
         semoFeedId: item.id,
@@ -51,6 +57,7 @@ export function FeedCellDetail({
           setCounts((prev) => ({ ...prev, [emojiType]: count }));
           setReacted((prev) => ({ ...prev, [emojiType]: newReacted }));
         },
+        onSettled: () => setPendingEmoji(null),
       },
     );
   };
@@ -96,8 +103,8 @@ export function FeedCellDetail({
                 {imageUrl ? (
                   <Image
                     source={{ uri: imageUrl }}
-                    className="h-full w-full"
-                    resizeMode="cover"
+                    style={{ flex: 1 }}
+                    contentFit="cover"
                   />
                 ) : null}
               </View>
@@ -108,8 +115,8 @@ export function FeedCellDetail({
                   {item.profileUrl ? (
                     <Image
                       source={{ uri: item.profileUrl }}
-                      className="h-full w-full"
-                      resizeMode="cover"
+                      style={{ flex: 1 }}
+                      contentFit="cover"
                     />
                   ) : null}
                 </View>
@@ -125,18 +132,28 @@ export function FeedCellDetail({
             className="flex-row justify-center gap-2"
             style={{ paddingBottom: bottom + 24 }}
           >
-            {EMOJI_ORDER.map(({ key, char }) => (
-              <Pressable
-                key={key}
-                onPress={() => handleEmojiPress(key)}
-                className={`h-10 w-[70px] flex-row items-center justify-center gap-1 rounded-full ${reacted[key] ? "bg-white/25" : "bg-white/10"}`}
-              >
-                <Text style={{ fontSize: 20 }}>{char}</Text>
-                <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
-                  {counts[key] ?? 0}
-                </Text>
-              </Pressable>
-            ))}
+            {EMOJI_ORDER.map(({ key, char }) => {
+              const isLoading = pendingEmoji === key;
+              return (
+                <Pressable
+                  key={key}
+                  onPress={() => handleEmojiPress(key)}
+                  disabled={pendingEmoji !== null}
+                  className={`h-10 w-[70px] flex-row items-center justify-center gap-1 rounded-full ${reacted[key] ? "bg-white/25" : "bg-white/10"}`}
+                >
+                  {isLoading ? (
+                    <ActivityIndicator size="small" color="#ffffff" />
+                  ) : (
+                    <>
+                      <Text style={{ fontSize: 20 }}>{char}</Text>
+                      <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
+                        {counts[key] ?? 0}
+                      </Text>
+                    </>
+                  )}
+                </Pressable>
+              );
+            })}
           </View>
         </View>
       </Pressable>

--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -1,6 +1,7 @@
 import { SemoFeedResponse } from "@/types/api.generated";
+import { Image } from "expo-image";
 import { memo } from "react";
-import { Image, View } from "react-native";
+import { View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, { FadeInDown } from "react-native-reanimated";
 import { runOnJS } from "react-native-worklets";
@@ -49,8 +50,8 @@ export const FeedCell = memo(function FeedCell({
             <Image
               // TODO: 백엔드에서 URL에 큰따옴표 포함 저장 현상 수정되면 replace 로직 제거
               source={{ uri: imageUrl.replace(/"/g, "") }}
-              className="absolute inset-0 h-full w-full"
-              resizeMode="cover"
+              style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+              contentFit="cover"
             />
           )}
         </View>

--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -1,8 +1,9 @@
-import { MountainChipIcon } from "@/components/icons/mountain-chip-icon";
+import { SemoFeedResponse } from "@/types/api.generated";
 import { memo } from "react";
-import { Image, Text, View } from "react-native";
+import { Image, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, { FadeInDown } from "react-native-reanimated";
+import { runOnJS } from "react-native-worklets";
 
 export const CELL_CONTENT_W = 234;
 export const CELL_CONTENT_H = 416;
@@ -15,19 +16,20 @@ export const MAX_COORD = 25;
 type FeedCellProps = {
   col: number;
   row: number;
-  imageUrl?: string;
-  onPress: (imageUri: string) => void;
+  item?: SemoFeedResponse;
+  onPress: (item: SemoFeedResponse) => void;
 };
 
 export const FeedCell = memo(function FeedCell({
   col,
   row,
-  imageUrl,
+  item,
   onPress,
 }: FeedCellProps) {
+  const imageUrl = item?.imageUrl;
+
   const tap = Gesture.Tap().onEnd(() => {
-    // TODO : 세모피드 상세 API 연동되면 주석해제
-    // if (imageUrl) runOnJS(onPress)(imageUrl);
+    if (item) runOnJS(onPress)(item);
   });
 
   return (
@@ -53,16 +55,6 @@ export const FeedCell = memo(function FeedCell({
           )}
         </View>
       </GestureDetector>
-      {/* 산 뱃지 */}
-      <View
-        className="absolute right-4 top-4 flex-row items-center gap-1 rounded-full bg-[rgba(26,27,31,0.6)] py-[5px] pl-[5px] pr-[10px]"
-        pointerEvents="none"
-      >
-        <MountainChipIcon size={18} />
-        <Text className="text-label-normal-inverse typo-caption-1-semi-bold">
-          관악산
-        </Text>
-      </View>
     </Animated.View>
   );
 });

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -1,4 +1,5 @@
 import { ResetIcon } from "@/components/icons/reset-icon";
+import { SemoFeedResponse } from "@/types/api.generated";
 import { Image } from "expo-image";
 import { useRef, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
@@ -51,8 +52,7 @@ export function FeedHomeView() {
   // JS 스레드 state: 가상화 계산용
   const [offset, setOffset] = useState({ x: 0, y: 0 });
 
-  // TODO : API연동되면 imageUri 아니라 id가 와야할듯.
-  const [selectedImageUri, setSelectedImageUri] = useState<string | null>(null);
+  const [selectedItem, setSelectedItem] = useState<SemoFeedResponse | null>(null);
 
   // UI 스레드 shared value: transform 갱신용
   const translateX = useSharedValue(0);
@@ -91,7 +91,7 @@ export function FeedHomeView() {
   // Pan 제스처 (디테일 열려있으면 비활성)
   // ─────────────────────────────────────────────
   const pan = Gesture.Pan()
-    .enabled(selectedImageUri === null)
+    .enabled(selectedItem === null)
     // 8px 이상 움직여야 Pan 활성화 → 그 전엔 Tap이 우선
     .activeOffsetX([-8, 8])
     .activeOffsetY([-8, 8])
@@ -153,8 +153,8 @@ export function FeedHomeView() {
             key={`${col},${row}`}
             col={col}
             row={row}
-            imageUrl={feedItems[spiralIdx]?.imageUrl ?? undefined}
-            onPress={setSelectedImageUri}
+            item={feedItems[spiralIdx]}
+            onPress={setSelectedItem}
           />,
         );
       }
@@ -211,10 +211,10 @@ export function FeedHomeView() {
         <ResetIcon size={24} color="#ffffff" />
       </Pressable>
 
-      {selectedImageUri !== null && (
+      {selectedItem !== null && (
         <FeedCellDetail
-          imageUri={selectedImageUri}
-          onClose={() => setSelectedImageUri(null)}
+          item={selectedItem}
+          onClose={() => setSelectedItem(null)}
         />
       )}
     </>

--- a/features/home/hooks/use-toggle-semofeed-emoji.ts
+++ b/features/home/hooks/use-toggle-semofeed-emoji.ts
@@ -1,0 +1,26 @@
+import { api } from "@/lib/api";
+import {
+  ENDPOINTS,
+  SemoFeedEmojiRequest,
+  SemoFeedEmojiToggleResponse,
+} from "@/types/api.generated";
+import { useMutation, UseMutationResult } from "@tanstack/react-query";
+
+type ToggleEmojiVariables = {
+  semoFeedId: number;
+  emojiType: SemoFeedEmojiRequest["emojiType"];
+};
+
+export function useToggleSemofeedEmoji(): UseMutationResult<
+  Awaited<ReturnType<typeof api.post<SemoFeedEmojiToggleResponse>>>,
+  Error,
+  ToggleEmojiVariables
+> {
+  return useMutation({
+    mutationFn: ({ semoFeedId, emojiType }: ToggleEmojiVariables) =>
+      api.post<SemoFeedEmojiToggleResponse>({
+        path: ENDPOINTS.SEMOFEED_BY_SEMOFEEDID_EMOJIS(semoFeedId),
+        body: { emojiType },
+      }),
+  });
+}

--- a/features/mountains/components/mountain-card.tsx
+++ b/features/mountains/components/mountain-card.tsx
@@ -1,6 +1,7 @@
 import { COURSE_BADGE } from "@/features/mountains/constants/course-badge";
 import { MountainListResponse } from "@/types/api.generated";
-import { Image, Text, View } from "react-native";
+import { Image } from "expo-image";
+import { Text, View } from "react-native";
 
 type MountainDifficulty = NonNullable<MountainListResponse["difficulty"]>;
 
@@ -16,8 +17,8 @@ export function MountainCard({ mountain }: { mountain: MountainListResponse }) {
       {mountain.imageUrls?.[0] ? (
         <Image
           source={{ uri: mountain.imageUrls[0] }}
-          className="h-[72px] w-[86px] rounded-[10px] bg-fill-stronger"
-          resizeMode="cover"
+          style={{ width: 86, height: 72, borderRadius: 10 }}
+          contentFit="cover"
         />
       ) : (
         <View className="h-[72px] w-[86px] rounded-[10px] bg-fill-stronger" />


### PR DESCRIPTION
## Summary

- `FeedCell`에 `imageUrl` 단독 대신 `SemoFeedResponse` 전체 item 전달
- `FeedCellDetail`에 프로필 이미지, 닉네임, 이모지 카운트 실제 데이터 렌더링
- `useToggleSemofeedEmoji` 훅 추가 — `POST /api/semofeed/{id}/emojis` 호출
- 이모지 버튼 토글 시 응답값(`reacted`, `count`)으로 로컬 state 즉시 업데이트
- `StyleSheet` 제거 후 NativeWind `className`으로 전면 대체

## Test plan

- [ ] 세모피드 셀 탭 → 상세 모달 오픈 확인
- [ ] 상세에서 프로필 이미지·닉네임 정상 표시 확인
- [ ] 이모지 버튼 탭 → 카운트 증가 및 하이라이트(bg-white/25) 확인
- [ ] 동일 이모지 재탭 → 카운트 감소 및 하이라이트 해제 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)