### PR TITLE
fix : tracking fcm notification

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -170,6 +170,7 @@ export default function TrackingScreen() {
   const backgroundedAtRef = useRef<number | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
+  const [mapZoom, setMapZoom] = useState(12);
   const isMountedRef = useRef(true);
   useEffect(
     () => () => {
@@ -434,6 +435,13 @@ export default function TrackingScreen() {
   const { markerRatio, remainingDistanceM, remainingDurationMin } =
     courseProgressState;
 
+  // 줌 레벨에 따른 폴리라인 두께 — 줌아웃 시 얇게, 줌인 시 두껍게
+  const polylineWidth = useMemo(() => {
+    const colored = Math.max(2, Math.round((mapZoom - 9) * 1.2));
+    const base = colored + 4;
+    return { colored, base };
+  }, [mapZoom]);
+
   // altitudes 문자열에서 최고 고도(m) 파싱
   const peakAltitudeM = useMemo(() => {
     const raw = courseDetail?.altitudes;
@@ -511,7 +519,7 @@ export default function TrackingScreen() {
                 {/* 흰색 베이스 — 가장자리 border 역할 */}
                 <NaverMapPathOverlay
                   coords={courseCoords}
-                  width={16}
+                  width={polylineWidth.base}
                   color={COLOR_WHITE}
                   outlineWidth={1}
                   outlineColor={COLOR_WHITE}
@@ -525,7 +533,7 @@ export default function TrackingScreen() {
                     <NaverMapPathOverlay
                       key={i}
                       coords={coords}
-                      width={12}
+                      width={polylineWidth.colored}
                       color={color}
                       outlineWidth={1}
                       outlineColor={color}
@@ -537,13 +545,14 @@ export default function TrackingScreen() {
               <>
                 <NaverMapPathOverlay
                   coords={courseCoords}
-                  width={10}
+                  width={polylineWidth.base}
                   color={COLOR_WHITE}
-                  outlineWidth={0}
+                  outlineWidth={1}
+                  outlineColor={COLOR_WHITE}
                 />
                 <NaverMapPathOverlay
                   coords={courseCoords}
-                  width={12}
+                  width={polylineWidth.colored}
                   color="#FFD40D"
                   outlineWidth={1}
                   outlineColor="#FFD40D"
@@ -622,7 +631,7 @@ export default function TrackingScreen() {
         )}
       </>
     ),
-    [courseCoords, courseDetail?.segments, isFreeMode, recordedCoords, isTracking, nearbyData],
+    [courseCoords, courseDetail?.segments, isFreeMode, recordedCoords, isTracking, nearbyData, polylineWidth],
   );
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
@@ -1136,8 +1145,9 @@ export default function TrackingScreen() {
             left: 0,
             right: 0,
           }}
-          onCameraChanged={({ reason }) => {
+          onCameraChanged={({ reason, zoom }) => {
             if (reason === "Gesture") setIsFollowingUser(false);
+            if (zoom != null) setMapZoom(zoom);
           }}
         >
           {staticMapOverlays}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -627,17 +627,31 @@ export default function TrackingScreen() {
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
 
-  // polyline 로드되거나 트래킹 시작 시 카메라를 전체 경로가 보이도록 맞춤
+  // polyline 로드되거나 트래킹 시작 시 카메라 설정
+  // 데모 모드 + 트래킹 중: 출발 좌표로 줌 (follow 모드와 충돌 방지)
+  // 그 외: 전체 경로가 보이도록 맞춤
   useEffect(() => {
     if (courseCoords.length < 2) return;
-    const lats = courseCoords.map((c) => c.latitude);
-    const lngs = courseCoords.map((c) => c.longitude);
-    const minLat = Math.min(...lats);
-    const maxLat = Math.max(...lats);
-    const minLng = Math.min(...lngs);
-    const maxLng = Math.max(...lngs);
-    const padding = 0.15;
-    const fit = () =>
+
+    const timer = setTimeout(() => {
+      if (DEMO_MODE && isTracking) {
+        // 데모 모드 트래킹 중 — 출발 좌표(첫 번째 포인트)로 줌
+        mapRef.current?.animateCameraTo({
+          latitude: courseCoords[0].latitude,
+          longitude: courseCoords[0].longitude,
+          zoom: 15,
+          duration: 500,
+        });
+        return;
+      }
+
+      const lats = courseCoords.map((c) => c.latitude);
+      const lngs = courseCoords.map((c) => c.longitude);
+      const minLat = Math.min(...lats);
+      const maxLat = Math.max(...lats);
+      const minLng = Math.min(...lngs);
+      const maxLng = Math.max(...lngs);
+      const padding = 0.15;
       mapRef.current?.animateCameraWithTwoCoords({
         coord1: {
           latitude: minLat - (maxLat - minLat) * padding,
@@ -649,8 +663,7 @@ export default function TrackingScreen() {
         },
         duration: 500,
       });
-    // mapRef가 아직 마운트 전일 수 있으니 약간 지연
-    const timer = setTimeout(fit, 300);
+    }, 300);
     return () => clearTimeout(timer);
   }, [courseDetail?.polyline, isTracking]);
 

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -437,7 +437,7 @@ export default function TrackingScreen() {
 
   // 줌 레벨에 따른 폴리라인 두께 — 줌아웃 시 얇게, 줌인 시 두껍게
   const polylineWidth = useMemo(() => {
-    const colored = Math.max(2, Math.round((mapZoom - 9) * 1.2));
+    const colored = Math.max(5, Math.round((mapZoom - 9) * 1.2));
     const base = colored + 4;
     return { colored, base };
   }, [mapZoom]);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -682,7 +682,9 @@ export default function TrackingScreen() {
   }, [isTracking]);
 
   // 트래킹 중 실시간 위치 마커 카메라 추적 (사용자가 직접 조작하면 follow 해제)
+  // 데모 모드에서는 카메라 follow 비활성 — 출발 좌표로 고정 (시뮬 마커가 카메라 흔들기 방지)
   useEffect(() => {
+    if (DEMO_MODE) return;
     if (!isFollowingUser || !markerCoord) return;
     mapRef.current?.animateCameraTo({
       latitude: markerCoord.latitude,

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -170,7 +170,6 @@ export default function TrackingScreen() {
   const backgroundedAtRef = useRef<number | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
-  const [mapZoom, setMapZoom] = useState(12);
   const isMountedRef = useRef(true);
   useEffect(
     () => () => {
@@ -436,11 +435,7 @@ export default function TrackingScreen() {
     courseProgressState;
 
   // 줌 레벨에 따른 폴리라인 두께 — 줌아웃 시 얇게, 줌인 시 두껍게
-  const polylineWidth = useMemo(() => {
-    const colored = Math.max(5, Math.round((mapZoom - 9) * 1.2));
-    const base = colored + 4;
-    return { colored, base };
-  }, [mapZoom]);
+  const polylineWidth = { colored: 7, base: 11 };
 
   // altitudes 문자열에서 최고 고도(m) 파싱
   const peakAltitudeM = useMemo(() => {
@@ -631,7 +626,7 @@ export default function TrackingScreen() {
         )}
       </>
     ),
-    [courseCoords, courseDetail?.segments, isFreeMode, recordedCoords, isTracking, nearbyData, polylineWidth],
+    [courseCoords, courseDetail?.segments, isFreeMode, recordedCoords, isTracking, nearbyData],
   );
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
@@ -1147,9 +1142,8 @@ export default function TrackingScreen() {
             left: 0,
             right: 0,
           }}
-          onCameraChanged={({ reason, zoom }) => {
+          onCameraChanged={({ reason }) => {
             if (reason === "Gesture") setIsFollowingUser(false);
-            if (zoom != null) setMapZoom(zoom);
           }}
         >
           {staticMapOverlays}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,12 +26,27 @@ import "../global.css";
 
 // 포어그라운드에서도 알림 배너 표시
 Notifications.setNotificationHandler({
-  handleNotification: async () => {
+  handleNotification: async (notification) => {
+    const data = notification.request.content.data as { type?: string } | null;
+    const type = data?.type;
+
+    // 트래킹 푸시: 포어그라운드에서 시스템 배너 차단 (in-app banner 만 노출)
+    // mixed payload 로 백엔드가 notification + data 둘 다 보내므로 중복 방지
+    if (type === 'TRACKING_PHOTO_MILESTONE' || type === 'TRACKING_SUMMIT_REACHED') {
+      return {
+        shouldShowBanner: false,
+        shouldShowList: false,
+        shouldPlaySound: false,
+        shouldSetBadge: true,
+      };
+    }
+
+    // 그 외 (커뮤니티/세모피드 등): 시스템 배너 그대로 표시
     return {
       shouldShowBanner: true,
       shouldShowList: true,
       shouldPlaySound: true,
-      shouldSetBadge: false,
+      shouldSetBadge: true,
     };
   },
 });

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -2,7 +2,6 @@ import { getApp } from '@react-native-firebase/app';
 import { getMessaging, onMessage } from '@react-native-firebase/messaging';
 import * as Notifications from 'expo-notifications';
 import { useEffect } from 'react';
-
 import { PhotoWindowPayload } from './use-tracking-socket';
 
 type Options = {

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -2,6 +2,7 @@ import { getApp } from '@react-native-firebase/app';
 import { getMessaging, onMessage } from '@react-native-firebase/messaging';
 import * as Notifications from 'expo-notifications';
 import { useEffect } from 'react';
+
 import { PhotoWindowPayload } from './use-tracking-socket';
 
 type Options = {
@@ -86,20 +87,8 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
       console.log('[TrackingFCM] milestoneIndex:', payload.milestoneIndex, 'distance:', payload.milestoneDistance);
 
       // 인앱 PhotoWindowBanner 활성화
+      // notification 필드가 포함된 FCM 페이로드로 변경되어 iOS가 자동으로 시스템 배너 표시
       onPhotoWindow(payload);
-
-      // 포어그라운드 시스템 배너 수동 표시 (Firebase SDK가 자동 표시 안 함)
-      try {
-        await Notifications.scheduleNotificationAsync({
-          content: {
-            title: 'SEMOSAN',
-            body: `${payload.milestoneDistance}m 돌파! 인증 사진을 남겨보세요!`,
-          },
-          trigger: null,
-        });
-      } catch (err) {
-        console.warn('[TrackingFCM] 로컬 알림 예약 실패:', err);
-      }
     });
 
     // 백그라운드/잠금화면 알림 탭 후 앱 복귀

--- a/index.js
+++ b/index.js
@@ -11,17 +11,8 @@ messaging().setBackgroundMessageHandler(async (remoteMessage) => {
   // 핸들러 실행 확인용 — 타입 관계없이 뱃지 증가
   await Notifications.setBadgeCountAsync(1);
 
-  if (!data || data.type !== 'TRACKING_PHOTO_MILESTONE') return;
-
-  const distance = parseFloat(data.distance ?? '0');
-
-  await Notifications.scheduleNotificationAsync({
-    content: {
-      title: 'SEMOSAN',
-      body: `${Math.round(distance)}m 돌파! 인증 사진을 남겨보세요!`,
-    },
-    trigger: null,
-  });
+  // mixed payload 트래킹 푸시는 시스템이 자동 배너 표시 → 로컬 알림 생성 X
+  if (data?.type === 'TRACKING_PHOTO_MILESTONE' || data?.type === 'TRACKING_SUMMIT_REACHED') return;
 });
 
 require('expo-router/entry');


### PR DESCRIPTION
## 요약

- FCM silent push → mixed payload(notification + data) 전환 대응
- 트래킹 푸시 알림 중복 제거 및 포어그라운드/백그라운드 배너 분기 처리
- 데모 모드 카메라 동작 개선 (출발 좌표 고정)
- 코스 폴리라인 두께 고정 (7/11px)

## 변경 파일

- `index.js` — 백그라운드 핸들러에서 트래킹 타입 로컬 알림 생성 제거 (mixed payload로 OS 자동 표시)
- `features/tracking/hooks/use-tracking-fcm.ts` — 포어그라운드 `scheduleNotificationAsync` 중복 제거
- `app/_layout.tsx` — `setNotificationHandler`에 타입별 배너 분기 추가 (트래킹 타입은 포어그라운드 시스템 배너 차단, in-app banner만 노출)
- `app/(tabs)/tracking.tsx` — 데모 모드 카메라 follow 비활성화 / 트래킹 시작 시 출발 좌표 줌 / 폴리라인 두께 7/11px 고정

## 테스트 체크리스트

- [ ] 포어그라운드 트래킹 중 마일스톤 도달 시 in-app 배너만 표시되는지 확인 (시스템 배너 중복 없음)
- [ ] 백그라운드에서 마일스톤 도달 시 시스템 푸시 알림 정상 수신 확인
- [ ] 커뮤니티 등 다른 알림은 시스템 배너 정상 표시 확인
- [ ] 데모 모드 트래킹 시작 시 카메라가 출발 좌표로 이동 확인
- [ ] 코스 폴리라인 두께 정상 표시 확인

## 연관 백엔드 PR

- SEMOSAN_BE #190 — 트래킹 푸시 mixed payload 전환