### PR TITLE
fix: 저장한 산 목록 로딩 속도 개선

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -9,7 +9,10 @@ import {
   HIKING_LEVEL_LABEL,
   useProfile,
 } from "@/features/mypage/hooks/use-profile";
+import { usePrefetchSavedMountains } from "@/features/mountains/hooks/use-saved-mountains";
+import { useFocusEffect } from "expo-router";
 import { useRouter } from "expo-router";
+import { useCallback } from "react";
 import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
@@ -18,6 +21,13 @@ export default function MyPageScreen() {
   const router = useRouter();
 
   const { data: profile } = useProfile();
+  const prefetchSavedMountains = usePrefetchSavedMountains();
+
+  useFocusEffect(
+    useCallback(() => {
+      prefetchSavedMountains();
+    }, [prefetchSavedMountains]),
+  );
   const { mutate: logout } = useLogout();
   const { mutate: withdraw } = useWithdraw();
 

--- a/app/mypage/saved-mountains.tsx
+++ b/app/mypage/saved-mountains.tsx
@@ -4,9 +4,9 @@ import { DIFFICULTY_LABEL } from '@/features/mountains/components/mountain-card'
 import { COURSE_BADGE } from '@/features/mountains/constants/course-badge';
 import { useSavedMountains } from '@/features/mountains/hooks/use-saved-mountains';
 import { LikedMountainResponse } from '@/types/api.generated';
-import { useFocusEffect, useRouter } from 'expo-router';
-import { useCallback } from 'react';
-import { FlatList, Image, Text, TouchableOpacity, View } from 'react-native';
+import { Image } from 'expo-image';
+import { useRouter } from 'expo-router';
+import { FlatList, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 function SavedMountainItem({ mountain }: { mountain: LikedMountainResponse }) {
@@ -24,7 +24,7 @@ function SavedMountainItem({ mountain }: { mountain: LikedMountainResponse }) {
         source={mountain.imageUrls?.[0] ? { uri: mountain.imageUrls[0] } : undefined}
         className="bg-fill-stronger"
         style={{ width: 72, height: 72, borderRadius: 10 }}
-        resizeMode="cover"
+        contentFit="cover"
       />
 
       {/* 정보 */}
@@ -80,14 +80,7 @@ function EmptyState() {
 export default function SavedMountainsScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
-  const { data, isLoading, refetch } = useSavedMountains();
-
-  // 화면 포커스될 때마다 최신 데이터 동기화
-  useFocusEffect(
-    useCallback(() => {
-      refetch();
-    }, [refetch])
-  );
+  const { data, isLoading } = useSavedMountains();
 
   // 낙관적 업데이트로 임시 추가된 불완전한 항목(name 없는 항목) 필터링
   const mountains = (data?.content ?? []).filter((m) => !!m.name);

--- a/features/mountains/hooks/use-saved-mountains.ts
+++ b/features/mountains/hooks/use-saved-mountains.ts
@@ -1,9 +1,20 @@
 import { getLikedMountains, LIKES_KEY } from './use-mountain-bookmark';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 export function useSavedMountains() {
   return useQuery({
     queryKey: LIKES_KEY,
     queryFn: getLikedMountains,
+    staleTime: 5 * 60 * 1000,
   });
+}
+
+export function usePrefetchSavedMountains() {
+  const queryClient = useQueryClient();
+  return () =>
+    queryClient.prefetchQuery({
+      queryKey: LIKES_KEY,
+      queryFn: getLikedMountains,
+      staleTime: 5 * 60 * 1000,
+    });
 }

--- a/features/mountains/hooks/use-saved-mountains.ts
+++ b/features/mountains/hooks/use-saved-mountains.ts
@@ -1,5 +1,6 @@
 import { getLikedMountains, LIKES_KEY } from './use-mountain-bookmark';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 
 export function useSavedMountains() {
   return useQuery({
@@ -11,10 +12,13 @@ export function useSavedMountains() {
 
 export function usePrefetchSavedMountains() {
   const queryClient = useQueryClient();
-  return () =>
-    queryClient.prefetchQuery({
-      queryKey: LIKES_KEY,
-      queryFn: getLikedMountains,
-      staleTime: 5 * 60 * 1000,
-    });
+  return useCallback(
+    () =>
+      queryClient.prefetchQuery({
+        queryKey: LIKES_KEY,
+        queryFn: getLikedMountains,
+        staleTime: 5 * 60 * 1000,
+      }),
+    [queryClient],
+  );
 }


### PR DESCRIPTION
## Summary
- 마이페이지 탭 포커스 시 저장한 산 목록 prefetch → 화면 진입 전에 데이터 미리 수신
- `staleTime: 5분` 추가 → 재진입 시 불필요한 API 재호출 제거
- `useFocusEffect` + `refetch` 제거 (북마크 mutation의 `invalidateQueries`로 충분)
- 디스크 캐싱으로 이미지 재로딩 제거