### PR TITLE
fix : 포어그라운드 트래킹 알림 시스템 배너 활성화

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -34,9 +34,9 @@ Notifications.setNotificationHandler({
     // mixed payload 로 백엔드가 notification + data 둘 다 보내므로 중복 방지
     if (type === 'TRACKING_PHOTO_MILESTONE' || type === 'TRACKING_SUMMIT_REACHED') {
       return {
-        shouldShowBanner: false,
-        shouldShowList: false,
-        shouldPlaySound: false,
+        shouldShowBanner: true,
+        shouldShowList: true,
+        shouldPlaySound: true,
         shouldSetBadge: true,
       };
     }


### PR DESCRIPTION
## 요약

- FCM silent push → mixed payload(notification + data) 전환 대응
- 트래킹 푸시 알림 중복 제거 및 포어그라운드/백그라운드 시스템 배너 정상화
- 데모 모드 카메라 동작 개선 (출발 좌표 고정, follow 비활성화)
- 코스 폴리라인 두께 7/11px 고정

## 변경 파일

- `index.js` — 백그라운드 핸들러에서 트래킹 타입 로컬 알림 생성 제거 (mixed payload로 OS 자동 표시)
- `features/tracking/hooks/use-tracking-fcm.ts` — 포어그라운드 `scheduleNotificationAsync` 중복 제거
- `app/_layout.tsx` — `setNotificationHandler` 타입별 배너 분기 추가, 트래킹 타입 포어그라운드 시스템 배너 활성화
- `app/(tabs)/tracking.tsx` — 데모 모드 카메라 follow 비활성화 / 트래킹 시작 시 출발 좌표 줌 / 폴리라인 두께 고정

## 테스트 체크리스트

- [ ] 포어그라운드 트래킹 중 마일스톤 도달 시 시스템 배너 + in-app 배너 둘 다 표시 확인
- [ ] 백그라운드에서 마일스톤 도달 시 시스템 푸시 알림 정상 수신 확인
- [ ] 커뮤니티 등 다른 알림 시스템 배너 정상 표시 확인
- [ ] 데모 모드 트래킹 시작 시 카메라가 출발 좌표로 이동 확인
- [ ] 코스 폴리라인 두께 정상 표시 확인

## 연관 백엔드 PR

- SEMOSAN_BE #190 — 트래킹 푸시 mixed payload 전환