### PR TITLE
fix : demo API 제거 및 기록 화면 통계 API 연동 복원

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -272,9 +272,9 @@ export default function RecordScreen() {
         {/* 통계 */}
         <View style={{ flexDirection: "row", marginHorizontal: 20, marginTop: 16, marginBottom: 16, gap: 4 }}>
           {[
-            { label: "소요시간", value: "3시간 24분" },
-            { label: "고도", value: "642m" },
-            { label: "칼로리", value: "1128kcal" },
+            { label: "소요시간", value: formatDuration(recordDetail?.durationSeconds ?? durationSec) },
+            { label: "고도", value: recordDetail?.ascentMeters != null ? `${Math.round(recordDetail.ascentMeters)}Nm` : "--" },
+            { label: "칼로리", value: recordDetail?.calories != null ? `${recordDetail.calories}kcal` : "--" },
           ].map((stat) => (
             <View key={stat.label} style={styles.statItem}>
               <Text style={styles.statLabel}>{stat.label}</Text>

--- a/features/tracking/hooks/use-clive-photos.ts
+++ b/features/tracking/hooks/use-clive-photos.ts
@@ -2,15 +2,27 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { ENDPOINTS } from "@/types/api.generated";
 
+type ClivePhoto = {
+  photoId: number;
+  trackingSessionId: number;
+  milestoneIndex: number;
+  milestoneDistanceM: number;
+  imageUrl: string;
+  capturedAt: string;
+  lat: number;
+  lng: number;
+  altitude: number;
+};
+
 export function useClivePhotos(sessionId: number | null) {
   return useQuery({
     queryKey: ["clivePhotos", sessionId],
     enabled: sessionId != null,
     queryFn: async () => {
-      const res = await api.get<string[]>({
-        path: `${ENDPOINTS.DEMO_TRACKING_SESSIONS_BY_SESSIONID_PHOTOS(sessionId!)}?count=2`,
+      const res = await api.get<ClivePhoto[]>({
+        path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_PHOTOS(sessionId!),
       });
-      return res.data ?? [];
+      return (res.data ?? []).map((p) => p.imageUrl);
     },
   });
 }


### PR DESCRIPTION
## Summary
- `useClivePhotos` demo API → 실제 API(`TRACKING_SESSIONS_BY_SESSIONID_PHOTOS`)로 복원
- `ClivePhoto` 타입 복원 및 `imageUrl` 매핑 복원
- 기록 화면 통계(소요시간/고도/칼로리) 하드코딩 제거, `recordDetail` API 연동으로 복원
- 고도 단위 `Nm` 유지

## Test plan
- [ ] 기록 화면 진입 시 소요시간/고도/칼로리 API 값 정상 표시 확인
- [ ] 클라이브 사진 실제 API 호출 확인