### PR TITLE
feat : 게시글 작성자 차단하기 기능 추가

### DIFF
--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -6,6 +6,8 @@ import {
 } from "@/components/icons/heart-icon";
 import { SirenIcon } from "@/components/icons/siren-icon";
 import { TrashIcon } from "@/components/icons/trash-icon";
+import { UserBlockIcon } from "@/components/icons/user-block-icon";
+import { useBlockUser } from "@/features/community/hooks/use-block-user";
 import { useTogglePostLike } from "@/features/community/hooks/use-post-like";
 import { useReportPost } from "@/features/community/hooks/use-report-post";
 import { formatDate } from "@/lib/utils";
@@ -53,10 +55,12 @@ export function PostBody({
 }: PostBodyProps) {
   const { mutate: toggleLike } = useTogglePostLike(post.id!);
   const { mutate: reportPost } = useReportPost(post.id!);
+  const { mutate: blockUser } = useBlockUser(post.id!);
   const [liked, setLiked] = useState(post.likedByMe ?? false);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 });
+  const [blockModalVisible, setBlockModalVisible] = useState(false);
   const buttonRef = useRef<View>(null);
 
   const isAuthor =
@@ -82,6 +86,21 @@ export function PostBody({
         onPress: onDelete,
       },
     ]);
+  }
+
+  function handleBlock(): void {
+    setMenuVisible(false);
+    setBlockModalVisible(true);
+  }
+
+  function confirmBlock(): void {
+    setBlockModalVisible(false);
+    blockUser(undefined, {
+      onSuccess: () =>
+        Alert.alert("차단 완료", "해당 사용자를 차단했습니다."),
+      onError: () =>
+        Alert.alert("오류", "차단 처리 중 오류가 발생했습니다."),
+    });
   }
 
   function handleReport(): void {
@@ -268,9 +287,8 @@ export function PostBody({
                   </View>
                 </Pressable>
 
-                {/* TODO : 차단 API 나오기 전까지 임시 주석처리 */}
-                {/* <View style={{ height: 1, backgroundColor: "#f0f0f0" }} /> */}
-                {/* <Pressable
+                <View style={{ height: 1, backgroundColor: "#f0f0f0" }} />
+                <Pressable
                   onPress={handleBlock}
                   style={({ pressed }) => ({
                     opacity: pressed ? 0.7 : 1,
@@ -296,11 +314,85 @@ export function PostBody({
                       차단하기
                     </Text>
                   </View>
-                </Pressable> */}
+                </Pressable>
               </>
             )}
           </View>
         </Pressable>
+      </Modal>
+
+      <Modal
+        visible={blockModalVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setBlockModalVisible(false)}
+      >
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: "rgba(0,0,0,0.4)",
+            justifyContent: "center",
+            paddingHorizontal: 24,
+          }}
+        >
+          <View
+            className="bg-fill-normal"
+            style={{
+              borderRadius: 16,
+              padding: 24,
+              gap: 24,
+            }}
+          >
+            <View style={{ gap: 8 }}>
+              <Text className="typo-heading-1-semi-bold text-label-normal">
+                사용자를 차단할까요?
+              </Text>
+              <Text className="typo-body-1-normal-regular text-label-normal">
+                차단한 사용자는 [마이페이지 {">"} 차단목록]에서 관리할 수 있어요.
+              </Text>
+            </View>
+            <View style={{ flexDirection: "row", gap: 8 }}>
+              <View
+                className="bg-fill-stronger"
+                style={{ flex: 1, height: 52, borderRadius: 10, justifyContent: "center", alignItems: "center" }}
+              >
+                <Pressable
+                  onPress={() => setBlockModalVisible(false)}
+                  style={({ pressed }) => ({
+                    position: "absolute",
+                    top: 0, left: 0, right: 0, bottom: 0,
+                    justifyContent: "center",
+                    alignItems: "center",
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Text className="typo-label-large text-label-subtle">
+                    취소
+                  </Text>
+                </Pressable>
+              </View>
+              <View
+                className="bg-status-negative-normal"
+                style={{ flex: 1, height: 52, borderRadius: 10, justifyContent: "center", alignItems: "center" }}
+              >
+                <Pressable
+                  onPress={confirmBlock}
+                  style={({ pressed }) => ({
+                    position: "absolute",
+                    top: 0, left: 0, right: 0, bottom: 0,
+                    justifyContent: "center",
+                    alignItems: "center",
+                    opacity: pressed ? 0.7 : 1,
+                  })}
+                >
+                  <Text className="typo-label-large text-label-normal-inverse">
+                    차단하기
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </View>
       </Modal>
 
       <ImageViewerModal

--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -8,6 +8,7 @@ import { SirenIcon } from "@/components/icons/siren-icon";
 import { TrashIcon } from "@/components/icons/trash-icon";
 import { UserBlockIcon } from "@/components/icons/user-block-icon";
 import { useBlockUser } from "@/features/community/hooks/use-block-user";
+import { ApiError } from "@/lib/api";
 import { useTogglePostLike } from "@/features/community/hooks/use-post-like";
 import { useReportPost } from "@/features/community/hooks/use-report-post";
 import { formatDate } from "@/lib/utils";
@@ -98,8 +99,15 @@ export function PostBody({
     blockUser(undefined, {
       onSuccess: () =>
         Alert.alert("차단 완료", "해당 사용자를 차단했습니다."),
-      onError: () =>
-        Alert.alert("오류", "차단 처리 중 오류가 발생했습니다."),
+      onError: (error) => {
+        if (error instanceof ApiError && error.statusCode === 400) {
+          Alert.alert("차단 불가", "자기 자신은 차단할 수 없습니다.");
+        } else if (error instanceof ApiError && error.statusCode === 404) {
+          Alert.alert("오류", "게시글을 찾을 수 없습니다.");
+        } else {
+          Alert.alert("오류", "차단 처리 중 오류가 발생했습니다.");
+        }
+      },
     });
   }
 

--- a/features/community/hooks/use-block-user.ts
+++ b/features/community/hooks/use-block-user.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useMutation } from "@tanstack/react-query";
+
+export function useBlockUser(postId: number) {
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post({
+        path: ENDPOINTS.COMMUNITY_FREE_POSTS_BY_POSTID_BLOCKS(postId),
+        body: {},
+      });
+
+      return data;
+    },
+  });
+}

--- a/features/community/hooks/use-block-user.ts
+++ b/features/community/hooks/use-block-user.ts
@@ -7,7 +7,6 @@ export function useBlockUser(postId: number) {
     mutationFn: async () => {
       const { data } = await api.post({
         path: ENDPOINTS.COMMUNITY_FREE_POSTS_BY_POSTID_BLOCKS(postId),
-        body: {},
       });
 
       return data;


### PR DESCRIPTION
## Summary
- 게시글 상세 화면의 더보기(⋮) 메뉴에 차단하기 버튼 추가 (신고하기 하단)
- 차단하기 클릭 시 확인 모달 표시
- POST /api/community/free-posts/{postId}/blocks API 연동
- 400(자기 자신 차단 불가), 404(게시글 없음) 에러 케이스 별도 처리

## Test plan
- [ ] 타인 게시글에서 더보기(⋮) 버튼 클릭 시 신고하기 + 차단하기 메뉴 노출 확인
- [ ] 차단하기 클릭 시 확인 모달 표시 확인
- [ ] 모달에서 취소 클릭 시 모달 닫힘 확인
- [ ] 모달에서 차단하기 클릭 시 API 호출 및 완료 알림 확인
- [ ] 내 게시글에서는 차단하기 메뉴 미노출 확인 (삭제하기만 표시)