### PR TITLE
feat : 온보딩 프로필 화면 건너뛰기 버튼 추가

### DIFF
--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -230,6 +230,15 @@ export function OnboardingScreen() {
           <View className="h-1 w-1/4 bg-secondary-normal" />
         </View>
 
+        {/* 건너뛰기 */}
+        <View className="items-end px-5 pt-3">
+          <Pressable onPress={() => router.replace("/(tabs)")} hitSlop={8}>
+            <Text className="typo-body-2-normal-regular text-label-subtler">
+              건너뛰기
+            </Text>
+          </Pressable>
+        </View>
+
         <ScrollView
           ref={scrollRef}
           className="flex-1"

--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -230,15 +230,6 @@ export function OnboardingScreen() {
           <View className="h-1 w-1/4 bg-secondary-normal" />
         </View>
 
-        {/* 건너뛰기 */}
-        <View className="items-end px-5 pt-3">
-          <Pressable onPress={() => router.replace("/(tabs)")} hitSlop={8}>
-            <Text className="typo-body-2-normal-regular text-label-subtler">
-              건너뛰기
-            </Text>
-          </Pressable>
-        </View>
-
         <ScrollView
           ref={scrollRef}
           className="flex-1"
@@ -246,9 +237,16 @@ export function OnboardingScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
         >
-          <Text className="text-label-normal typo-heading-1-semi-bold">
-            프로필 정보를 입력해 주세요
-          </Text>
+          <View className="flex-row items-center justify-between">
+            <Text className="text-label-normal typo-heading-1-semi-bold">
+              프로필 정보를 입력해 주세요
+            </Text>
+            <Pressable onPress={() => router.replace("/(tabs)")} hitSlop={8}>
+              <Text className="typo-body-2-normal-regular text-label-subtler">
+                건너뛰기
+              </Text>
+            </Pressable>
+          </View>
 
           <View className="mt-6 gap-6">
             {/* 아바타 */}


### PR DESCRIPTION
## 변경 사항
- 온보딩 프로필 정보 입력 화면에 건너뛰기 버튼 추가
- "프로필 정보를 입력해 주세요" 제목과 같은 라인 우측에 배치
- 건너뛰기 클릭 시 온보딩을 건너뛰고 홈 화면으로 이동


## 테스트
- [ ] 온보딩 프로필 화면에서 건너뛰기 버튼 노출 확인
- [ ] 건너뛰기 클릭 시 홈 화면으로 이동 확인
- [ ] 홈 이동 후 뒤로가기 시 온보딩으로 돌아가지 않는 것 확인