### PR TITLE
fix: iOS 위치 권한 팝업 문구 앱스토어 심사 대응

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -38,6 +38,7 @@ const config = {
   },
   locales: {
     ko: "./locales/ko.json",
+    en: "./locales/en.json",
   },
   android: {
     ...(hasAndroidGoogleServiceFile
@@ -78,7 +79,7 @@ const config = {
       "expo-location",
       {
         locationWhenInUsePermission:
-          "내 위치 기반 코스 추천 및 현재 위치 표시를 위해 위치 정보 접근이 필요합니다.",
+          "현재 위치를 사용해 주변 산을 찾고, 지도에서 내 위치와 등산 경로를 안내합니다. 예: 가까운 산 추천 및 트래킹 중 현재 위치 표시",
         locationAlwaysAndWhenInUsePermission:
           "코스 추적 중 앱이 백그라운드에 있어도 위치를 기록하기 위해 항상 위치 접근 권한이 필요합니다.",
         locationAlwaysPermission:

--- a/components/bottom-sheet.tsx
+++ b/components/bottom-sheet.tsx
@@ -23,6 +23,7 @@ type Props = {
   scrollEnabled?: boolean;
   onDetailOpenChange?: (isOpen: boolean) => void;
   closeSelectedToken?: number;
+  selectedMountainId?: number | null;
 };
 
 const TABS: Tab[] = ["내 기록", "큐레이션"];
@@ -38,6 +39,7 @@ export default function BottomSheet({
   scrollEnabled = false,
   onDetailOpenChange,
   closeSelectedToken,
+  selectedMountainId,
 }: Props) {
   const router = useRouter();
   const [internalTab, setInternalTab] = useState<Tab>("내 기록");
@@ -59,6 +61,12 @@ export default function BottomSheet({
       setSelectedCard(null);
     }
   }, [closeSelectedToken]);
+
+  useEffect(() => {
+    if (selectedMountainId == null) return;
+    const card = cards?.find((c) => c.mountainId === selectedMountainId);
+    if (card) setSelectedCard(card);
+  }, [selectedMountainId, cards]);
 
   const { data: mountainRecords } = useMyMountainRecords(
     selectedCard?.mountainId,

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -65,12 +65,14 @@ type VisitedMarkerOverlayProps = {
   mountain: MountainMapItem;
   selected: boolean;
   imageUri?: string;
+  onPress: () => void;
 };
 
 const VisitedMarkerOverlay = memo(function VisitedMarkerOverlay({
   mountain,
   selected,
   imageUri,
+  onPress,
 }: VisitedMarkerOverlayProps) {
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -81,7 +83,7 @@ const VisitedMarkerOverlay = memo(function VisitedMarkerOverlay({
       width={VISITED_MARKER_OVERLAY_WIDTH}
       height={VISITED_MARKER_OVERLAY_HEIGHT}
       anchor={{ x: 0.2, y: 1 }}
-      onTap={() => router.push(`/mountains/${mountain.id}`)}
+      onTap={onPress}
     >
       <View
         key={`${selected} ${isLoaded}`}
@@ -204,6 +206,10 @@ const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
                     imageUri={
                       myMountainImageMap[mountain.id] ?? mountain.imageUrl
                     }
+                    onPress={() => {
+                      setSelectedMountainId(mountain.id);
+                      sheetRef.current?.expandToDefault();
+                    }}
                   />
                 ))
             : mapData?.mountains?.map((mountain) => (
@@ -267,6 +273,7 @@ const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
                 onCardSelect={(id) => setSelectedMountainId(Number(id))}
                 onDetailOpenChange={handleDetailOpenChange}
                 closeSelectedToken={closeSelectedToken}
+                selectedMountainId={selectedMountainId}
               />
             ) : (
               <NoRecordBottomSheet

--- a/ios/semosan.xcodeproj/project.pbxproj
+++ b/ios/semosan.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		5924807866955ACF8228BF7A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0FDB9639E5FC65402DB80F /* PrivacyInfo.xcprivacy */; };
 		62AA5F0527CE7EF046B086D9 /* SemosanWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DB1C917F4FFF3242AA9628 /* SemosanWidgetBundle.swift */; };
 		693D45F803EE4908BCAFAFA8 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43040695C0354B4EA32E7480 /* InfoPlist.strings */; };
+		4A732CF95E76DA32F805FA8A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* SemosanLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D6279DA4FA6101E8B8853A /* SemosanLiveActivityAttributes.swift */; };
 		B15883B685E09F4ACB7111FB /* SemosanLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F062AF6F8F169DC8CB336099 /* SemosanLiveActivity.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
@@ -52,6 +53,7 @@
 		30A54906D1126612186FF146 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = SemosanWidget/Assets.xcassets; sourceTree = "<group>"; };
 		41BBCF6E2CE0497EA17A760B /* WidgetKit.framework */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		43040695C0354B4EA32E7480 /* InfoPlist.strings */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		69DB1C917F4FFF3242AA9628 /* SemosanWidgetBundle.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = SemosanWidgetBundle.swift; path = SemosanWidget/SemosanWidgetBundle.swift; sourceTree = "<group>"; };
 		6AEEBEE1FB64461746792160 /* libPods-semosan.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-semosan.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		87D6279DA4FA6101E8B8853A /* SemosanLiveActivityAttributes.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = SemosanLiveActivityAttributes.swift; path = SemosanWidget/SemosanLiveActivityAttributes.swift; sourceTree = "<group>"; };
@@ -162,6 +164,7 @@
 			children = (
 				BB2F792C24A3F905000567C9 /* Expo.plist */,
 				E9D036FFABE447CF9365B81D /* ko.lproj */,
+				4C05F667C69F443D24AEDE69 /* en.lproj */,
 			);
 			name = Supporting;
 			path = semosan/Supporting;
@@ -173,6 +176,15 @@
 				43040695C0354B4EA32E7480 /* InfoPlist.strings */,
 			);
 			name = ko.lproj;
+			path = "";
+			sourceTree = "<group>";
+		};
+		4C05F667C69F443D24AEDE69 /* en.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */,
+			);
+			name = en.lproj;
 			path = "";
 			sourceTree = "<group>";
 		};
@@ -254,6 +266,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				ko,
 				Base,
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
@@ -276,6 +289,7 @@
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
 				693D45F803EE4908BCAFAFA8 /* InfoPlist.strings in Resources */,
+				4A732CF95E76DA32F805FA8A /* InfoPlist.strings in Resources */,
 				032B5A433A1E446384D535C8 /* GoogleService-Info.plist in Resources */,
 				5924807866955ACF8228BF7A /* PrivacyInfo.xcprivacy in Resources */,
 			);

--- a/ios/semosan/Info.plist
+++ b/ios/semosan/Info.plist
@@ -62,11 +62,11 @@
     <key>NSCameraUsageDescription</key>
     <string>프로필 사진 촬영을 위해 카메라 접근이 필요합니다.</string>
     <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <string>코스 추적 중 앱이 백그라운드에 있어도 위치를 기록하기 위해 항상 위치 접근 권한이 필요합니다.</string>
     <key>NSLocationAlwaysUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <string>코스 추적 중 앱이 백그라운드에 있어도 위치를 기록하기 위해 항상 위치 접근 권한이 필요합니다.</string>
     <key>NSLocationWhenInUseUsageDescription</key>
-    <string>Allow $(PRODUCT_NAME) to access your location</string>
+    <string>현재 위치를 사용해 주변 산을 찾고, 지도에서 내 위치와 등산 경로를 안내합니다. 예: 가까운 산 추천 및 트래킹 중 현재 위치 표시</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>Allow $(PRODUCT_NAME) to access your microphone</string>
     <key>NSPhotoLibraryAddUsageDescription</key>

--- a/ios/semosan/Supporting/en.lproj/InfoPlist.strings
+++ b/ios/semosan/Supporting/en.lproj/InfoPlist.strings
@@ -1,1 +1,3 @@
 NSLocationWhenInUseUsageDescription = "SEMOSAN uses your location to find nearby mountains and show your position on the map during hiking. For example, we use it for nearby mountain recommendations and route tracking.";
+NSLocationAlwaysAndWhenInUseUsageDescription = "SEMOSAN requires location access even in the background to record your hiking route during course tracking.";
+NSLocationAlwaysUsageDescription = "SEMOSAN requires location access even in the background to record your hiking route during course tracking.";

--- a/ios/semosan/Supporting/en.lproj/InfoPlist.strings
+++ b/ios/semosan/Supporting/en.lproj/InfoPlist.strings
@@ -1,0 +1,1 @@
+NSLocationWhenInUseUsageDescription = "SEMOSAN uses your location to find nearby mountains and show your position on the map during hiking. For example, we use it for nearby mountain recommendations and route tracking.";

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,3 +1,5 @@
 {
-  "NSLocationWhenInUseUsageDescription": "SEMOSAN uses your location to find nearby mountains and show your position on the map during hiking. For example, we use it for nearby mountain recommendations and route tracking."
+  "NSLocationWhenInUseUsageDescription": "SEMOSAN uses your location to find nearby mountains and show your position on the map during hiking. For example, we use it for nearby mountain recommendations and route tracking.",
+  "NSLocationAlwaysAndWhenInUseUsageDescription": "SEMOSAN requires location access even in the background to record your hiking route during course tracking.",
+  "NSLocationAlwaysUsageDescription": "SEMOSAN requires location access even in the background to record your hiking route during course tracking."
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,3 @@
+{
+  "NSLocationWhenInUseUsageDescription": "SEMOSAN uses your location to find nearby mountains and show your position on the map during hiking. For example, we use it for nearby mountain recommendations and route tracking."
+}


### PR DESCRIPTION
## Summary
- Apple 심사 가이드라인 5.1.1(ii) 대응 — 위치 권한 목적 문구에 구체적 사용 예시 추가
- `app.config.js`에만 반영되고 실제 네이티브 프로젝트(`ios/semosan/Info.plist`)에는 반영되지 않아 Apple 기본 placeholder 문구("Allow $(PRODUCT_NAME) to access your location")가 그대로 노출되던 문제 수정
- 영문 로컬라이징(`en.lproj`) 신규 추가

## Test plan
- [ ] `plutil -lint`로 Info.plist / project.pbxproj 문법 검증 완료
- [ ] Xcode에서 정상 빌드되는지 확인
- [ ] 기기 언어를 한국어/영어로 각각 설정 후 위치 권한 팝업 문구 확인