### PR TITLE
feat : 댓글 차단 기능 구현

### DIFF
--- a/features/community/components/comment-item.tsx
+++ b/features/community/components/comment-item.tsx
@@ -1,8 +1,10 @@
+import { useBlockUser } from "@/features/community/hooks/use-block-user";
 import { useCommentReplies } from "@/features/community/hooks/use-comment-replies";
 import { useDeleteComment } from "@/features/community/hooks/use-delete-comment";
+import { ApiError } from "@/lib/api";
 import { formatDate } from "@/lib/utils";
 import { CommentResponse } from "@/types/api.generated";
-import { Alert, Pressable, Text, View } from "react-native";
+import { ActionSheetIOS, Alert, Platform, Pressable, Text, View } from "react-native";
 import { PostAvatar } from "./post-avatar";
 
 function confirmDelete(onConfirm: () => void): void {
@@ -11,6 +13,27 @@ function confirmDelete(onConfirm: () => void): void {
     { text: "삭제", style: "destructive", onPress: onConfirm },
   ]);
 }
+
+function showBlockSheet(onBlock: () => void): void {
+  if (Platform.OS === "ios") {
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: ["취소", "차단하기"],
+        destructiveButtonIndex: 1,
+        cancelButtonIndex: 0,
+      },
+      (index) => {
+        if (index === 1) onBlock();
+      },
+    );
+  } else {
+    Alert.alert("차단하기", "해당 사용자를 차단하시겠습니까?", [
+      { text: "취소", style: "cancel" },
+      { text: "차단하기", style: "destructive", onPress: onBlock },
+    ]);
+  }
+}
+
 
 type ReplyItemProps = {
   reply: CommentResponse;
@@ -34,9 +57,30 @@ function ReplyItem({
   const isAuthor =
     !!currentUserNickname && reply.author?.nickname === currentUserNickname;
   const { mutate: deleteComment } = useDeleteComment(postId, parentCommentId);
+  const { mutate: blockUser } = useBlockUser(postId);
+
+  function handleLongPress(): void {
+    if (isAuthor) return;
+    showBlockSheet(() =>
+      blockUser(undefined, {
+        onSuccess: () => Alert.alert("차단 완료", "해당 사용자를 차단했습니다."),
+        onError: (error) => {
+          if (error instanceof ApiError && error.statusCode === 400) {
+            Alert.alert("차단 불가", "자기 자신은 차단할 수 없습니다.");
+          } else {
+            Alert.alert("오류", "차단 처리 중 오류가 발생했습니다.");
+          }
+        },
+      }),
+    );
+  }
 
   return (
-    <View className="flex-row gap-2 py-3 pl-[38px]">
+    <Pressable
+      className="flex-row gap-2 py-3 pl-[38px]"
+      onLongPress={handleLongPress}
+      delayLongPress={400}
+    >
       <PostAvatar size="sm" imageUrl={reply.author?.profileUrl} />
       <View className="flex-1 gap-1">
         <View className="flex-row flex-wrap items-center gap-1">
@@ -73,7 +117,7 @@ function ReplyItem({
           )}
         </View>
       </View>
-    </View>
+    </Pressable>
   );
 }
 
@@ -97,11 +141,32 @@ export function CommentItem({
   const isAuthor =
     !!currentUserNickname && comment.author?.nickname === currentUserNickname;
   const { mutate: deleteComment } = useDeleteComment(postId);
+  const { mutate: blockUser } = useBlockUser(postId);
   const { data: replies = [] } = useCommentReplies(comment.id!);
+
+  function handleLongPress(): void {
+    if (isAuthor) return;
+    showBlockSheet(() =>
+      blockUser(undefined, {
+        onSuccess: () => Alert.alert("차단 완료", "해당 사용자를 차단했습니다."),
+        onError: (error) => {
+          if (error instanceof ApiError && error.statusCode === 400) {
+            Alert.alert("차단 불가", "자기 자신은 차단할 수 없습니다.");
+          } else {
+            Alert.alert("오류", "차단 처리 중 오류가 발생했습니다.");
+          }
+        },
+      }),
+    );
+  }
 
   return (
     <View>
-      <View className="flex-row gap-2 py-3">
+      <Pressable
+        className="flex-row gap-2 py-3"
+        onLongPress={handleLongPress}
+        delayLongPress={400}
+      >
         <PostAvatar size="md" imageUrl={comment.author?.profileUrl} />
         <View className="flex-1 gap-1">
           <View className="flex-row flex-wrap items-center gap-1">
@@ -140,7 +205,7 @@ export function CommentItem({
             )}
           </View>
         </View>
-      </View>
+      </Pressable>
       {replies.map((reply) => (
         <ReplyItem
           key={reply.id}

--- a/features/community/components/comment-item.tsx
+++ b/features/community/components/comment-item.tsx
@@ -1,4 +1,4 @@
-import { useBlockUser } from "@/features/community/hooks/use-block-user";
+import { useBlockCommentUser } from "@/features/community/hooks/use-block-comment-user";
 import { useCommentReplies } from "@/features/community/hooks/use-comment-replies";
 import { useDeleteComment } from "@/features/community/hooks/use-delete-comment";
 import { ApiError } from "@/lib/api";
@@ -57,7 +57,7 @@ function ReplyItem({
   const isAuthor =
     !!currentUserNickname && reply.author?.nickname === currentUserNickname;
   const { mutate: deleteComment } = useDeleteComment(postId, parentCommentId);
-  const { mutate: blockUser } = useBlockUser(postId);
+  const { mutate: blockUser } = useBlockCommentUser(reply.id!);
 
   function handleLongPress(): void {
     if (isAuthor) return;
@@ -67,6 +67,8 @@ function ReplyItem({
         onError: (error) => {
           if (error instanceof ApiError && error.statusCode === 400) {
             Alert.alert("차단 불가", "자기 자신은 차단할 수 없습니다.");
+          } else if (error instanceof ApiError && error.statusCode === 404) {
+            Alert.alert("오류", "댓글 또는 사용자를 찾을 수 없습니다.");
           } else {
             Alert.alert("오류", "차단 처리 중 오류가 발생했습니다.");
           }
@@ -141,7 +143,7 @@ export function CommentItem({
   const isAuthor =
     !!currentUserNickname && comment.author?.nickname === currentUserNickname;
   const { mutate: deleteComment } = useDeleteComment(postId);
-  const { mutate: blockUser } = useBlockUser(postId);
+  const { mutate: blockUser } = useBlockCommentUser(comment.id!);
   const { data: replies = [] } = useCommentReplies(comment.id!);
 
   function handleLongPress(): void {
@@ -152,6 +154,8 @@ export function CommentItem({
         onError: (error) => {
           if (error instanceof ApiError && error.statusCode === 400) {
             Alert.alert("차단 불가", "자기 자신은 차단할 수 없습니다.");
+          } else if (error instanceof ApiError && error.statusCode === 404) {
+            Alert.alert("오류", "댓글 또는 사용자를 찾을 수 없습니다.");
           } else {
             Alert.alert("오류", "차단 처리 중 오류가 발생했습니다.");
           }

--- a/features/community/hooks/use-block-comment-user.ts
+++ b/features/community/hooks/use-block-comment-user.ts
@@ -1,0 +1,14 @@
+import { api } from "@/lib/api";
+import { useMutation } from "@tanstack/react-query";
+
+export function useBlockCommentUser(commentId: number) {
+  return useMutation({
+    mutationFn: async () => {
+      const { data } = await api.post({
+        path: `/api/community/comments/${commentId}/blocks`,
+      });
+
+      return data;
+    },
+  });
+}


### PR DESCRIPTION
## 🔍 작업 내용

커뮤니티 댓글/답글을 꾹 누르면 작성자를 차단할 수 있는 기능을 추가했습니다.

### 변경 파일

- `features/community/hooks/use-block-comment-user.ts` — 댓글 차단 API 훅 (`POST /api/community/comments/{commentId}/blocks`)
- `features/community/components/comment-item.tsx` — 댓글/답글 long press 이벤트 및 차단 액션시트 연동


## ✅ 구현 상세

- 댓글 및 답글에 `onLongPress` (400ms) 추가
- **iOS**: `ActionSheetIOS`로 네이티브 액션시트 표시 ("취소" / "차단하기")
- **Android**: `Alert`로 폴백 처리
- 자기 댓글(`isAuthor`)은 long press 무시
- 차단 성공 시 알림, 400(자기 자신 차단)/404(댓글 없음) 에러 케이스 별도 처리


## 🖥️ 스크린샷

<img width="200" height="450" alt="simulator_screenshot_110A2E99-2C29-4BC4-B505-D38579F2BCA4" src="https://github.com/user-attachments/assets/3123d364-3d11-46d4-a274-85cc1181b1ed" />


## 💬 리뷰 요청 사항

없음