### PR TITLE
fix : 트래킹 중 현재 위치 마커/카메라 동작 개선 (실시간 갱신·튐 좌표 필터·중앙 follow)

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -713,8 +713,10 @@ export default function TrackingScreen() {
 
   // [DEV] 코스 좌표를 빠르게 publish — 백엔드 마일스톤 트리거 테스트용
 
-  // polyline 로드되거나 트래킹 시작 시 전체 경로가 보이도록 카메라 맞춤
+  // 트래킹 시작 전, polyline 로드 시 전체 경로가 보이도록 카메라 맞춤 (코스 미리보기)
+  // 트래킹 중에는 현위치 follow가 카메라를 담당하므로 전체 맞춤을 하지 않음
   useEffect(() => {
+    if (isTracking) return;
     if (courseCoords.length < 2) return;
 
     const timer = setTimeout(() => {
@@ -741,15 +743,11 @@ export default function TrackingScreen() {
   }, [courseDetail?.polyline, isTracking]);
 
   // 트래킹 시작/종료 시 follow 모드 토글
-  // 코스 따라가기: 시작 시 전체 코스가 보이도록 follow 비활성 (위치 버튼으로 재활성 가능)
-  // 자유기록: 시작 시 현위치 follow 활성
+  // 트래킹 중(코스·자유기록 공통): 현위치가 지도 중앙에 오도록 follow 활성
+  // (사용자가 직접 지도를 조작하면 onCameraChanged에서 follow 해제)
   useEffect(() => {
-    if (isTracking) {
-      setIsFollowingUser(isFreeMode);
-    } else {
-      setIsFollowingUser(false);
-    }
-  }, [isTracking, isFreeMode]);
+    setIsFollowingUser(isTracking);
+  }, [isTracking]);
 
   // 트래킹 중 실시간 위치 마커 카메라 추적 (사용자가 직접 조작하면 follow 해제)
   useEffect(() => {

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -97,6 +97,28 @@ const SEGMENT_COLORS: Record<string, { color: string }> = {
 // 좌표 개수가 MIN_SEGMENT_COORDS 미만인 짧은 세그먼트를 앞 세그먼트에 흡수해 색 전환 빈도를 줄임
 const MIN_SEGMENT_COORDS = 8;
 
+// GPS 튐(outlier) 좌표 필터링 기준 — 누적 경로가 삐죽하게 그려지는 문제 방지
+const MAX_LOCATION_ACCURACY_M = 30; // 정확도(m)가 이보다 나쁘면서 크게 튄 좌표는 버림
+const MIN_JUMP_M = 20; // 이보다 작은 이동은 속도 판정에서 제외 (정지 시 노이즈)
+const MAX_SPEED_MPS = 30; // 이보다 빠른 이동(≈108km/h)은 비현실적 → 튐 좌표로 간주
+
+// 두 좌표 간 거리(m) — Haversine
+function haversineMeters(
+  a: { latitude: number; longitude: number },
+  b: { latitude: number; longitude: number },
+): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.latitude - a.latitude);
+  const dLng = toRad(b.longitude - a.longitude);
+  const lat1 = toRad(a.latitude);
+  const lat2 = toRad(b.latitude);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+}
+
 function mergeShortSegments(
   segments: { startIdx: number; endIdx: number; grade: string }[],
 ): { startIdx: number; endIdx: number; grade: string }[] {
@@ -175,6 +197,12 @@ export default function TrackingScreen() {
   const backgroundedAtRef = useRef<number | null>(null);
   // 위치 업데이트 중복 방지 — foreground watch + background task 동시 수신 대비
   const lastLocationTsRef = useRef(0);
+  // 직전에 채택된 좌표 — GPS 튐 좌표 필터링용 (누적 경로 왜곡 방지)
+  const lastAcceptedCoordRef = useRef<{
+    latitude: number;
+    longitude: number;
+    timestamp: number;
+  } | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
   const isMountedRef = useRef(true);
@@ -249,12 +277,30 @@ export default function TrackingScreen() {
       latitude: number;
       longitude: number;
       altitude: number | null;
+      accuracy?: number | null;
       timestamp: number;
     }) => {
       if (loc.timestamp && loc.timestamp <= lastLocationTsRef.current) return;
       lastLocationTsRef.current = loc.timestamp || Date.now();
 
-      const { latitude, longitude, altitude, timestamp } = loc;
+      const { latitude, longitude, altitude, accuracy, timestamp } = loc;
+
+      // GPS 튐 좌표 제거 — 직전 채택 좌표 대비 비현실적 점프/저정확도 좌표는 버림
+      const last = lastAcceptedCoordRef.current;
+      if (last) {
+        const dist = haversineMeters(last, { latitude, longitude });
+        const dtSec = (timestamp - last.timestamp) / 1000;
+        const speed = dtSec > 0 ? dist / dtSec : 0;
+        const inaccurateJump =
+          accuracy != null &&
+          accuracy > MAX_LOCATION_ACCURACY_M &&
+          dist > MAX_LOCATION_ACCURACY_M;
+        const teleport = dist > MIN_JUMP_M && speed > MAX_SPEED_MPS;
+        // 마커·경로·publish 모두 스킵 (다음 좌표는 마지막 정상 좌표 기준으로 재판정)
+        if (inaccurateJump || teleport) return;
+      }
+      lastAcceptedCoordRef.current = { latitude, longitude, timestamp };
+
       setUserLocation({ latitude, longitude, altitude });
       setMarkerCoord({ latitude, longitude });
       setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
@@ -314,6 +360,7 @@ export default function TrackingScreen() {
       // GPS 추적 재시작 — 백그라운드 포함
       sessionIdRef.current = activeSession.sessionId;
       lastLocationTsRef.current = 0;
+      lastAcceptedCoordRef.current = null;
       setLocationTaskCallback(handleLocationUpdate);
       startLocationTask().catch((err) =>
         console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
@@ -737,6 +784,7 @@ export default function TrackingScreen() {
               latitude: loc.coords.latitude,
               longitude: loc.coords.longitude,
               altitude: loc.coords.altitude,
+              accuracy: loc.coords.accuracy,
               timestamp: loc.timestamp,
             }),
         );
@@ -794,6 +842,7 @@ export default function TrackingScreen() {
                 // GPS 추적 시작 — 백그라운드 포함
                 setRecordedCoords([]);
                 lastLocationTsRef.current = 0;
+                lastAcceptedCoordRef.current = null;
                 setLocationTaskCallback(handleLocationUpdate);
                 startLocationTask().catch((err) => {
                   console.warn("[Location] 백그라운드 위치 시작 실패:", err);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -85,7 +85,6 @@ const { colors } = require("../../tokens.cjs") as {
 };
 const COLOR_WHITE = colors.common["100"]; // #ffffff
 
-
 // 경사 등급별 polyline 색상 (outline은 디자인 토큰 common-100 사용)
 const SEGMENT_COLORS: Record<string, { color: string }> = {
   STEEP_DOWN: { color: "#2563EB" },
@@ -174,6 +173,8 @@ export default function TrackingScreen() {
     { latitude: number; longitude: number }[]
   >([]);
   const backgroundedAtRef = useRef<number | null>(null);
+  // 위치 업데이트 중복 방지 — foreground watch + background task 동시 수신 대비
+  const lastLocationTsRef = useRef(0);
   const mapRef = useRef<NaverMapViewRef>(null);
   const [isFollowingUser, setIsFollowingUser] = useState(false);
   const isMountedRef = useRef(true);
@@ -237,6 +238,40 @@ export default function TrackingScreen() {
     onPhotoWindow: handlePhotoWindow,
   });
 
+  // sessionId를 ref로 미러링 — 위치 콜백에서 항상 최신 값 참조
+  const sessionIdRef = useRef<number | null>(null);
+  sessionIdRef.current = sessionId;
+
+  // 포어그라운드 watch + 백그라운드 task 공용 위치 업데이트 핸들러
+  // 동일/과거 타임스탬프는 무시해 두 소스 동시 수신 시 좌표·publish 중복 방지
+  const handleLocationUpdate = useCallback(
+    (loc: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      timestamp: number;
+    }) => {
+      if (loc.timestamp && loc.timestamp <= lastLocationTsRef.current) return;
+      lastLocationTsRef.current = loc.timestamp || Date.now();
+
+      const { latitude, longitude, altitude, timestamp } = loc;
+      setUserLocation({ latitude, longitude, altitude });
+      setMarkerCoord({ latitude, longitude });
+      setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
+
+      const sid = sessionIdRef.current;
+      if (sid != null) {
+        publishGps(sid, {
+          lat: latitude,
+          lng: longitude,
+          altitude,
+          recordedAt: new Date(timestamp).toISOString(),
+        });
+      }
+    },
+    [publishGps],
+  );
+
   // 포어그라운드 FCM 수신 (백그라운드는 OS가 시스템 알림으로 자동 처리)
   useTrackingFcm({ enabled: isTracking, onPhotoWindow: handlePhotoWindow });
 
@@ -277,20 +312,9 @@ export default function TrackingScreen() {
       }
       connectSocket(activeSession.sessionId);
       // GPS 추적 재시작 — 백그라운드 포함
-      const sid = activeSession.sessionId;
-      setLocationTaskCallback(
-        ({ latitude, longitude, altitude, timestamp }) => {
-          setUserLocation({ latitude, longitude, altitude });
-          setMarkerCoord({ latitude, longitude });
-          setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
-          publishGps(sid, {
-            lat: latitude,
-            lng: longitude,
-            altitude,
-            recordedAt: new Date(timestamp).toISOString(),
-          });
-        },
-      );
+      sessionIdRef.current = activeSession.sessionId;
+      lastLocationTsRef.current = 0;
+      setLocationTaskCallback(handleLocationUpdate);
       startLocationTask().catch((err) =>
         console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
       );
@@ -691,6 +715,45 @@ export default function TrackingScreen() {
     });
   }, [markerCoord, isFollowingUser]);
 
+  // 포어그라운드 실시간 위치 추적 — 앱이 열려 있는 동안 마커/경로 갱신을 담당.
+  // 백그라운드 task는 "항상" 위치 권한이 있어야 시작되므로, 권한을 "앱 사용 중"만
+  // 허용한 경우 마커가 갱신되지 않던 문제를 해결한다. (화면이 꺼졌을 때는 백그라운드 task가 담당)
+  useEffect(() => {
+    if (!isTracking) return;
+    let sub: Location.LocationSubscription | null = null;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { status } = await Location.getForegroundPermissionsAsync();
+        if (status !== "granted") return;
+        sub = await Location.watchPositionAsync(
+          {
+            accuracy: Location.Accuracy.BestForNavigation,
+            timeInterval: 2000,
+            distanceInterval: 5,
+          },
+          (loc) =>
+            handleLocationUpdate({
+              latitude: loc.coords.latitude,
+              longitude: loc.coords.longitude,
+              altitude: loc.coords.altitude,
+              timestamp: loc.timestamp,
+            }),
+        );
+        // await 도중 언마운트/트래킹 종료된 경우 즉시 해제
+        if (cancelled) {
+          sub.remove();
+          sub = null;
+        }
+      } catch (err) {
+        console.warn("[Location] 포어그라운드 위치 추적 실패:", err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      sub?.remove();
+    };
+  }, [isTracking, handleLocationUpdate]);
 
   const startCountdown = (freeMode = false) => {
     setIsFreeMode(freeMode === true); // 이벤트 객체 등 non-boolean 방지
@@ -725,26 +788,13 @@ export default function TrackingScreen() {
               if (data.sessionId != null) {
                 const sid = data.sessionId;
                 setSessionId(sid);
+                sessionIdRef.current = sid;
                 // 세션 ID 확정 후 웹소켓 연결 및 photo-window 구독
                 connectSocket(sid);
                 // GPS 추적 시작 — 백그라운드 포함
                 setRecordedCoords([]);
-                setLocationTaskCallback(
-                  ({ latitude, longitude, altitude, timestamp }) => {
-                    setUserLocation({ latitude, longitude, altitude });
-                    setMarkerCoord({ latitude, longitude });
-                    setRecordedCoords((prev) => [
-                      ...prev,
-                      { latitude, longitude },
-                    ]);
-                    publishGps(sid, {
-                      lat: latitude,
-                      lng: longitude,
-                      altitude,
-                      recordedAt: new Date(timestamp).toISOString(),
-                    });
-                  },
-                );
+                lastLocationTsRef.current = 0;
+                setLocationTaskCallback(handleLocationUpdate);
                 startLocationTask().catch((err) => {
                   console.warn("[Location] 백그라운드 위치 시작 실패:", err);
                 });

--- a/features/tracking/tasks/location-task.ts
+++ b/features/tracking/tasks/location-task.ts
@@ -1,7 +1,7 @@
-import * as Location from 'expo-location';
-import * as TaskManager from 'expo-task-manager';
+import * as Location from "expo-location";
+import * as TaskManager from "expo-task-manager";
 
-export const LOCATION_TASK_NAME = 'semosan-tracking-location';
+export const LOCATION_TASK_NAME = "semosan-tracking-location";
 
 type LocationTaskData = {
   locations: Location.LocationObject[];
@@ -11,6 +11,7 @@ type LocationCallback = (location: {
   latitude: number;
   longitude: number;
   altitude: number | null;
+  accuracy: number | null;
   timestamp: number;
 }) => void;
 
@@ -24,7 +25,7 @@ export function setLocationTaskCallback(cb: LocationCallback | null) {
 // TaskManager는 앱 최상단(모듈 레벨)에서 정의되어야 함
 TaskManager.defineTask(LOCATION_TASK_NAME, async ({ data, error }) => {
   if (error) {
-    console.warn('[LocationTask] 에러:', error.message);
+    console.warn("[LocationTask] 에러:", error.message);
     return;
   }
   const { locations } = data as LocationTaskData;
@@ -35,6 +36,7 @@ TaskManager.defineTask(LOCATION_TASK_NAME, async ({ data, error }) => {
     latitude: loc.coords.latitude,
     longitude: loc.coords.longitude,
     altitude: loc.coords.altitude,
+    accuracy: loc.coords.accuracy,
     timestamp: loc.timestamp,
   });
 });
@@ -42,12 +44,14 @@ TaskManager.defineTask(LOCATION_TASK_NAME, async ({ data, error }) => {
 /** 백그라운드 위치 추적 시작 */
 export async function startLocationTask() {
   const { status } = await Location.requestBackgroundPermissionsAsync();
-  if (status !== 'granted') {
-    console.warn('[LocationTask] 백그라운드 위치 권한 거부됨');
+  if (status !== "granted") {
+    console.warn("[LocationTask] 백그라운드 위치 권한 거부됨");
     return false;
   }
 
-  const isRunning = await Location.hasStartedLocationUpdatesAsync(LOCATION_TASK_NAME).catch(() => false);
+  const isRunning = await Location.hasStartedLocationUpdatesAsync(
+    LOCATION_TASK_NAME,
+  ).catch(() => false);
   if (isRunning) return true;
 
   await Location.startLocationUpdatesAsync(LOCATION_TASK_NAME, {
@@ -57,8 +61,8 @@ export async function startLocationTask() {
     showsBackgroundLocationIndicator: true, // iOS 상태바 파란 아이콘
     foregroundService: {
       // Android 포어그라운드 서비스 알림
-      notificationTitle: '세모산 트래킹 중',
-      notificationBody: '위치를 기록하고 있습니다.',
+      notificationTitle: "세모산 트래킹 중",
+      notificationBody: "위치를 기록하고 있습니다.",
     },
   });
 
@@ -67,7 +71,9 @@ export async function startLocationTask() {
 
 /** 백그라운드 위치 추적 중지 */
 export async function stopLocationTask() {
-  const isRunning = await Location.hasStartedLocationUpdatesAsync(LOCATION_TASK_NAME).catch(() => false);
+  const isRunning = await Location.hasStartedLocationUpdatesAsync(
+    LOCATION_TASK_NAME,
+  ).catch(() => false);
   if (isRunning) {
     await Location.stopLocationUpdatesAsync(LOCATION_TASK_NAME);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@tokens-studio/sd-transforms": "^2.0.3",
         "axios": "^1.15.2",
         "babel-preset-expo": "~54.0.10",
-        "expo": "~54.0.35",
+        "expo": "~54.0.36",
         "expo-apple-authentication": "~8.0.8",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "~6.0.21",
@@ -79,9 +79,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
-      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.2.tgz",
+      "integrity": "sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==",
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
@@ -132,7 +132,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -407,9 +406,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1535,7 +1534,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1920,15 +1918,15 @@
       }
     },
     "node_modules/@expo/config": {
-      "version": "12.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
-      "integrity": "sha512-Cu52arBa4vSaupIWsF0h7F/Cg//N374nYb7HAxV0I4KceKA7x2UXpYaHOL7EEYYvp7tZdThBjvGpVmr8ScIvaQ==",
+      "version": "12.0.14",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.14.tgz",
+      "integrity": "sha512-3dfbBd9LnPDgyylhCgkOsaG8Adg52uOVOTQYH5lf23a/t8M5eQpXKCvzUarrf62B78057n2NnkiofK9TfPgvzw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "^10.0.8",
+        "@expo/json-file": "^10.0.16",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
         "glob": "^13.0.0",
@@ -1941,14 +1939,14 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "54.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.4.tgz",
-      "integrity": "sha512-g2yXGICdoOw5i3LkQSDxl2Q5AlQCrG7oniu0pCPPO+UxGb7He4AFqSvPSy8HpRUj55io17hT62FTjYRD+d6j3Q==",
+      "version": "54.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.5.tgz",
+      "integrity": "sha512-aWQ3sViNRoQWw6So4A2qhWCt24CuGBK6MrRHI1AG+V6/NQAjIZCHaSvcXK2gXKpmisRhTSUWaKPIgLJQFB+AeQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/config-types": "^54.0.10",
-        "@expo/json-file": "~10.0.8",
-        "@expo/plist": "^0.4.8",
+        "@expo/json-file": "~10.0.16",
+        "@expo/plist": "^0.4.9",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -1987,6 +1985,30 @@
       "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/@expo/config/node_modules/@expo/json-file": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@expo/config/node_modules/semver": {
@@ -2042,9 +2064,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.11.tgz",
-      "integrity": "sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.0.12.tgz",
+      "integrity": "sha512-wVfzeBGlUohZG5kS8QCqXurpuWZFJEkBB1wXCifai3EZ/Llcg/VMTiUCpAgHImD3lI7GIU3V1uI64c04XIo98Q==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -2164,13 +2186,22 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "10.0.14",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.14.tgz",
-      "integrity": "sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==",
+      "version": "10.0.16",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.20.0",
+        "@babel/code-frame": "~7.10.4",
         "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/metro": {
@@ -2219,9 +2250,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
-      "integrity": "sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.7.1.tgz",
+      "integrity": "sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.8.0"
@@ -2231,12 +2262,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.12.0.tgz",
-      "integrity": "sha512-SWr6093nwBjn94cvElsYZNUnhvs+XtUatUz3h0vAn0IbaWG0B6l/V5ZfOBptX/xq6rMpFG5ibIf/eckLSXw8Gg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.13.1.tgz",
+      "integrity": "sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.2.0",
+        "@expo/json-file": "^11.0.1",
         "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -2245,9 +2276,9 @@
       }
     },
     "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
-      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-11.0.1.tgz",
+      "integrity": "sha512-zxHWj4MKKMAL29ZQSY/Fssx4Thluk40JmuGNaeS078wy/NhlFhnVi+rHHunulE3xJAJ0CM73m8VK2+GkF9eRwQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
@@ -2299,9 +2330,9 @@
       }
     },
     "node_modules/@expo/schema-utils": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.8.tgz",
-      "integrity": "sha512-9I6ZqvnAvKKDiO+ZF8BpQQFYWXOJvTAL5L/227RUbWG1OVZDInFifzCBiqAZ3b67NRfeAgpgvbA7rejsqhY62A==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.9.tgz",
+      "integrity": "sha512-t9bYwG4Z0yCVzHYJoDMci1OFq2FkBkhStlfUGSkspKYTwB/84+x6sY+CXCgdhkQNQtvWaugW5KUs9YZfAXq9Sg==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -2422,7 +2453,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -2489,7 +2519,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -2505,8 +2534,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -2957,7 +2985,6 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -4084,7 +4111,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
       "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -4106,7 +4132,6 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/app/-/app-24.0.0.tgz",
       "integrity": "sha512-rLWNd8/4FjKYV7PeDR9uiT5vwYWdJ7dJ1yiIIaZ/eL+Y56Ij2iXbqRCUu4zWkvu/ZrJfaGOyT12Vhy1SLy0NMg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "firebase": "12.10.0"
       },
@@ -4523,7 +4548,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -5106,7 +5130,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5200,7 +5223,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -5365,7 +5387,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5443,7 +5464,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -6042,7 +6062,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6799,7 +6818,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8128,7 +8146,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8325,7 +8342,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8545,23 +8561,22 @@
       }
     },
     "node_modules/expo": {
-      "version": "54.0.35",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
-      "integrity": "sha512-E+tXpQwjGm5fK/uwa55p0Xx/kuo5dXDKfVJ95IargTNa5KiFt26lSTXXa9KnHbI4EDLwFD38/xTKZvzPTlGTdg==",
+      "version": "54.0.36",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.36.tgz",
+      "integrity": "sha512-HMHp1H+actmnX85NJE6lILKzSJV6pTDNkwghq9EMOP3zTynjvBYVqJGSLlm6sEVzJCC5Z2ZiKgLvtsHrqlY0dg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "54.0.25",
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/cli": "54.0.26",
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/devtools": "0.1.8",
         "@expo/fingerprint": "0.15.5",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "54.0.16",
+        "@expo/metro-config": "54.0.17",
         "@expo/vector-icons": "^15.0.3",
         "@ungap/structured-clone": "^1.3.0",
-        "babel-preset-expo": "~54.0.11",
+        "babel-preset-expo": "~54.0.12",
         "expo-asset": "~12.0.13",
         "expo-constants": "~18.0.13",
         "expo-file-system": "~19.0.23",
@@ -8636,7 +8651,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -8762,7 +8776,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
       "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8851,7 +8864,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
       "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
@@ -9295,26 +9307,26 @@
       }
     },
     "node_modules/expo/node_modules/@expo/cli": {
-      "version": "54.0.25",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
-      "integrity": "sha512-WnUqIb8oMBhtwSfIqdCHCzcaDIpLNXItRVd5miuvWi4GO0SGo89PSsAkbVJ+LJgcaY+v5rbgMELJS9I/CqOulA==",
+      "version": "54.0.26",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.26.tgz",
+      "integrity": "sha512-BjsAoKINLEo3LRE+sDC6FCgjxuOWsyfOFOKz0txrbEcxSatzIjJDVuX8XaTdmeicZdcoN524yl1sfwCWfxhYMw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@expo/code-signing-certificates": "^0.0.6",
-        "@expo/config": "~12.0.13",
-        "@expo/config-plugins": "~54.0.4",
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
         "@expo/devcert": "^1.2.1",
-        "@expo/env": "~2.0.8",
+        "@expo/env": "~2.0.12",
         "@expo/image-utils": "^0.8.8",
         "@expo/json-file": "^10.0.16",
         "@expo/metro": "~54.2.0",
-        "@expo/metro-config": "~54.0.16",
+        "@expo/metro-config": "~54.0.17",
         "@expo/osascript": "^2.3.8",
         "@expo/package-manager": "^1.9.10",
         "@expo/plist": "^0.4.9",
-        "@expo/prebuild-config": "^54.0.8",
-        "@expo/schema-utils": "^0.1.8",
+        "@expo/prebuild-config": "^54.0.9",
+        "@expo/schema-utils": "^0.1.9",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
@@ -9381,27 +9393,38 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/json-file": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
-      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+    "node_modules/expo/node_modules/@expo/cli/node_modules/@expo/prebuild-config": {
+      "version": "54.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.9.tgz",
+      "integrity": "sha512-3/Rmyzt8vduPjnSVHbnc0wYFrlhwLWn2g596rDyKcLGeqN2WTLJbzVeznsrUwyzhBNXgnTomZWO5HDzbZ/4E7g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.20.0",
-        "json5": "^2.2.3"
+        "@expo/config": "~12.0.14",
+        "@expo/config-plugins": "~54.0.5",
+        "@expo/config-types": "^54.0.10",
+        "@expo/image-utils": "^0.8.8",
+        "@expo/json-file": "^10.0.16",
+        "@react-native/normalize-colors": "0.81.5",
+        "debug": "^4.3.1",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0",
+        "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo/node_modules/@expo/metro-config": {
-      "version": "54.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
-      "integrity": "sha512-3LLb9ZQl0VlqSlsalJ7+CYjfz60PBoSDHvpE1UF71aTM1Nx0Vb4LhXo7bCCC+PYP9q/GPB58LLbIROQ8PjKX2w==",
+      "version": "54.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.17.tgz",
+      "integrity": "sha512-PQFgQCZGY0DffZUvBzJttDPreZfHrQakaBlKjnvOUMNXbDna+TYmg1IFZuIDUYJezLcdp+TvVFTLjNi1+mqaVw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.20.0",
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
-        "@expo/config": "~12.0.13",
-        "@expo/env": "~2.0.8",
+        "@expo/config": "~12.0.14",
+        "@expo/env": "~2.0.12",
         "@expo/json-file": "~10.0.16",
         "@expo/metro": "~54.2.0",
         "@expo/spawn-async": "^1.7.2",
@@ -9428,29 +9451,10 @@
         }
       }
     },
-    "node_modules/expo/node_modules/@expo/metro-config/node_modules/@expo/json-file": {
-      "version": "10.0.16",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
-      "integrity": "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3"
-      }
-    },
-    "node_modules/expo/node_modules/@expo/metro-config/node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
     "node_modules/expo/node_modules/babel-preset-expo": {
-      "version": "54.0.11",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.11.tgz",
-      "integrity": "sha512-dEpeFDtYEFzmWtWVwvt7sUCZH0fxXPfbJlgXd7XNZSQDa/Ki/hTOj9exMTzqR2oyPHDNcE9VxYCJ4oS6xw4Pjg==",
+      "version": "54.0.12",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.12.tgz",
+      "integrity": "sha512-6xeSkdaixmQhWSYL7tfLu0pOS0BY+8ftwmdNSHtpEFSizrXYZkCjk/B6Dxr+6nwNRihixMcS0aBlWS1wlDl3pw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -9491,9 +9495,9 @@
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9552,9 +9556,9 @@
       }
     },
     "node_modules/expo/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9585,9 +9589,9 @@
       }
     },
     "node_modules/expo/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9597,9 +9601,9 @@
       }
     },
     "node_modules/expo/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -11393,7 +11397,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11567,9 +11570,9 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -11582,23 +11585,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.32.0",
-        "lightningcss-darwin-arm64": "1.32.0",
-        "lightningcss-darwin-x64": "1.32.0",
-        "lightningcss-freebsd-x64": "1.32.0",
-        "lightningcss-linux-arm-gnueabihf": "1.32.0",
-        "lightningcss-linux-arm64-gnu": "1.32.0",
-        "lightningcss-linux-arm64-musl": "1.32.0",
-        "lightningcss-linux-x64-gnu": "1.32.0",
-        "lightningcss-linux-x64-musl": "1.32.0",
-        "lightningcss-win32-arm64-msvc": "1.32.0",
-        "lightningcss-win32-x64-msvc": "1.32.0"
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
       "cpu": [
         "arm64"
       ],
@@ -11616,9 +11619,9 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
       "cpu": [
         "arm64"
       ],
@@ -11636,9 +11639,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
       "cpu": [
         "x64"
       ],
@@ -11656,9 +11659,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
       "cpu": [
         "x64"
       ],
@@ -11676,9 +11679,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
       "cpu": [
         "arm"
       ],
@@ -11696,9 +11699,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
       "cpu": [
         "arm64"
       ],
@@ -11716,9 +11719,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
       ],
@@ -11736,9 +11739,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
       "cpu": [
         "x64"
       ],
@@ -11756,9 +11759,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
       ],
@@ -11776,9 +11779,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
       "cpu": [
         "arm64"
       ],
@@ -11796,9 +11799,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
       "cpu": [
         "x64"
       ],
@@ -12709,9 +12712,9 @@
       }
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13383,7 +13386,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -13575,7 +13577,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13927,7 +13928,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13947,7 +13947,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13984,7 +13983,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -14325,7 +14323,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -14351,7 +14348,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -14379,7 +14375,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -14390,7 +14385,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -14406,7 +14400,6 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -14452,7 +14445,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -14485,7 +14477,6 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -14596,7 +14587,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15744,7 +15734,6 @@
       "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.0.tgz",
       "integrity": "sha512-6BzO0DV19t6KUEXYfvHJ73d3y8bBDcd0wNLfoZRX817obJ8YX5Vev8Xh3+k9601tHE8qRJ/586iLt0byuY2THw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^13.0.6",
@@ -15926,7 +15915,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -15981,9 +15969,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -16176,7 +16164,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16282,8 +16269,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -16400,7 +16386,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16455,9 +16440,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -17277,7 +17262,6 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@tokens-studio/sd-transforms": "^2.0.3",
     "axios": "^1.15.2",
     "babel-preset-expo": "~54.0.10",
-    "expo": "~54.0.35",
+    "expo": "~54.0.36",
     "expo-apple-authentication": "~8.0.8",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "~6.0.21",


### PR DESCRIPTION
## 개요
트래킹(자유기록·코스) 중 현재 위치 마커와 카메라 동작에서 발견된 이슈 3건을 수정합니다.

##  문제 상황
1. **마커가 안 움직임** — 자유기록 중 사용자가 이동해도 초록색 현위치 마커가 초기 위치에 고정됨.
2. **경로가 삐죽하게 그려짐** — 자유기록 경로에 GPS 튐 좌표가 그대로 찍혀, 몇 km 떨어진 지점까지 직선으로 이어져 지그재그로 그려짐.
3. **현위치가 중앙에 안 옴** — 코스 트래킹 중 현재 위치 마커가 지도 중앙에 오지 않음.

##  변경 사항
### 1. 마커 실시간 갱신 (포어그라운드 위치 추적 추가)
- 기존엔 마커 갱신이 **백그라운드 위치 태스크**에만 의존 → 이 태스크는 "항상(Always)" 위치 권한이 있어야 시작되므로, "앱 사용 중에만 허용" 권한 시 마커가 갱신되지 않았음.
- 트래킹 중 **포어그라운드 `watchPositionAsync`** 를 추가해, 앱이 열려 있는 동안 마커·경로·GPS publish를 담당하도록 함. (백그라운드 태스크는 화면이 꺼졌을 때 담당)
- 두 소스가 동시에 발화해도 **타임스탬프 기반 중복 제거**로 좌표/publish 중복 방지.

### 2. GPS 튐 좌표 필터
- 직전 채택 좌표 대비 **비현실적 점프(속도 ≈108km/h 초과)** 또는 **저정확도 큰 점프** 좌표를 마커·경로·publish에서 모두 스킵.
- 필터에 필요한 `accuracy`를 위치 콜백에 함께 전달.
- 임계값은 상수(`MAX_LOCATION_ACCURACY_M`, `MIN_JUMP_M`, `MAX_SPEED_MPS`)로 분리해 조정 가능.

### 3. 트래킹 중 현위치 중앙 follow
- 트래킹 중에는 **모드 무관하게 현위치 follow** 활성화 → 마커가 지도 중앙(바텀시트 위 영역 기준)에 오도록 추적.
- 전체 코스 맞춤은 **트래킹 시작 전 미리보기용으로만** 동작하도록 변경.
- 사용자가 직접 지도를 조작하면 follow 자동 해제(기존 동작 유지).

## 변경 파일
- `app/(tabs)/tracking.tsx`
- `features/tracking/tasks/location-task.ts`

## ✅ 체크리스트
- [x] TypeScript 타입체크 통과
- [x] Prettier 포맷 통과
- [ ] 실기기 GPS 검증 — 자유기록 시 마커가 이동에 따라 실시간 갱신되는지
- [ ] 실기기 GPS 검증 — 경로가 튐 없이 깔끔하게 그려지는지
- [ ] 실기기 GPS 검증 — 코스/자유기록 트래킹 중 현위치가 중앙에 잡히고 따라오는지
- [ ] 백그라운드 전환 시 좌표 중복/누락 없는지

## 참고
- 마커는 화면 물리적 정중앙이 아니라 **바텀시트를 제외한 보이는 지도 영역의 중앙**에 옵니다 (mapPadding 적용, 시트에 안 가리게 하는 정상 동작).
- 튐 좌표 필터 임계값은 실측 후 조정 가능하며, 정상 이동인데도 경로가 끊기면 `MAX_SPEED_MPS`를 상향하면 됩니다.