### PR TITLE
fix : 게시글 좋아요/댓글 알림 탭 시 unmatched route 대신 해당 게시글로 이동

### DIFF
--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -156,7 +156,9 @@ function navigateByType(
     case 'COMMUNITY_REPLY':
     case 'COMMUNITY_LIKE':
     case 'COMMUNITY_MENTION':
-      push(`/community/${extras.postId}`);
+      // 자유게시판 게시글 상세 라우트는 /community/free-board/[id]
+      // (기존 /community/[postId]는 매칭되는 라우트가 없어 unmatched route 발생)
+      push(`/community/free-board/${extras.postId}`);
       break;
 
     case 'FOLLOW_RECEIVED':


### PR DESCRIPTION
##  개요
게시글 좋아요/댓글 등 커뮤니티 푸시 알림을 상단바에서 탭했을 때 해당 게시글로 이동하지 않고 **unmatched route** 화면이 뜨던 문제를 수정합니다.

##  문제 상황
- 좋아요/댓글/답글/멘션 알림을 탭하면 존재하지 않는 `/community/[postId]` 경로로 이동 시도 → expo-router가 매칭 실패 → "unmatched route" 화면 표시
- 실제 자유게시판 게시글 상세 라우트는 `/community/free-board/[id]` 뿐임

##  변경 사항
- `hooks/use-push-notification.ts`의 `navigateByType`에서 커뮤니티 알림(`COMMUNITY_COMMENT` / `COMMUNITY_REPLY` / `COMMUNITY_LIKE` / `COMMUNITY_MENTION`) 이동 경로를 `/community/${extras.postId}` → `/community/free-board/${extras.postId}` 로 수정
- 앱 내 정상 이동 코드(`post-item.tsx`)와 동일한 경로 패턴으로 정렬
- 포어그라운드 탭 리스너와 앱 종료 후 콜드스타트 탭(`getLastNotificationResponseAsync`) 모두 이 함수를 거치므로 두 경로 동시 해결

##  변경 파일
- `hooks/use-push-notification.ts`

##  체크리스트
- [x] TypeScript 타입체크 통과
- [ ] 실기기 검증 — 포어그라운드에서 좋아요/댓글 알림 탭 시 게시글 이동
- [ ] 실기기 검증 — 앱 종료 상태에서 알림 탭으로 실행 시 게시글 이동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 커뮤니티 댓글, 답글, 좋아요, 멘션 알림을 선택했을 때 올바른 자유게시판 게시글로 이동하도록 경로를 수정했습니다.
  * 잘못된 경로로 인해 페이지를 찾을 수 없던 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->