### PR TITLE
chore : 앱 버전 1.1로 상향 (앱 심사 버전과 동일하게 맞춤)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -10,7 +10,7 @@ const hasKakaoNativeAppKey = !!process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY;
 const config = {
   name: "semosan",
   slug: "semosan",
-  version: "1.0.0",
+  version: "1.1",
   orientation: "portrait",
   icon: "./assets/images/app-icon.png",
   scheme: "semosan",


### PR DESCRIPTION
##  개요
앱 마케팅 버전을 App Store 심사 버전과 동일하게 `1.1`로 상향합니다.

## 변경 사항
- `app.config.js`의 `version` `"1.0.0"` → `"1.1"`
- iOS `CFBundleShortVersionString`, Android `versionName`에 반영 (App Store/Play Store 노출 버전)

## 변경 파일
- `app.config.js` (1줄)

## 참고
- 빌드 번호(iOS `buildNumber` / Android `versionCode`)는 이 PR에서 변경하지 않았습니다. EAS 빌드 설정에서 관리됩니다.
- `expo prebuild` 또는 EAS 빌드 시 네이티브 프로젝트(`Info.plist` / `build.gradle`)에 자동 반영됩니다.