### PR TITLE
chore : CodeRabbit 설정 추가 (한국어 리뷰 + 자동생성/락/네이티브 파일 제외)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+# CodeRabbit 설정 — 리뷰 언어/강도 및 자동생성·lock·네이티브 파일 제외
+language: ko-KR
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  # 리뷰 제외 경로 — 자동생성물/락파일/네이티브/에셋은 리뷰 낭비이므로 제외
+  path_filters:
+    - "!tokens/**" # Figma 내보내기 (직접 수정 금지)
+    - "!tokens.cjs" # npm run tokens 자동생성
+    - "!typography-plugin.cjs" # npm run tokens 자동생성
+    - "!css/variables.css" # npm run tokens 자동생성
+    - "!css/typography.css" # npm run tokens 자동생성
+    - "!global.css" # Tailwind 진입점 (자동생성 import)
+    - "!package-lock.json" # 의존성 락파일
+    - "!ios/**" # prebuild 생성 네이티브 프로젝트
+    - "!android/**" # prebuild 생성 네이티브 프로젝트
+    - "!**/*.png"
+    - "!**/*.jpg"
+    - "!**/*.jpeg"
+    - "!**/*.svg"
+chat:
+  auto_reply: true


### PR DESCRIPTION
##  개요
CodeRabbit AI 코드리뷰 동작을 프로젝트에 맞게 설정하는 `.coderabbit.yaml`을 추가합니다. 리뷰 언어를 한국어로 지정하고, 리뷰가 불필요한 자동생성물·락파일·네이티브 폴더를 제외해 **리뷰 한도(rate limit) 낭비를 줄입니다.**

##  변경 사항
`.coderabbit.yaml` 신규 추가:
- `language: ko-KR` — 리뷰 코멘트 한국어
- `profile: chill` — 완만한 리뷰 강도
- `poem: false` — 시 생성 비활성화 (노이즈 감소)
- `auto_review` — `main` 대상 PR 자동 리뷰(드래프트 제외)
- `path_filters` 로 리뷰 제외:
  - 자동생성물: `tokens/**`, `tokens.cjs`, `typography-plugin.cjs`, `css/variables.css`, `css/typography.css`, `global.css`
  - `package-lock.json`, `ios/**`, `android/**`, 이미지 에셋(png/jpg/svg)

##  변경 파일
- `.coderabbit.yaml` (신규)

##  머지 순서 (중요)
`.coderabbit.yaml`은 **PR의 base 브랜치(main) 기준**으로 적용됩니다. 이 설정이 효력을 가지려면 **이 PR을 가장 먼저 main에 머지**해야 하며, 이후 열리는 PR부터 반영됩니다. (현재 열려 있는 다른 PR에는 소급 적용되지 않음)

##  체크리스트
- [x] YAML 문법 검증 통과
- [ ] 머지 후 다음 PR에서 자동생성/락 파일이 리뷰에서 제외되는지 확인