### PR TITLE
feat : 산 상세 맛집 탭 시 네이버 지도로 이동

### DIFF
--- a/features/mountains-detail/components/restaurant-tab.tsx
+++ b/features/mountains-detail/components/restaurant-tab.tsx
@@ -61,23 +61,6 @@ export function RestaurantTab() {
                 </View>
               </Pressable>
             ))}
-            {/* TODO : 화면 개발되면 추가 */}
-            {/* 더보기 버튼은 앞에 아이템 3개 이상일때 부터 추가 */}
-            {/* {(section.restaurants?.length ?? 0) >= 3 && (
-              <Pressable
-                className="h-[116px] w-[188px] items-center justify-center gap-1 rounded-[10px] bg-fill-stronger"
-                onPress={() => {
-                  // TODO: 맛집 더보기 화면으로 이동
-                }}
-              >
-                <Text className="text-center text-label-subtle typo-body-2-normal-semi-bold">
-                  {section.title}
-                </Text>
-                <Text className="text-label-subtler typo-body-2-normal-regular">
-                  {"더보기 >"}
-                </Text>
-              </Pressable>
-            )} */}
           </ScrollView>
         </View>
       ))}

--- a/features/mountains-detail/components/restaurant-tab.tsx
+++ b/features/mountains-detail/components/restaurant-tab.tsx
@@ -1,7 +1,14 @@
 import { LoadingSpinner } from "@/components/loading-spinner";
 import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import { useLocalSearchParams } from "expo-router";
-import { Image, ScrollView, Text, View } from "react-native";
+import {
+  Image,
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
 
 export function RestaurantTab() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -24,7 +31,18 @@ export function RestaurantTab() {
             contentContainerStyle={{ paddingHorizontal: 20, gap: 12 }}
           >
             {section.restaurants?.map((item) => (
-              <View key={item.restaurantId} className="gap-2">
+              <Pressable
+                key={item.restaurantId}
+                className="gap-2"
+                disabled={!item.mapUrl}
+                onPress={() => {
+                  // 맛집 탭 시 네이버 지도(mapUrl)로 이동
+                  if (!item.mapUrl) return;
+                  Linking.openURL(item.mapUrl).catch((err) =>
+                    console.warn("[Restaurant] 지도 열기 실패:", err),
+                  );
+                }}
+              >
                 {item.imageUrl ? (
                   <Image
                     source={{ uri: item.imageUrl }}
@@ -41,7 +59,7 @@ export function RestaurantTab() {
                     {item.category}
                   </Text>
                 </View>
-              </View>
+              </Pressable>
             ))}
             {/* TODO : 화면 개발되면 추가 */}
             {/* 더보기 버튼은 앞에 아이템 3개 이상일때 부터 추가 */}

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -556,6 +556,7 @@ export type RestaurantInfo = {
   name?: string;
   category?: string;
   imageUrl?: string;
+  mapUrl?: string;
 };
 export type RestaurantSectionInfo = {
   title?: string;


### PR DESCRIPTION
## 개요
산 상세 정보 조회 API에 맛집 `mapUrl` 필드가 추가됨에 따라, 산 상세 화면에서 **맛집을 누르면 네이버 지도로 이동**하도록 구현합니다.

## 변경 사항
- **`types/api.generated.ts`** — `RestaurantInfo`에 `mapUrl?: string` 필드 추가
- **`features/mountains-detail/components/restaurant-tab.tsx`**
  - 맛집 아이템을 `Pressable`로 감싸 탭 시 `Linking.openURL(item.mapUrl)`로 네이버 지도 열기
  - `mapUrl`이 없는 항목은 `disabled` 처리, 열기 실패는 로그만 남기고 무시
  - 미구현 상태로 주석 처리돼 있던 "더보기" 블록(죽은 코드) 제거

## 변경 파일
- `types/api.generated.ts`
- `features/mountains-detail/components/restaurant-tab.tsx`

## 체크리스트
- [x] TypeScript 타입체크 통과
- [x] Prettier 포맷 통과
- [ ] 실기기 — 맛집 탭 시 네이버 지도(앱/웹)로 정상 이동
- [ ] `mapUrl` 없는 맛집은 탭해도 아무 동작 안 하는지

##  참고 — 타입 재생성 관련
`types/api.generated.ts`는 원래 `npm run typegen`으로 재생성하는 파일이나, 전체 재생성 시 백엔드 스펙 드리프트로 **관련 없는 타입 242줄 변경 + `SlopeSegmentResponse` optional화로 인한 `tracking.tsx` 타입 에러**가 발생합니다. 이 PR을 깨끗하게 유지하기 위해 **`mapUrl` 필드만 최소 추가**했습니다.
→ 추후 전체 `typegen` 재생성은 `tracking.tsx`(`mergeShortSegments`) 대응과 함께 **별도 PR**로 진행 필요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 맛집 카드에서 지도 URL이 제공된 경우, 카드를 눌러 외부 지도 앱 또는 웹페이지를 열 수 있습니다.
  * 지도 URL이 없는 맛집 카드는 클릭할 수 없습니다.

* **버그 수정**
  * 지도 링크를 열지 못할 때 오류를 기록하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->