### PR TITLE
fix: 자유기록 거리(km) 기록 화면 미반영 수정

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -113,7 +113,6 @@ export default function RecordScreen() {
   const sessionId = id ? parseInt(id) : null;
   const hikingRecordIdNum = hikingRecordId ? parseInt(hikingRecordId) : null;
   const courseIdNum = courseId ? parseInt(courseId) : null;
-  const distanceKm = distance ? parseFloat(distance) / 1000 : null;
   const durationSec = duration ? parseInt(duration) : null;
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -167,6 +166,12 @@ export default function RecordScreen() {
   const { data: hikingSummary } = useHikingSummary();
   const { data: recordDetail } = useHikingRecordDetail(hikingRecordIdNum);
   const { data: courseDetail } = useCourseDetail(courseIdNum);
+  const distanceKm =
+    recordDetail?.distanceMeters != null
+      ? recordDetail.distanceMeters / 1000
+      : distance
+        ? parseFloat(distance) / 1000
+        : null;
   const displayPhotos = [...clivePhotos].reverse();
   const cliveShotRef = useRef<ViewShot | null>(null);
   const photoReportShotRef = useRef<ViewShot | null>(null);

--- a/components/course-bottom-sheet.tsx
+++ b/components/course-bottom-sheet.tsx
@@ -1,4 +1,5 @@
 import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
+import { useHikingRecordDetail } from "@/features/home/hooks/use-hiking-record-detail";
 import { GetUserHikingRecordResponse } from "@/types/api.generated";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ChevronRightIcon } from "./icons/chevron-right-icon";
@@ -157,6 +158,14 @@ function CourseItem({
   mountainId?: number;
   onPress?: () => void;
 }) {
+  // 자유기록 등 목록 요약 API의 distance/duration이 비어있는 경우 상세 API로 폴백
+  const needsDetailFallback = !course.distance || !course.duration;
+  const { data: recordDetail } = useHikingRecordDetail(
+    needsDetailFallback ? (course.hikingRecordId ?? null) : null,
+  );
+  const distanceMeters = course.distance || recordDetail?.distanceMeters;
+  const durationSeconds = course.duration || recordDetail?.durationSeconds;
+
   return (
     <TouchableOpacity
       className="w-full flex-row items-center justify-between"
@@ -179,12 +188,12 @@ function CourseItem({
             {course.courseName}
           </Text>
           <Text className="text-label-subtler typo-caption-1-medium">
-            {!!course.distance && (
-              <>{(course.distance / 1000).toFixed(1)}km · </>
+            {!!distanceMeters && (
+              <>{(distanceMeters / 1000).toFixed(1)}km · </>
             )}
-            {!!course.duration && (
+            {!!durationSeconds && (
               <>
-                {formatDuration(course.duration)} ·{" "}
+                {formatDuration(durationSeconds)} ·{" "}
                 {formatHikedAt(course.hikedAt)}
               </>
             )}


### PR DESCRIPTION
## Summary
- 기록 상세 화면(`app/record/[id].tsx`) 상단 거리 표시가 목록에서 넘어온 route param 대신, 상세 API(`recordDetail.distanceMeters`)를 우선 사용하도록 수정
- 산 상세 바텀시트의 "다녀온 기록" 목록(`components/course-bottom-sheet.tsx`)도 요약 API의 distance/duration이 비어있을 때(자유기록 등) 상세 API로 폴백하도록 수정

## Test plan
- [ ] 자유기록(코스 미지정)으로 하이킹 후 기록 화면 상단 거리(km)가 올바르게 표시되는지 확인
- [ ] 코스 기반 기록도 기존과 동일하게 거리가 표시되는지 확인
- [ ] 산 상세 바텀시트의 "다녀온 기록" 목록에서 자유기록 항목의 거리/소요시간이 표시되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기록 상세 화면에서 더 정확한 거리 정보를 우선 표시합니다.
  * 요약 정보에 거리나 시간이 없을 경우 상세 기록 데이터를 활용해 보완합니다.
  * 상세 데이터가 unavailable한 경우에도 기존 정보로 대체해 표시가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->