### PR TITLE
fix: 인증 사진 촬영 시 창 만료·업로드 실패 누락 문제 수정

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -53,6 +53,7 @@ import {
   LiveActivity,
   addLiveActivityControlListener,
 } from "@/modules/live-activity";
+import { toast } from "@/store/toast.store";
 import {
   NaverMapMarkerOverlay,
   NaverMapPathOverlay,
@@ -1086,6 +1087,20 @@ export default function TrackingScreen() {
   const requestStop = () => setShowStopModal(true);
 
   const handleCameraPress = async () => {
+    // 카메라를 열기 전에 인증 창을 먼저 확정 — 촬영 도중 창이 닫혀 사진이
+    // 조용히 버려지는 것을 막고, 이미 닫혔다면 촬영 전에 바로 안내한다.
+    const isWindowOpen = photoWindow?.status === "OPEN";
+    const activeWindow = isWindowOpen
+      ? photoWindow
+      : hasSummited
+        ? summitPhotoWindowRef.current
+        : null;
+
+    if (activeWindow == null || sessionId == null) {
+      toast.show("인증 사진을 찍을 수 있는 시간이 지났어요.", { type: "error" });
+      return;
+    }
+
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== "granted") {
       console.warn("[Camera] 카메라 권한 거부됨");
@@ -1100,37 +1115,28 @@ export default function TrackingScreen() {
 
     if (result.canceled || !result.assets?.[0]?.uri) return;
 
-    const isWindowOpen = photoWindow?.status === "OPEN";
-    // 정상 인증 후에는 summitPhotoWindowRef에 저장된 photoWindow 사용
-    const activeWindow = isWindowOpen
-      ? photoWindow
-      : hasSummited
-        ? summitPhotoWindowRef.current
-        : null;
+    try {
+      const capturedAt = new Date().toISOString();
+      const imageUrl = await uploadTrackingPhoto(result.assets[0].uri);
+      console.log("[Tracking] 인증 사진 업로드 완료:", imageUrl);
 
-    if (activeWindow != null && sessionId != null) {
-      try {
-        const capturedAt = new Date().toISOString();
-        const imageUrl = await uploadTrackingPhoto(result.assets[0].uri);
-        console.log("[Tracking] 인증 사진 업로드 완료:", imageUrl);
-
-        await savePhoto({
-          sessionId,
-          body: {
-            milestoneIndex: activeWindow.milestoneIndex,
-            milestoneDistanceM: activeWindow.milestoneDistance,
-            imageUrl,
-            capturedAt,
-            lat: userLocation?.latitude ?? 0,
-            lng: userLocation?.longitude ?? 0,
-            altitude: userLocation?.altitude ?? 0,
-          },
-        });
-        console.log("[Tracking] 사진 메타 저장 완료");
-      } catch (err) {
-        console.warn("[Tracking] 인증 사진 처리 실패:", err);
-        Sentry.captureException(new Error("TrackingPhotoUploadFailed"));
-      }
+      await savePhoto({
+        sessionId,
+        body: {
+          milestoneIndex: activeWindow.milestoneIndex,
+          milestoneDistanceM: activeWindow.milestoneDistance,
+          imageUrl,
+          capturedAt,
+          lat: userLocation?.latitude ?? 0,
+          lng: userLocation?.longitude ?? 0,
+          altitude: userLocation?.altitude ?? 0,
+        },
+      });
+      console.log("[Tracking] 사진 메타 저장 완료");
+    } catch (err) {
+      console.warn("[Tracking] 인증 사진 처리 실패:", err);
+      Sentry.captureException(new Error("TrackingPhotoUploadFailed"));
+      toast.show("사진 저장에 실패했어요. 다시 시도해주세요.", { type: "error" });
     }
   };
 


### PR DESCRIPTION
## Summary
- 인증 창(photoWindow) 만료 여부를 카메라 실행 **전에** 확인하도록 순서 변경 — 촬영 도중 창이 닫혀 사진이 조용히 버려지는 것을 방지하고, 이미 닫혔다면 촬영 전에 토스트로 즉시 안내
- 사진 업로드/저장(`uploadTrackingPhoto`, `savePhoto`) 실패 시 `console.warn` + Sentry 로그만 남기던 것에 사용자 대상 에러 토스트 추가 — 신호가 약한 산 환경에서 실패해도 사용자가 인지하고 재시도 가능

## Test plan
- [ ] 인증 창이 열려 있을 때 사진 촬영 시 정상적으로 클라이브/포토리포트에 반영되는지 확인
- [ ] 인증 창이 닫힌 상태에서 카메라 버튼을 눌렀을 때 카메라가 열리지 않고 토스트가 뜨는지 확인
- [ ] 네트워크를 차단한 상태로 사진 촬영 시 실패 토스트가 뜨는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 카메라를 열기 전 사진 인증 및 세션 상태를 확인합니다.
  - 인증 또는 세션이 유효하지 않으면 오류 알림을 표시하고 작업을 중단합니다.
  - 사진 업로드 및 정보 저장에 실패한 경우 오류 알림을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->