### PR TITLE
chore : iOS 네이티브 앱 버전 1.0.0 → 1.1 (Info.plist / MARKETING_VERSION)

### DIFF
--- a/ios/semosan.xcodeproj/project.pbxproj
+++ b/ios/semosan.xcodeproj/project.pbxproj
@@ -534,7 +534,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/semosan/Info.plist
+++ b/ios/semosan/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.0</string>
+    <string>1.1</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>


### PR DESCRIPTION
## 📌 개요
App Store 심사 버전(1.1)에 맞춰 iOS 네이티브 앱 버전을 상향합니다.

## 🐛 배경
이 프로젝트는 `ios/` 네이티브 프로젝트가 커밋된 bare 워크플로우라, EAS 빌드가 prebuild를 건너뛰고 **네이티브 파일의 버전**을 사용합니다. 따라서 `app.config.js`의 `version: "1.1"`만으로는 빌드에 반영되지 않아, 네이티브 파일에서 직접 1.0.0 → 1.1로 올려야 앱스토어 버전 트레인(1.0.0 closed) 에러(90186/90062)가 해결됩니다.

## 🔧 변경 사항
- `ios/semosan/Info.plist` — `CFBundleShortVersionString` 1.0.0 → 1.1
- `ios/semosan.xcodeproj/project.pbxproj` — `MARKETING_VERSION` 1.0 → 1.1 (2곳)

빌드 번호(`CFBundleVersion`)는 EAS `autoIncrement`가 관리하므로 미변경.

## ✅ 체크리스트
- [ ] 머지 후 EAS 프로덕션 빌드 시 버전이 1.1로 표시되는지 확인
- [ ] App Store Connect 1.1 트레인으로 제출 성공