### PR TITLE
fix : 백그라운드 알림 탭 시 unmatched route 대신 해당 화면으로 이동

### DIFF
--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -1,15 +1,22 @@
 import * as Sentry from "@sentry/react-native";
-import { api } from '@/lib/api';
-import { getApp } from '@react-native-firebase/app';
-import { getMessaging, getToken, onMessage } from '@react-native-firebase/messaging';
-import * as Device from 'expo-device';
-import * as Notifications from 'expo-notifications';
-import { useRouter } from 'expo-router';
-import { useEffect } from 'react';
-import { Platform } from 'react-native';
+import { api } from "@/lib/api";
+import { getApp } from "@react-native-firebase/app";
+import {
+  getMessaging,
+  getToken,
+  onMessage,
+} from "@react-native-firebase/messaging";
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import { useRouter } from "expo-router";
+import { useEffect } from "react";
+import { Platform } from "react-native";
 
 // 트래킹 전용 타입 — use-tracking-fcm.ts에서 처리하므로 여기서 제외
-const TRACKING_TYPES = new Set(['TRACKING_PHOTO_MILESTONE', 'TRACKING_SUMMIT_REACHED']);
+const TRACKING_TYPES = new Set([
+  "TRACKING_PHOTO_MILESTONE",
+  "TRACKING_SUMMIT_REACHED",
+]);
 
 /**
  * 앱 시작 시 FCM 토큰을 서버에 등록하고
@@ -30,15 +37,26 @@ export function usePushNotification(enabled = true): void {
     // 트래킹 타입은 use-tracking-fcm.ts에서 처리하므로 제외
     const fcmMessaging = getMessaging(getApp());
     const unsubscribeFcm = onMessage(fcmMessaging, async (remoteMessage) => {
-      const type = typeof remoteMessage.data?.type === 'string' ? remoteMessage.data.type : undefined;
+      const type =
+        typeof remoteMessage.data?.type === "string"
+          ? remoteMessage.data.type
+          : undefined;
       if (type && TRACKING_TYPES.has(type)) return;
 
-      const title = remoteMessage.notification?.title ?? (typeof remoteMessage.data?.title === 'string' ? remoteMessage.data.title : undefined);
-      const body = remoteMessage.notification?.body ?? (typeof remoteMessage.data?.body === 'string' ? remoteMessage.data.body : undefined);
+      const title =
+        remoteMessage.notification?.title ??
+        (typeof remoteMessage.data?.title === "string"
+          ? remoteMessage.data.title
+          : undefined);
+      const body =
+        remoteMessage.notification?.body ??
+        (typeof remoteMessage.data?.body === "string"
+          ? remoteMessage.data.body
+          : undefined);
       if (!title && !body) return;
 
       await Notifications.scheduleNotificationAsync({
-        content: { title: title ?? 'SEMOSAN', body: body ?? '' },
+        content: { title: title ?? "SEMOSAN", body: body ?? "" },
         trigger: null,
       });
     });
@@ -46,16 +64,16 @@ export function usePushNotification(enabled = true): void {
     // 알림 탭 → 화면 이동
     const tapSub = Notifications.addNotificationResponseReceivedListener(
       (response) => {
-        const data = response.notification.request.content.data as PushData;
-        navigateByType(data, router);
+        const data = extractPushData(response);
+        if (data) navigateByType(data, router);
       },
     );
 
     // 앱이 종료된 상태에서 알림 탭으로 열린 경우
     Notifications.getLastNotificationResponseAsync().then((response) => {
       if (!response) return;
-      const data = response.notification.request.content.data as PushData;
-      navigateByType(data, router);
+      const data = extractPushData(response);
+      if (data) navigateByType(data, router);
     });
 
     return () => {
@@ -75,46 +93,46 @@ type PushData = {
 
 // 백엔드 NotificationType enum과 동기화
 type NotificationType =
-  | 'COMMUNITY_COMMENT'
-  | 'COMMUNITY_REPLY'
-  | 'COMMUNITY_LIKE'
-  | 'COMMUNITY_MENTION'
-  | 'FOLLOW_RECEIVED'
-  | 'HIKING_INVITE'
-  | 'HIKING_INVITE_ACCEPTED'
-  | 'HIKING_STARTED'
-  | 'HIKING_MEMBER_JOINED'
-  | 'HIKING_MEMBER_LEFT'
-  | 'HIKING_NEAR_DESTINATION'
-  | 'HIKING_OFF_TRAIL'
-  | 'HIKING_FINISHED'
-  | 'HIKING_CHAT'
-  | 'EMERGENCY_SOS'
-  | 'WEATHER_WARNING'
-  | 'TRAIL_CLOSED'
-  | 'SYSTEM_NOTICE'
-  | 'SYSTEM_MAINTENANCE'
-  | 'APP_UPDATE'
-  | 'TRACKING_PHOTO_MILESTONE';
+  | "COMMUNITY_COMMENT"
+  | "COMMUNITY_REPLY"
+  | "COMMUNITY_LIKE"
+  | "COMMUNITY_MENTION"
+  | "FOLLOW_RECEIVED"
+  | "HIKING_INVITE"
+  | "HIKING_INVITE_ACCEPTED"
+  | "HIKING_STARTED"
+  | "HIKING_MEMBER_JOINED"
+  | "HIKING_MEMBER_LEFT"
+  | "HIKING_NEAR_DESTINATION"
+  | "HIKING_OFF_TRAIL"
+  | "HIKING_FINISHED"
+  | "HIKING_CHAT"
+  | "EMERGENCY_SOS"
+  | "WEATHER_WARNING"
+  | "TRAIL_CLOSED"
+  | "SYSTEM_NOTICE"
+  | "SYSTEM_MAINTENANCE"
+  | "APP_UPDATE"
+  | "TRACKING_PHOTO_MILESTONE";
 
 // ─── FCM 토큰 등록 ───────────────────────────────────────────
 
 async function registerFcmToken() {
   if (!Device.isDevice) {
-    console.log('[Push] 실기기에서만 토큰 등록 가능');
+    console.log("[Push] 실기기에서만 토큰 등록 가능");
     return;
   }
 
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
   let finalStatus = existingStatus;
 
-  if (existingStatus !== 'granted') {
+  if (existingStatus !== "granted") {
     const { status } = await Notifications.requestPermissionsAsync();
     finalStatus = status;
   }
 
-  if (finalStatus !== 'granted') {
-    console.log('[Push] 알림 권한 거부됨');
+  if (finalStatus !== "granted") {
+    console.log("[Push] 알림 권한 거부됨");
     return;
   }
 
@@ -126,68 +144,79 @@ async function registerFcmToken() {
     const token = await getToken(fcmMessaging);
 
     await api.post({
-      path: '/api/fcm/tokens',
+      path: "/api/fcm/tokens",
       body: {
         token,
-        deviceType: Platform.OS === 'ios' ? 'IOS' : 'ANDROID',
+        deviceType: Platform.OS === "ios" ? "IOS" : "ANDROID",
       },
     });
 
-    console.log('[Push] FCM 토큰 등록 완료:', token);
+    console.log("[Push] FCM 토큰 등록 완료:", token);
   } catch (error) {
-    console.error('[Push] FCM 토큰 등록 실패:', error);
+    console.error("[Push] FCM 토큰 등록 실패:", error);
     Sentry.captureException(new Error("FcmTokenRegistrationFailed"));
   }
 }
 
 // ─── 알림 탭 라우팅 ──────────────────────────────────────────
 
-function navigateByType(
-  data: PushData,
-  router: ReturnType<typeof useRouter>,
-) {
-  const extras = data.extras ? JSON.parse(data.extras) : {};
+/**
+ * 알림 응답에서 데이터 추출.
+ * 백그라운드/종료 상태 탭 시 Firebase SDK 충돌로 content.data가 비어 있고
+ * 실제 데이터가 trigger.payload에 담기므로 폴백 처리한다. (use-tracking-fcm.ts와 동일)
+ */
+function extractPushData(
+  response: Notifications.NotificationResponse,
+): PushData | null {
+  const contentData = response.notification.request.content.data as
+    | PushData
+    | undefined;
+  if (contentData?.type) return contentData;
+  const triggerPayload = (response.notification.request.trigger as any)
+    ?.payload as PushData | undefined;
+  if (triggerPayload?.type) return triggerPayload;
+  return null;
+}
+
+function navigateByType(data: PushData, router: ReturnType<typeof useRouter>) {
+  let extras: { postId?: number | string; actorId?: number | string } = {};
+  try {
+    extras = data.extras ? JSON.parse(data.extras) : {};
+  } catch {
+    extras = {};
+  }
   // expo-router typedRoutes 미등록 경로는 as any로 우회
-  // 해당 화면 구현 시 타입 제거 가능
   const push = (path: string) => router.push(path as any);
 
   switch (data.type) {
-    case 'COMMUNITY_COMMENT':
-    case 'COMMUNITY_REPLY':
-    case 'COMMUNITY_LIKE':
-    case 'COMMUNITY_MENTION':
-      // 자유게시판 게시글 상세 라우트는 /community/free-board/[id]
-      // (기존 /community/[postId]는 매칭되는 라우트가 없어 unmatched route 발생)
-      push(`/community/free-board/${extras.postId}`);
+    case "COMMUNITY_COMMENT":
+    case "COMMUNITY_REPLY":
+    case "COMMUNITY_LIKE":
+    case "COMMUNITY_MENTION":
+      // 자유게시판 게시글 상세 — postId 없으면 이동하지 않음(undefined 경로 방지)
+      if (extras.postId != null) {
+        push(`/community/free-board/${extras.postId}`);
+      }
       break;
 
-    case 'FOLLOW_RECEIVED':
-      push(`/profile/${extras.actorId}`);
+    case "HIKING_INVITE":
+    case "HIKING_INVITE_ACCEPTED":
+    case "HIKING_STARTED":
+    case "HIKING_MEMBER_JOINED":
+    case "HIKING_MEMBER_LEFT":
+    case "HIKING_NEAR_DESTINATION":
+    case "HIKING_OFF_TRAIL":
+    case "HIKING_FINISHED":
+    case "HIKING_CHAT":
+    case "EMERGENCY_SOS":
+    case "TRACKING_PHOTO_MILESTONE":
+      router.push("/(tabs)/tracking");
       break;
 
-    case 'HIKING_INVITE':
-    case 'HIKING_INVITE_ACCEPTED':
-    case 'HIKING_STARTED':
-    case 'HIKING_MEMBER_JOINED':
-    case 'HIKING_MEMBER_LEFT':
-    case 'HIKING_NEAR_DESTINATION':
-    case 'HIKING_OFF_TRAIL':
-    case 'HIKING_FINISHED':
-    case 'HIKING_CHAT':
-    case 'EMERGENCY_SOS':
-    case 'TRACKING_PHOTO_MILESTONE':
-      router.push('/(tabs)/tracking');
-      break;
-
-    case 'SYSTEM_NOTICE':
-    case 'SYSTEM_MAINTENANCE':
-    case 'APP_UPDATE':
-    case 'WEATHER_WARNING':
-    case 'TRAIL_CLOSED':
-      push('/notification');
-      break;
-
+    // 대응 화면이 아직 없는 타입(FOLLOW_RECEIVED, SYSTEM_*, WEATHER_WARNING 등)은
+    // 존재하지 않는 라우트로 이동하면 unmatched route가 뜨므로 이동하지 않는다.
+    // (알림 센터/프로필 화면 구현 시 여기에 연결)
     default:
-      push('/notification');
+      break;
   }
 }


### PR DESCRIPTION
## 📌 개요
백그라운드/종료 상태에서 푸시 알림을 탭하면 해당 화면으로 이동하지 않고 **Unmatched Route(`semosan:///`)** 가 뜨던 문제를 수정합니다. 이제 트래킹 알림 → 트래킹 화면, 게시글 알림 → 해당 게시글로 이동합니다.

## 🐛 원인
- 백그라운드/종료 상태에서 알림을 탭하면 Firebase SDK와 expo-notifications 충돌로 `response.notification.request.content.data`가 비어 있고, 실제 데이터가 `request.trigger.payload`에 담김
- `usePushNotification`의 탭 핸들러는 `content.data`만 읽어 `type`을 못 읽음 → `default` 분기 → 존재하지 않는 `/notification`으로 이동 → unmatched route
- 이 `trigger.payload` 폴백은 이미 `use-tracking-fcm.ts`에는 있었으나 `usePushNotification`에는 없었음
- 추가로 `navigateByType`이 미구현 라우트(`/notification`, `/profile/[actorId]`)로도 이동하고 있었음

## 🔧 변경 사항
`hooks/use-push-notification.ts`
- **`extractPushData` 헬퍼 추가** — `content.data` → 없으면 `trigger.payload` 폴백 (use-tracking-fcm와 동일 패턴). 포어그라운드 탭 리스너·콜드스타트(`getLastNotificationResponseAsync`) 모두 적용
- **`navigateByType` 방어 강화**
  - 게시글 알림: `extras.postId`가 있을 때만 `/community/free-board/[id]` 이동 (undefined 경로 차단)
  - 트래킹/하이킹 알림: `/(tabs)/tracking`
  - 대응 화면이 아직 없는 타입(`FOLLOW_RECEIVED`, `SYSTEM_*`, `WEATHER_WARNING` 등)은 **이동하지 않음** → unmatched route 방지
  - `extras` JSON 파싱 실패 안전 처리

## 📂 변경 파일
- `hooks/use-push-notification.ts`

## ✅ 체크리스트
- [x] TypeScript 타입체크 통과
- [x] Prettier 포맷 통과
- [ ] 실기기 — 백그라운드 상태에서 게시글 알림 탭 → 해당 게시글 이동
- [ ] 실기기 — 종료 상태에서 트래킹 알림 탭 → 트래킹 화면 이동
- [ ] 포어그라운드 알림 탭도 정상 이동

## 📝 참고
- `FOLLOW_RECEIVED`(프로필), `SYSTEM_*`(알림 센터) 등은 대상 화면이 아직 없어 현재는 이동하지 않도록 처리했습니다. 화면 구현 시 `navigateByType`에 라우트를 연결하면 됩니다.
- 백엔드가 `trigger.payload`에도 `type`을 넣지 않는 경우엔 여전히 이동이 안 될 수 있어, 실기기 검증 시 실제 payload 구조 확인이 필요합니다.