### PR TITLE
feat : 앱 강제 업데이트 / 점검 모드 체크 추가

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { isExpoGo } from "@/constants/platform";
 import { useAuthState } from "@/features/auth/hooks/use-auth-state";
 import { useAppState } from "@/hooks/use-app-state";
 import { useOnlineManager } from "@/hooks/use-online-manager";
+import { AppUpdateGate } from "@/features/app-update/components/app-update-gate";
 import { usePushNotification } from "@/hooks/use-push-notification";
 import { useReactQueryDevTools } from "@dev-plugins/react-query";
 import { Lexend_700Bold, useFonts } from "@expo-google-fonts/lexend";
@@ -32,7 +33,10 @@ Notifications.setNotificationHandler({
 
     // 트래킹 푸시: 포어그라운드에서 시스템 배너 차단 (in-app banner 만 노출)
     // mixed payload 로 백엔드가 notification + data 둘 다 보내므로 중복 방지
-    if (type === 'TRACKING_PHOTO_MILESTONE' || type === 'TRACKING_SUMMIT_REACHED') {
+    if (
+      type === "TRACKING_PHOTO_MILESTONE" ||
+      type === "TRACKING_SUMMIT_REACHED"
+    ) {
       return {
         shouldShowBanner: true,
         shouldShowList: true,
@@ -183,6 +187,7 @@ function RootLayout(): React.JSX.Element | null {
           </Stack>
           {authStatus === "unauthenticated" && <Redirect href="/login" />}
           <Toast />
+          <AppUpdateGate />
           <StatusBar style="dark" />
         </ThemeProvider>
       </GestureHandlerRootView>

--- a/features/app-update/components/app-update-gate.tsx
+++ b/features/app-update/components/app-update-gate.tsx
@@ -1,0 +1,118 @@
+import Constants from "expo-constants";
+import {
+  Linking,
+  Modal,
+  Platform,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useAppVersion } from "../hooks/use-app-version";
+import { compareVersion } from "../utils/compare-version";
+
+const OVERLAY_COLOR = "rgba(0,0,0,0.4)";
+
+/**
+ * 앱 버전/점검 상태를 확인해 필요 시 전체 화면을 막는 게이트.
+ * 우선순위: 점검(maintenance) > 강제 업데이트 > 없음.
+ * 강제 업데이트 조건: 현재 버전 < minimumVersion, 또는 forceUpdate && 현재 < latestVersion.
+ */
+export function AppUpdateGate() {
+  const { data } = useAppVersion();
+  const platform = Platform.OS === "ios" ? data?.ios : data?.android;
+  if (!platform) return null;
+
+  const current = Constants.expoConfig?.version ?? "1.0.0";
+
+  if (platform.maintenanceMode) {
+    return (
+      <BlockingModal
+        title="서비스 점검 중이에요"
+        message={
+          platform.maintenanceMessage ??
+          "더 나은 서비스를 위해 점검하고 있어요.\n잠시 후 다시 이용해주세요."
+        }
+      />
+    );
+  }
+
+  const belowMinimum =
+    !!platform.minimumVersion &&
+    compareVersion(current, platform.minimumVersion) < 0;
+  const forced =
+    platform.forceUpdate === true &&
+    !!platform.latestVersion &&
+    compareVersion(current, platform.latestVersion) < 0;
+
+  if (belowMinimum || forced) {
+    return (
+      <BlockingModal
+        title="업데이트가 필요해요"
+        message={
+          platform.releaseNotes ??
+          "원활한 이용을 위해 최신 버전으로 업데이트해주세요."
+        }
+        actionLabel="업데이트하기"
+        onAction={() => {
+          if (platform.storeUrl) {
+            Linking.openURL(platform.storeUrl).catch(() => {});
+          }
+        }}
+      />
+    );
+  }
+
+  return null;
+}
+
+type BlockingModalProps = {
+  title: string;
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+
+function BlockingModal({
+  title,
+  message,
+  actionLabel,
+  onAction,
+}: BlockingModalProps) {
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={() => {}}>
+      <View
+        className="flex-1 items-center justify-center px-4"
+        style={{ backgroundColor: OVERLAY_COLOR }}
+      >
+        <View
+          className="w-full bg-fill-normal"
+          style={{ maxWidth: 320, borderRadius: 16 }}
+        >
+          <View className="px-5 pb-2 pt-6">
+            <Text className="text-label-normal typo-heading-1-semi-bold">
+              {title}
+            </Text>
+          </View>
+          <View className="px-5 pb-5">
+            <Text className="text-label-subtle typo-body-1-normal-regular">
+              {message}
+            </Text>
+          </View>
+          {actionLabel && (
+            <View className="px-4 pb-4">
+              <TouchableOpacity
+                className="items-center justify-center rounded-[10px] bg-primary-normal"
+                style={{ height: 48 }}
+                onPress={onAction}
+              >
+                <Text className="text-common-100 typo-label-large">
+                  {actionLabel}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/features/app-update/hooks/use-app-version.ts
+++ b/features/app-update/hooks/use-app-version.ts
@@ -1,0 +1,26 @@
+import { api } from "@/lib/api";
+import { AppVersionResponse, ENDPOINTS } from "@/types/api.generated";
+import { useQuery } from "@tanstack/react-query";
+
+const REFETCH_INTERVAL_MS = 1000 * 60 * 30; // 30분마다 재확인
+
+/**
+ * 서버의 앱 버전/점검 정보를 주기적으로 조회한다.
+ * - 30분 간격 폴링(포어그라운드) + 앱 포어그라운드 복귀 시 재확인(refetchOnWindowFocus)
+ * - 실패/빈 응답이면 null → 게이트는 아무것도 막지 않음(fail-open)
+ */
+export function useAppVersion() {
+  return useQuery({
+    queryKey: [ENDPOINTS.APP_VERSION],
+    queryFn: async (): Promise<AppVersionResponse | null> => {
+      const res = await api.get<AppVersionResponse>({
+        path: ENDPOINTS.APP_VERSION,
+      });
+      return res.data ?? null;
+    },
+    refetchInterval: REFETCH_INTERVAL_MS,
+    refetchOnWindowFocus: true,
+    staleTime: 0,
+    retry: 1,
+  });
+}

--- a/features/app-update/utils/compare-version.ts
+++ b/features/app-update/utils/compare-version.ts
@@ -1,0 +1,15 @@
+/**
+ * semver 형식 버전 비교.
+ * a < b → -1, a === b → 0, a > b → 1. 누락된 세그먼트는 0으로 취급.
+ * 예: compareVersion("1.1", "1.2.0") === -1
+ */
+export function compareVersion(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff > 0 ? 1 : -1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## 📌 개요
백엔드 요청에 따라, 앱 실행 중 서버의 버전 정보를 주기적으로 조회해 **강제 업데이트**와 **서비스 점검**을 전체 화면 모달로 안내하는 기능을 추가합니다. 기존에 프론트에는 `/api/app-version`을 소비하는 코드가 전혀 없었습니다.

## 🔧 변경 사항
- **`useAppVersion`** (`features/app-update/hooks/use-app-version.ts`) — `GET /api/app-version`을 조회. **30분 주기 폴링 + 앱 포어그라운드 복귀 시 재조회**(refetchOnWindowFocus). 실패/빈 응답이면 아무것도 막지 않음(fail-open)
- **`compareVersion`** (`features/app-update/utils/compare-version.ts`) — semver 비교 유틸
- **`AppUpdateGate`** (`features/app-update/components/app-update-gate.tsx`) — 플랫폼별(ios/android) 서버 값과 현재 버전 비교 후 차단 모달 표시
  - `maintenanceMode` → 점검 안내 모달(전체 차단)
  - `현재 < minimumVersion` 또는 `forceUpdate && 현재 < latestVersion` → 강제 업데이트 모달(닫기 불가, "업데이트하기" → `storeUrl` 이동)
  - 우선순위: 점검 > 강제 업데이트 > 없음
- 루트 레이아웃(`app/_layout.tsx`)에 `<AppUpdateGate />` 마운트 (로그인 화면 포함 전 구간 오버레이)

## 📂 변경 파일
- `features/app-update/hooks/use-app-version.ts` (신규)
- `features/app-update/utils/compare-version.ts` (신규)
- `features/app-update/components/app-update-gate.tsx` (신규)
- `app/_layout.tsx`

## 🔌 백엔드 응답 스펙 (필요)
`GET /api/app-version` → `data.{ios|android}`:
```json
{ "latestVersion": "1.2.0", "minimumVersion": "1.1.0", "forceUpdate": true,
  "storeUrl": "https://apps.apple.com/...", "maintenanceMode": false, "maintenanceMessage": "" }