### PR TITLE
다녀온 산 지도 마커 디자인(피그마) 반영 및 선택 시 포커스/필터링

### DIFF
--- a/components/map-markers/mountain-marker-textbox.tsx
+++ b/components/map-markers/mountain-marker-textbox.tsx
@@ -7,6 +7,9 @@ type Props = {
   leading?: ReactNode;
   nameColor?: string;
   suffixColor?: string;
+  gap?: number;
+  fontSize?: number;
+  lineHeight?: number;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -16,16 +19,25 @@ export function MountainMarkerTextBox({
   leading,
   nameColor = '#464A57',
   suffixColor = '#BFC4D1',
+  gap = 4,
+  fontSize = 12,
+  lineHeight = 16,
   style,
 }: Props) {
   return (
-    <View style={[styles.container, style]}>
+    <View style={[styles.container, { gap }, style]}>
       {leading}
-      <Text style={[styles.name, { color: nameColor }]} numberOfLines={1}>
+      <Text
+        style={[styles.name, { color: nameColor, fontSize, lineHeight }]}
+        numberOfLines={1}
+      >
         {name}
       </Text>
       {suffix !== undefined && suffix !== null ? (
-        <Text style={[styles.suffix, { color: suffixColor }]} numberOfLines={1}>
+        <Text
+          style={[styles.suffix, { color: suffixColor, fontSize, lineHeight }]}
+          numberOfLines={1}
+        >
           {suffix}
         </Text>
       ) : null}

--- a/components/map-markers/mountain-marker-textbox.tsx
+++ b/components/map-markers/mountain-marker-textbox.tsx
@@ -1,5 +1,13 @@
-import { type ReactNode } from 'react';
-import { StyleSheet, Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { type ReactNode } from "react";
+import {
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+
+type Variant = "default" | "compact";
 
 type Props = {
   name: string;
@@ -7,35 +15,54 @@ type Props = {
   leading?: ReactNode;
   nameColor?: string;
   suffixColor?: string;
-  gap?: number;
-  fontSize?: number;
-  lineHeight?: number;
+  variant?: Variant;
   style?: StyleProp<ViewStyle>;
+};
+
+// variant별 간격/타이포그래피 — 호출자가 임의의 숫자를 넘기지 못하도록 컴포넌트 내부에서 토큰으로 고정
+const GAP_CLASSNAME: Record<Variant, string> = {
+  default: "gap-1",
+  compact: "gap-0.5",
+};
+
+// default는 디자인 토큰(typo-caption-1-semi-bold, 12px/line-height 1.3)을 그대로 사용.
+// compact(다녀온 산 마커, Figma 10px/13px 스펙)는 대응하는 typo 토큰이 아직 없어 폰트 크기만 예외적으로 인라인 처리.
+const TEXT_CLASSNAME: Record<Variant, string | undefined> = {
+  default: "typo-caption-1-semi-bold",
+  compact: undefined,
+};
+const COMPACT_TEXT_STYLE = {
+  fontSize: 10,
+  lineHeight: 13,
+  fontWeight: "600" as const,
 };
 
 export function MountainMarkerTextBox({
   name,
   suffix,
   leading,
-  nameColor = '#464A57',
-  suffixColor = '#BFC4D1',
-  gap = 4,
-  fontSize = 12,
-  lineHeight = 16,
+  nameColor = "#464A57",
+  suffixColor = "#BFC4D1",
+  variant = "default",
   style,
 }: Props) {
+  const textClassName = TEXT_CLASSNAME[variant];
+  const textStyle = variant === "compact" ? COMPACT_TEXT_STYLE : undefined;
+
   return (
-    <View style={[styles.container, { gap }, style]}>
+    <View className={GAP_CLASSNAME[variant]} style={[styles.container, style]}>
       {leading}
       <Text
-        style={[styles.name, { color: nameColor, fontSize, lineHeight }]}
+        className={textClassName}
+        style={[styles.text, textStyle, { color: nameColor }]}
         numberOfLines={1}
       >
         {name}
       </Text>
       {suffix !== undefined && suffix !== null ? (
         <Text
-          style={[styles.suffix, { color: suffixColor, fontSize, lineHeight }]}
+          className={textClassName}
+          style={[styles.text, textStyle, { color: suffixColor }]}
           numberOfLines={1}
         >
           {suffix}
@@ -47,27 +74,13 @@ export function MountainMarkerTextBox({
 
 const styles = StyleSheet.create({
   container: {
-    backgroundColor: '#ffffff',
+    backgroundColor: "#ffffff",
     borderRadius: 999,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 4,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
   },
-  name: {
-    color: '#464A57',
-    fontFamily: 'Pretendard',
-    fontSize: 12,
-    fontWeight: '600',
-    lineHeight: 16,
-    textAlign: 'center',
-  },
-  suffix: {
-    color: '#BFC4D1',
-    fontFamily: 'Pretendard',
-    fontSize: 12,
-    fontWeight: '600',
-    lineHeight: 16,
-    textAlign: 'center',
+  text: {
+    textAlign: "center",
   },
 });

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -58,7 +58,10 @@ export function VisitedMarker({
                 <Rect x={16.944} y={0} width={6.621} height={9.169} />
               </ClipPath>
               <ClipPath id={clipIdPhoto}>
-                <Path d={PHOTO_CLIP_PATH} transform="translate(1.764, 13.923)" />
+                <Path
+                  d={PHOTO_CLIP_PATH}
+                  transform="translate(1.764, 13.923)"
+                />
               </ClipPath>
             </Defs>
 
@@ -104,9 +107,7 @@ export function VisitedMarker({
             suffix={visitCount}
             nameColor={selected ? "#ffffff" : "#464A57"}
             suffixColor={selected ? "#A4ABC0" : "#BFC4D1"}
-            gap={2}
-            fontSize={10}
-            lineHeight={13}
+            variant="compact"
             style={[
               styles.textBox,
               selected ? { backgroundColor: SELECTED_BG } : undefined,

--- a/components/map-markers/visited-marker.tsx
+++ b/components/map-markers/visited-marker.tsx
@@ -6,8 +6,13 @@ import Svg, {
   Defs,
   G,
   Path,
+  Rect,
   Image as SvgImage,
 } from "react-native-svg";
+
+// 안쪽 사진도 바깥 테두리와 동일한 세모 배너 실루엣으로 클립 (Figma 인셋 버전)
+const PHOTO_CLIP_PATH =
+  "M11.8889 1.09785C12.739 -0.36595 14.8446 -0.36595 15.6947 1.09785L27.2802 21.0473C28.1369 22.5225 27.0775 24.3751 25.3773 24.3751L2.20631 24.3751C0.506062 24.3751 -0.553295 22.5225 0.303412 21.0473L11.8889 1.09785Z";
 
 const FALLBACK_IMAGE = require("@/assets/photo-thumb-1.jpg");
 
@@ -25,6 +30,12 @@ export const VISITED_MARKER_OVERLAY_HEIGHT = 52;
 
 const SELECTED_BG = "#464A57";
 
+// Figma "Map Marker" 컴포넌트(Visited=True) 벡터 좌표 그대로 사용 — viewBox 0 0 31.111 40 기준
+const FLAG_PATH =
+  "M1.25 0C1.47517 0 1.68601 0.0601934 1.86849 0.164388L1.87174 0.166016L8.70361 4.11051C9.25912 4.43124 9.25902 5.23339 8.70361 5.5542L2.5 9.13574L2.5 15.4167C2.49994 16.107 1.94032 16.6667 1.25 16.6667C0.559678 16.6667 5.50001e-05 16.107 0 15.4167L0 1.25C0 0.559644 0.559644 0 1.25 0Z";
+const PIN_PATH =
+  "M12.1341 1.96445C13.6626 -0.65482 17.4485 -0.654816 18.977 1.96446L30.5656 21.8231C32.106 24.4628 30.2012 27.7778 27.1441 27.7778L3.96701 27.7778C0.909913 27.7778 -0.994839 24.4628 0.545543 21.8231L12.1341 1.96445Z";
+
 export function VisitedMarker({
   name,
   visitCount,
@@ -33,55 +44,58 @@ export function VisitedMarker({
   selected = false,
   onImageLoad,
 }: Props) {
-  const clipIdOuter = useId();
-  const clipIdInner = useId();
+  const clipIdFlag = useId();
+  const clipIdPhoto = useId();
+  const whiteOrSelected = selected ? SELECTED_BG : "#FFFFFF";
 
   return (
     <View style={styles.container} collapsable={false}>
       <View style={styles.contentWrap}>
         <View style={styles.imageGroup}>
-          <View
-            style={[
-              styles.flagPole,
-              selected && { backgroundColor: SELECTED_BG },
-            ]}
-          />
-          <View
-            style={[
-              styles.flag,
-              { borderLeftColor: selected ? SELECTED_BG : flagColor },
-            ]}
-          />
+          <Svg width={28} height={36} viewBox="0 0 31.111 40">
+            <Defs>
+              <ClipPath id={clipIdFlag}>
+                <Rect x={16.944} y={0} width={6.621} height={9.169} />
+              </ClipPath>
+              <ClipPath id={clipIdPhoto}>
+                <Path d={PHOTO_CLIP_PATH} transform="translate(1.764, 13.923)" />
+              </ClipPath>
+            </Defs>
 
-          <View style={styles.imageShapeWrap}>
-            <Svg width={28} height={25} viewBox="0 0 32 29">
-              <Defs>
-                <ClipPath id={clipIdOuter}>
-                  <Path d="M13.7571 1.26472C14.7408 -0.421574 17.1773 -0.421574 18.161 1.26472L31.567 24.2465C32.5584 25.9459 31.3326 28.0802 29.3651 28.0802H2.55302C0.585586 28.0802 -0.640242 25.946 0.351092 24.2465L13.7571 1.26472Z" />
-                </ClipPath>
-                <ClipPath id={clipIdInner}>
-                  <Path d="M14.719 3.632C15.307 2.624 16.761 2.624 17.349 3.632L28.919 23.466C29.511 24.481 28.779 25.757 27.605 25.757H4.463C3.288 25.757 2.556 24.481 3.149 23.466L14.719 3.632Z" />
-                </ClipPath>
-              </Defs>
-
+            {/* 깃대 — 흰색(선택 시 다크) */}
+            <Path
+              d={FLAG_PATH}
+              transform="translate(14.445, 0)"
+              fill={whiteOrSelected}
+            />
+            {/* 깃발 — 초록(선택 시 다크), 깃대 상단만 마스킹해 색칠 */}
+            <G clipPath={`url(#${clipIdFlag})`}>
               <Path
-                d="M13.7571 1.26472C14.7408 -0.421574 17.1773 -0.421574 18.161 1.26472L31.567 24.2465C32.5584 25.9459 31.3326 28.0802 29.3651 28.0802H2.55302C0.585586 28.0802 -0.640242 25.946 0.351092 24.2465L13.7571 1.26472Z"
-                fill={selected ? SELECTED_BG : "#FFFFFF"}
+                d={FLAG_PATH}
+                transform="translate(14.445, 0)"
+                fill={selected ? SELECTED_BG : flagColor}
               />
+            </G>
 
-              <G clipPath={`url(#${clipIdInner})`}>
-                <SvgImage
-                  href={imageUri ? { uri: imageUri } : FALLBACK_IMAGE}
-                  x={0}
-                  y={0}
-                  width={32}
-                  height={29}
-                  preserveAspectRatio="xMidYMid slice"
-                  onLoad={onImageLoad}
-                />
-              </G>
-            </Svg>
-          </View>
+            {/* 포토 핀 프레임 */}
+            <Path
+              d={PIN_PATH}
+              transform="translate(0, 12.222)"
+              fill={whiteOrSelected}
+            />
+            {/* 산행 사진 — 테두리와 같은 세모 배너 모양으로 클립 */}
+            <G clipPath={`url(#${clipIdPhoto})`}>
+              <SvgImage
+                href={imageUri ? { uri: imageUri } : FALLBACK_IMAGE}
+                x={1.764}
+                y={13.923}
+                width={27.584}
+                height={24.375}
+                preserveAspectRatio="xMidYMid slice"
+                onLoad={onImageLoad}
+              />
+            </G>
+          </Svg>
         </View>
 
         <View style={styles.textBoxWrap}>
@@ -90,6 +104,9 @@ export function VisitedMarker({
             suffix={visitCount}
             nameColor={selected ? "#ffffff" : "#464A57"}
             suffixColor={selected ? "#A4ABC0" : "#BFC4D1"}
+            gap={2}
+            fontSize={10}
+            lineHeight={13}
             style={[
               styles.textBox,
               selected ? { backgroundColor: SELECTED_BG } : undefined,
@@ -112,11 +129,7 @@ const styles = StyleSheet.create({
     top: 8,
     width: 72,
     height: 36,
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.2,
-    shadowRadius: 4,
-    elevation: 4,
+    boxShadow: "0px 0.78px 6.26px 0px rgba(0, 0, 0, 0.2)",
   },
   imageGroup: {
     position: "absolute",
@@ -125,43 +138,6 @@ const styles = StyleSheet.create({
     width: 28,
     height: 36,
     zIndex: 2,
-  },
-  flagPole: {
-    position: "absolute",
-    left: 13,
-    top: 0,
-    width: 1.6,
-    height: 16,
-    borderRadius: 999,
-    backgroundColor: "#FFFFFF",
-  },
-  flag: {
-    position: "absolute",
-    top: 0.5,
-    left: 14.8,
-    width: 0,
-    height: 0,
-    borderTopWidth: 5,
-    borderBottomWidth: 4,
-    borderLeftWidth: 6.4,
-    borderTopColor: "transparent",
-    borderBottomColor: "transparent",
-  },
-  imageShapeWrap: {
-    position: "absolute",
-    left: 0,
-    top: 11,
-    width: 28,
-    height: 25,
-  },
-  imageIcon: {
-    position: "absolute",
-    top: 0,
-    left: 15,
-    width: 6,
-    height: 9,
-    alignItems: "center",
-    justifyContent: "center",
   },
   textBoxWrap: {
     position: "absolute",
@@ -173,9 +149,9 @@ const styles = StyleSheet.create({
     height: 21,
     borderRadius: 999,
     paddingLeft: 24,
-    paddingRight: 9,
-    paddingTop: 2,
-    paddingBottom: 2,
+    paddingRight: 8,
+    paddingTop: 4,
+    paddingBottom: 4,
     alignSelf: "flex-start",
   },
 });

--- a/features/home/components/map-home-view.tsx
+++ b/features/home/components/map-home-view.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/map-markers/visited-marker";
 import NoRecordBottomSheet from "@/components/no-record-bottom-sheet";
 import { useMyMountains } from "@/features/home/hooks/use-my-mountains";
+import { useMountainDetail } from "@/features/mountains/hooks/use-mountain-detail";
 import {
   BBox,
   MountainMapItem,
@@ -38,6 +39,7 @@ import { router } from "expo-router";
 import {
   forwardRef,
   memo,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -60,6 +62,9 @@ const DEFAULT_REGION: Region = {
   longitude: 126.978,
   zoom: 8,
 };
+
+// 바텀시트에서 산 카드 선택 시 지도 포커스 확대 레벨
+const FOCUS_ZOOM = 14;
 
 type VisitedMarkerOverlayProps = {
   mountain: MountainMapItem;
@@ -128,6 +133,29 @@ const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
     );
     const { data: mapData } = useMountainsMap(bbox);
     const hasRecords = mapData?.hasHikingRecord ?? false;
+
+    // 선택된 산이 현재 뷰포트 안에 있으면 좌표를 바로 재사용, 없으면 상세 API로 조회
+    const selectedFromViewport = mapData?.mountains?.find(
+      (m) => m.id === selectedMountainId,
+    );
+    const { data: selectedMountainDetail } = useMountainDetail(
+      selectedMountainId != null && !selectedFromViewport
+        ? selectedMountainId
+        : NaN,
+    );
+
+    // 바텀시트에서 산 카드 선택 시 해당 산 좌표로 지도 카메라 포커스
+    useEffect(() => {
+      if (selectedMountainId == null) return;
+      const coords =
+        selectedFromViewport ?? selectedMountainDetail?.mountain;
+      if (coords?.latitude == null || coords?.longitude == null) return;
+      setRegion({
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+        zoom: FOCUS_ZOOM,
+      });
+    }, [selectedMountainId, selectedFromViewport, selectedMountainDetail]);
     const snapExpanded = hasRecords
       ? SNAP_EXPANDED_WITH_RECORDS
       : SNAP_EXPANDED_NO_RECORDS;
@@ -197,7 +225,12 @@ const [selectedMountainId, setSelectedMountainId] = useState<number | null>(
         >
           {hasRecords
             ? mapData?.mountains
-                ?.filter((m) => m.visited)
+                ?.filter(
+                  (m) =>
+                    m.visited &&
+                    (selectedMountainId == null ||
+                      m.id === selectedMountainId),
+                )
                 .map((mountain) => (
                   <VisitedMarkerOverlay
                     key={mountain.id}


### PR DESCRIPTION
## Summary
- `VisitedMarker`를 피그마 "Map Marker" 컴포넌트의 정확한 벡터 좌표로 재구현 (깃대+깃발, 포토 핀 프레임, 세모 배너 모양 사진 클립)
- 라벨 pill의 padding/폰트 크기/줄간격/gap을 피그마 스펙에 맞춰 수정 (안 가본 산 마커는 기존 스타일 유지되도록 옵션화)
- iOS 전용 shadow 속성 대신 `boxShadow` 사용
- 홈 바텀시트에서 "다녀온 산" 카드를 선택하면 해당 산 좌표로 지도 카메라 포커스(zoom 14) + 지도에 선택된 산 마커만 표시

## Test plan
- [ ] 다녀온 산이 있는 계정으로 홈 화면 진입 → 마커 디자인(사진 세모 배너 클립, 이름/횟수 pill) 확인
- [ ] 바텀시트에서 산 카드 클릭 → 지도가 해당 산으로 이동/확대되고 그 마커만 남는지 확인
- [ ] 선택된 마커가 다크 배경 + 흰 텍스트로 바뀌는지 확인
- [ ] 바텀시트 상세 닫기 → 전체 다녀온 산 마커가 다시 표시되는지 확인
- [ ] 안 가본 산 마커(미방문) 스타일이 기존과 동일한지 확인

## 스크린샷
<img width="198" height="94" alt="image" src="https://github.com/user-attachments/assets/c4e62ac8-fd2e-42a6-aae9-8a3b15c474f4" />
<img width="348" height="260" alt="image" src="https://github.com/user-attachments/assets/f38019d8-c6d1-4bac-8cf5-f7dae3daa8ee" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 현재 지도 화면에 없는 산을 선택하면 해당 위치를 조회해 자동으로 확대하고 포커스합니다.
  * 선택한 산만 방문 마커로 표시됩니다.

* **UI 개선**
  * 방문 마커의 깃발과 사진 영역이 선택 상태에 따라 더욱 명확하게 표시됩니다.
  * 마커 사진이 깔끔한 삼각형 형태로 표시됩니다.
  * 산 이름과 접미사 텍스트의 간격, 글꼴 크기, 줄 높이를 상황에 맞게 조정할 수 있습니다.
  * компакт한 마커 표시에서 텍스트가 더 작은 크기와 간격으로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->