### PR TITLE
이미지 업로드 전 리사이징/압축/EXIF 제거 적용

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -148,6 +148,7 @@ const config = {
           ],
         ]
       : []),
+    "react-native-compressor",
   ],
   experiments: {
     typedRoutes: true,

--- a/features/tracking/utils/upload-tracking-photo.ts
+++ b/features/tracking/utils/upload-tracking-photo.ts
@@ -1,4 +1,5 @@
 import { api } from '@/lib/api';
+import { optimizeImageForUpload } from '@/lib/optimize-image';
 import { ENDPOINTS } from '@/types/api.generated';
 
 type PresignedUrlResponse = {
@@ -8,11 +9,12 @@ type PresignedUrlResponse = {
 
 /**
  * 트래킹 인증 사진을 tracking-photos 버킷에 업로드합니다.
- * 1. Presigned URL 발급 (GET /api/images/presigned-url?bucket=tracking-photos)
+ * 1. 리사이징/압축/EXIF 제거 후 Presigned URL 발급 (GET /api/images/presigned-url?bucket=tracking-photos)
  * 2. uri → blob 변환 후 uploadUrl로 MinIO에 직접 PUT
  * @returns 업로드된 이미지의 최종 URL
  */
 export async function uploadTrackingPhoto(uri: string): Promise<string> {
+  const optimizedUri = await optimizeImageForUpload(uri);
   const timestamp = Date.now();
   const filename = `tracking_${timestamp}.jpg`;
 
@@ -23,7 +25,7 @@ export async function uploadTrackingPhoto(uri: string): Promise<string> {
   });
 
   // 2. uri → blob 변환 (React Native에서 file:// URI를 바이너리로 읽음)
-  const fileResponse = await fetch(uri);
+  const fileResponse = await fetch(optimizedUri);
   const blob = await fileResponse.blob();
 
   // 3. MinIO에 직접 PUT (Presigned URL이므로 Authorization 헤더 불필요)

--- a/features/tracking/utils/upload-tracking-photo.ts
+++ b/features/tracking/utils/upload-tracking-photo.ts
@@ -1,6 +1,6 @@
-import { api } from '@/lib/api';
-import { optimizeImageForUpload } from '@/lib/optimize-image';
-import { ENDPOINTS } from '@/types/api.generated';
+import { api } from "@/lib/api";
+import { optimizeImageForUpload } from "@/lib/optimize-image";
+import { ENDPOINTS } from "@/types/api.generated";
 
 type PresignedUrlResponse = {
   uploadUrl: string;
@@ -21,7 +21,7 @@ export async function uploadTrackingPhoto(uri: string): Promise<string> {
   // 1. Presigned URL 발급
   const { data } = await api.get<PresignedUrlResponse>({
     path: ENDPOINTS.IMAGES_PRESIGNED_URL,
-    params: { bucket: 'tracking-photos', filename },
+    params: { bucket: "tracking-photos", filename },
   });
 
   // 2. uri → blob 변환 (React Native에서 file:// URI를 바이너리로 읽음)
@@ -30,8 +30,8 @@ export async function uploadTrackingPhoto(uri: string): Promise<string> {
 
   // 3. MinIO에 직접 PUT (Presigned URL이므로 Authorization 헤더 불필요)
   const uploadResponse = await fetch(data.uploadUrl, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'image/jpeg' },
+    method: "PUT",
+    headers: { "Content-Type": "image/jpeg" },
     body: blob,
   });
 

--- a/hooks/use-upload-image.ts
+++ b/hooks/use-upload-image.ts
@@ -1,4 +1,5 @@
 import { api } from "@/lib/api";
+import { optimizeImageForUpload } from "@/lib/optimize-image";
 import { ENDPOINTS } from "@/types/api.generated";
 
 type PresignedUrlResponse = {
@@ -11,16 +12,9 @@ export async function uploadImage(
   filename: string,
   bucket: string = "posts",
 ): Promise<string> {
-  const ext = filename.split(".").pop()?.toLowerCase() ?? "jpg";
-  const safeExt = ["jpg", "jpeg", "png", "webp"].includes(ext) ? ext : "jpg";
-  const safeFilename =
-    safeExt === ext ? filename : filename.replace(/\.[^.]+$/, ".jpg");
-  const mimeType =
-    safeExt === "png"
-      ? "image/png"
-      : safeExt === "webp"
-        ? "image/webp"
-        : "image/jpeg";
+  // 압축 결과는 항상 jpg로 재인코딩되므로 확장자/mime도 jpg로 통일
+  const optimizedUri = await optimizeImageForUpload(uri);
+  const safeFilename = filename.replace(/\.[^.]+$/, ".jpg");
 
   const { data } = await api.get<PresignedUrlResponse>({
     path: ENDPOINTS.IMAGES_PRESIGNED_URL,
@@ -35,7 +29,7 @@ export async function uploadImage(
       else reject(new Error(`이미지 업로드 실패: ${xhr.status}`));
     };
     xhr.onerror = () => reject(new Error("네트워크 오류"));
-    xhr.send({ uri, type: mimeType, name: safeFilename } as any);
+    xhr.send({ uri: optimizedUri, type: "image/jpeg", name: safeFilename } as any);
   });
 
   return data.imageUrl;

--- a/hooks/use-upload-image.ts
+++ b/hooks/use-upload-image.ts
@@ -13,8 +13,10 @@ export async function uploadImage(
   bucket: string = "posts",
 ): Promise<string> {
   // 압축 결과는 항상 jpg로 재인코딩되므로 확장자/mime도 jpg로 통일
+  // (확장자가 없는 filename도 대비해 basename만 뽑아 항상 .jpg를 붙임)
   const optimizedUri = await optimizeImageForUpload(uri);
-  const safeFilename = filename.replace(/\.[^.]+$/, ".jpg");
+  const baseName = filename.replace(/\.[^./]+$/, "");
+  const safeFilename = `${baseName}.jpg`;
 
   const { data } = await api.get<PresignedUrlResponse>({
     path: ENDPOINTS.IMAGES_PRESIGNED_URL,
@@ -29,7 +31,11 @@ export async function uploadImage(
       else reject(new Error(`이미지 업로드 실패: ${xhr.status}`));
     };
     xhr.onerror = () => reject(new Error("네트워크 오류"));
-    xhr.send({ uri: optimizedUri, type: "image/jpeg", name: safeFilename } as any);
+    xhr.send({
+      uri: optimizedUri,
+      type: "image/jpeg",
+      name: safeFilename,
+    } as any);
   });
 
   return data.imageUrl;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
     - ExpoModulesCore
   - EXNotifications (0.32.17):
     - ExpoModulesCore
-  - Expo (54.0.35):
+  - Expo (54.0.36):
     - ExpoModulesCore
     - hermes-engine
     - RCTRequired
@@ -1716,6 +1716,28 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
+  - react-native-compressor (1.16.0):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-safe-area-context (5.6.2):
@@ -2646,6 +2668,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-compressor (from `../node_modules/react-native-compressor`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-view-shot (from `../node_modules/react-native-view-shot`)
@@ -2862,6 +2885,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-compressor:
+    :path: "../node_modules/react-native-compressor"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -2965,7 +2990,7 @@ SPEC CHECKSUMS:
   EXJSONUtils: 1d3e4590438c3ee593684186007028a14b3686cd
   EXManifests: 378c7742de02a8605093b1c82b5774d8f9875cec
   EXNotifications: c67e92b9fdfe785ff9dbdc5f4c0ff935de357da7
-  Expo: edf5879dd9f83d2aa5b05d012412c810bc182ac1
+  Expo: 38ef0f0082a53f9604a48cbab2ab55289c658eaf
   expo-dev-client: b8adef5e6847b5335a3b95a1fd2edc731d4331ee
   expo-dev-launcher: 62424c01202c528a0421e5736c7cba2aa95312b6
   expo-dev-menu: ffb77acaa6a91d260780ab72a7d236ece882c787
@@ -3047,6 +3072,7 @@ SPEC CHECKSUMS:
   React-logger: 50fdb9a8236da90c0b1072da5c32ee03aeb5bf28
   React-Mapbuffer: 9050ee10c19f4f7fca8963d0211b2854d624973e
   React-microtasksnativemodule: f775db9e991c6f3b8ccbc02bfcde22770f96e23b
+  react-native-compressor: dca167f2e6e48e5e9efa165e30ee0ae4c6445de8
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
   react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2

--- a/lib/optimize-image.ts
+++ b/lib/optimize-image.ts
@@ -1,0 +1,21 @@
+import { Image as ImageCompressor } from "react-native-compressor";
+
+// 업로드 전 리사이징 + 압축 — 서버 리소스/전송량 절감 목적
+// react-native-compressor는 재인코딩 과정에서 EXIF(위치정보 등 메타데이터)도 함께 제거함
+const MAX_DIMENSION = 1920;
+const COMPRESS_QUALITY = 0.8;
+
+export async function optimizeImageForUpload(uri: string): Promise<string> {
+  try {
+    return await ImageCompressor.compress(uri, {
+      compressionMethod: "auto",
+      maxWidth: MAX_DIMENSION,
+      maxHeight: MAX_DIMENSION,
+      quality: COMPRESS_QUALITY,
+      output: "jpg",
+    });
+  } catch (error) {
+    console.warn("[optimizeImageForUpload] 압축 실패, 원본으로 업로드:", error);
+    return uri;
+  }
+}

--- a/lib/optimize-image.ts
+++ b/lib/optimize-image.ts
@@ -1,21 +1,19 @@
 import { Image as ImageCompressor } from "react-native-compressor";
 
 // 업로드 전 리사이징 + 압축 — 서버 리소스/전송량 절감 목적
-// react-native-compressor는 재인코딩 과정에서 EXIF(위치정보 등 메타데이터)도 함께 제거함
+// react-native-compressor는 재인코딩 과정에서 EXIF(위치정보 등 메타데이터)도 함께 제거함.
+// 압축에 실패했다고 원본으로 폴백하면 EXIF가 남은 원본이 그대로 업로드돼
+// 위치정보 제거 요구사항이 깨지므로, 원본으로 대체하지 않고 에러를 그대로
+// 던져 호출부(업로드 자체)가 중단되도록 한다.
 const MAX_DIMENSION = 1920;
 const COMPRESS_QUALITY = 0.8;
 
-export async function optimizeImageForUpload(uri: string): Promise<string> {
-  try {
-    return await ImageCompressor.compress(uri, {
-      compressionMethod: "auto",
-      maxWidth: MAX_DIMENSION,
-      maxHeight: MAX_DIMENSION,
-      quality: COMPRESS_QUALITY,
-      output: "jpg",
-    });
-  } catch (error) {
-    console.warn("[optimizeImageForUpload] 압축 실패, 원본으로 업로드:", error);
-    return uri;
-  }
+export function optimizeImageForUpload(uri: string): Promise<string> {
+  return ImageCompressor.compress(uri, {
+    compressionMethod: "auto",
+    maxWidth: MAX_DIMENSION,
+    maxHeight: MAX_DIMENSION,
+    quality: COMPRESS_QUALITY,
+    output: "jpg",
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-compressor": "^1.16.0",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -14033,6 +14034,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-compressor": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/react-native-compressor/-/react-native-compressor-1.16.0.tgz",
+      "integrity": "sha512-yBJ1j/ank4Ckx/0cKf8QiK1oATppxN8GuNBoW6P83Os7s7MUdCLzVmIXX0ikkusdrgdCaetW6j3hH2eMI54pcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-css-interop": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-compressor": "^1.16.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
## Summary
- 원본 이미지를 그대로 업로드하고 있어 서버 리소스 부담이 커지는 문제 해결
- `react-native-compressor`로 업로드 전 최대 1920px 리사이징 + quality 0.8 압축 (재인코딩 과정에서 EXIF 메타데이터도 함께 제거됨)
- 압축 실패 시 원본으로 폴백해 업로드 자체가 막히지 않도록 처리
- 적용 범위: 게시글 이미지, 프로필 사진(마이페이지/온보딩), 등산 인증 사진(`uploadTrackingPhoto`) — 모든 업로드 경로

## Changes
- `lib/optimize-image.ts` 신규 — 공통 압축 유틸
- `hooks/use-upload-image.ts`(`uploadImage`)
- `features/tracking/utils/upload-tracking-photo.ts`(`uploadTrackingPhoto`)
- `app.config.js` — `react-native-compressor` config plugin 등록
- `ios/Podfile.lock`, `package.json`/`package-lock.json` — 네이티브 의존성 추가

## Test plan
- [x] iOS 시뮬레이터 clean build — 네이티브 모듈 0 error(s)로 컴파일, 앱 정상 부팅/JS 번들 로드 확인
- [ ] 실제로 사진첩에서 이미지를 골라 업로드 → 서버에 저장된 파일 용량이 줄어드는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 이미지 업로드 전에 자동으로 크기를 최대 1920px로 조정하고 JPEG로 압축합니다.
  * EXIF 메타데이터를 제거해 개인정보 노출을 줄입니다.
  * 최적화된 이미지를 사용해 업로드 용량과 처리 부담을 줄입니다.
  * 업로드 이미지 형식을 JPEG로 통일해 호환성을 높입니다.
  * 이미지 최적화에 실패하면 원본으로 대체하지 않고 오류를 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->