### PR TITLE
chore: eas submit용 ascAppId 설정 추가

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -10,7 +10,7 @@ const hasKakaoNativeAppKey = !!process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY;
 const config = {
   name: "semosan",
   slug: "semosan",
-  version: "1.1",
+  version: "1.1.1",
   orientation: "portrait",
   icon: "./assets/images/app-icon.png",
   scheme: "semosan",

--- a/eas.json
+++ b/eas.json
@@ -35,6 +35,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6770389449"
+      }
+    }
   }
 }

--- a/ios/semosan.xcodeproj/project.pbxproj
+++ b/ios/semosan.xcodeproj/project.pbxproj
@@ -534,7 +534,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
## Summary
- `eas submit --non-interactive` 실행 시 `ascAppId`가 없어서 실패하던 문제 수정
- App Store Connect 앱 ID(`6770389449`)는 공개 정보 (앱스토어 URL `apps.apple.com/.../id6770389449`에도 그대로 노출됨) — 민감 정보 아님

## Test plan
- [x] 이 설정으로 실제 `eas submit --platform ios --latest --non-interactive` 실행해 App Store Connect 업로드 성공 확인함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **배포 설정**
  * iOS App Store 제출을 위한 앱 식별자 설정이 추가되었습니다.
  * production 빌드의 App Store 제출 구성이 업데이트되었습니다.
* **개선 사항**
  * 앱 버전이 1.1.1로 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->