### PR TITLE
fix: 클라이브/포토리포트 카드 저장 시 모서리 흰색 채움 문제 수정

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -495,7 +495,7 @@ export default function RecordScreen() {
           <View className="pb-10 pt-2">
             <ViewShot
               ref={cliveShotRef}
-              options={{ format: "jpg", quality: 1 }}
+              options={{ format: "png", quality: 1 }}
               style={{ width: 335, alignSelf: "center" }}
             >
               <View style={styles.cardWrap}>
@@ -714,7 +714,7 @@ export default function RecordScreen() {
             <View style={{ width: 335, alignSelf: "center" }}>
               <ViewShot
                 ref={photoReportShotRef}
-                options={{ format: "jpg", quality: 1 }}
+                options={{ format: "png", quality: 1 }}
               >
                 <View style={styles.cardWrap}>
                   {/* 배경 사진 */}

--- a/ios/semosan/Info.plist
+++ b/ios/semosan/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.1</string>
+    <string>$(MARKETING_VERSION)</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>


### PR DESCRIPTION
## Summary
- 클라이브/포토리포트 카드를 카메라 롤에 저장할 때 화면과 달리 모서리가 둥글게 잘리지 않고 흰색 사각형으로 채워지던 문제 수정
- `ViewShot` 캡처 포맷을 `jpg` → `png`로 변경 (JPEG은 알파 채널이 없어 `overflow:hidden` + `borderRadius`로 투명해야 할 모서리가 저장 시 흰색으로 채워짐)

## Test plan
- [ ] 클라이브 탭에서 카드 저장 → 카메라 롤에서 모서리가 둥글게 잘려 저장되는지 확인
- [ ] 포토 리포트 탭에서 카드 저장 → 카메라 롤에서 모서리가 둥글게 잘려 저장되는지 확인
- [ ] 세모피드 업로드(공개 전환)는 기존과 동일하게 정상 동작하는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 클라이브 및 포토 리포트 카드 캡처 이미지 형식을 JPG에서 PNG로 변경했습니다.
  * 이미지 품질 설정은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->