### PR TITLE
feat : 강제 종료 후 재진입 시 자유기록 이동 경로 복원

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -370,8 +370,15 @@ export default function TrackingScreen() {
       );
       // 강제 종료 후 재진입 시 저장된 이동 경로(회색 polyline) 복원 — 자유기록
       if (activeSession.isFreeRecording) {
-        fetchSessionTrack(activeSession.sessionId).then((saved) => {
-          if (!isMountedRef.current || saved.length === 0) return;
+        // 요청 시점의 세션 ID를 캡처 — 응답 지연 중 다른 세션으로 바뀌면 폐기
+        const restoringSessionId = activeSession.sessionId;
+        fetchSessionTrack(restoringSessionId).then((saved) => {
+          if (
+            !isMountedRef.current ||
+            sessionIdRef.current !== restoringSessionId ||
+            saved.length === 0
+          )
+            return;
           // fetch 지연 중 도착한 신규 좌표는 뒤에 유지
           setRecordedCoords((prev) =>
             prev.length ? [...saved, ...prev] : saved,

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -47,6 +47,7 @@ import {
   parseCoursePolyline,
   smoothCourseCoords,
 } from "@/features/tracking/utils/parse-course-polyline";
+import { fetchSessionTrack } from "@/features/tracking/utils/fetch-session-track";
 import { uploadTrackingPhoto } from "@/features/tracking/utils/upload-tracking-photo";
 import { useAppState } from "@/hooks/use-app-state";
 import { toast } from "@/store/toast.store";
@@ -367,6 +368,16 @@ export default function TrackingScreen() {
       startLocationTask().catch((err) =>
         console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
       );
+      // 강제 종료 후 재진입 시 저장된 이동 경로(회색 polyline) 복원 — 자유기록
+      if (activeSession.isFreeRecording) {
+        fetchSessionTrack(activeSession.sessionId).then((saved) => {
+          if (!isMountedRef.current || saved.length === 0) return;
+          // fetch 지연 중 도착한 신규 좌표는 뒤에 유지
+          setRecordedCoords((prev) =>
+            prev.length ? [...saved, ...prev] : saved,
+          );
+        });
+      }
       // 강제 종료 후 재진입 시 경과 시간을 서버 기준으로 복원 (0으로 초기화 방지)
       // 등산 시간 = (기준 시각 - 시작 시각) - 누적 일시정지 시간
       //   IN_PROGRESS: 기준 시각 = 현재, PAUSED: 기준 시각 = 일시정지 시각(시간 정지)

--- a/features/tracking/utils/fetch-session-track.ts
+++ b/features/tracking/utils/fetch-session-track.ts
@@ -1,0 +1,43 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS, TrackingSessionTrackResponse } from "@/types/api.generated";
+
+export type LatLng = { latitude: number; longitude: number };
+
+/**
+ * GeoJSON LineString 문자열을 좌표 배열로 파싱.
+ * GeoJSON 좌표 순서는 [경도, 위도]이므로 뒤집어서 매핑한다.
+ */
+export function parseGeoJsonTrack(track?: string): LatLng[] {
+  if (!track) return [];
+  try {
+    const geo = JSON.parse(track) as { coordinates?: [number, number][] };
+    const coords = geo.coordinates ?? [];
+    return coords
+      .filter(
+        (c): c is [number, number] =>
+          Array.isArray(c) &&
+          c.length >= 2 &&
+          typeof c[0] === "number" &&
+          typeof c[1] === "number",
+      )
+      .map(([lng, lat]) => ({ latitude: lat, longitude: lng }));
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * 세션의 저장된 이동 경로를 서버에서 조회해 좌표 배열로 반환한다.
+ * 앱 재실행/강제 종료 후 지도에 경로를 다시 그릴 때 사용.
+ * 저장 점이 없거나(0~1개) 실패(403/404 등) 시 빈 배열(fail-open).
+ */
+export async function fetchSessionTrack(sessionId: number): Promise<LatLng[]> {
+  try {
+    const res = await api.get<TrackingSessionTrackResponse>({
+      path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_TRACK(sessionId),
+    });
+    return parseGeoJsonTrack(res.data?.track);
+  } catch {
+    return [];
+  }
+}

--- a/types/api.generated.ts
+++ b/types/api.generated.ts
@@ -10,6 +10,7 @@ export const ENDPOINTS = {
   USERS_ONBOARDING: "/api/users/onboarding",
   TRACKING_SESSIONS: "/api/tracking/sessions",
   TRACKING_SESSIONS_BY_SESSIONID_RESUME: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/resume`,
+  TRACKING_SESSIONS_BY_SESSIONID_TRACK: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/track`,
   TRACKING_SESSIONS_BY_SESSIONID_PHOTOS: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/photos`,
   TRACKING_SESSIONS_BY_SESSIONID_PAUSE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/pause`,
   TRACKING_SESSIONS_BY_SESSIONID_COMPLETE: (sessionId: number | string) => `/api/tracking/sessions/${sessionId}/complete`,
@@ -143,6 +144,11 @@ export type ApiResponseTrackingSessionResponse = {
   code?: string;
   message?: string;
   data?: TrackingSessionResponse;
+};
+export type TrackingSessionTrackResponse = {
+  sessionId?: number;
+  track?: string;
+  altitudes?: string;
 };
 export type TrackingSessionResponse = {
   sessionId?: number;


### PR DESCRIPTION
##  개요
자유기록 진행 중 앱을 강제 종료했다가 다시 켜면 회색 이동 경로가 사라지고 새로 시작되던 문제를, 서버에 저장된 경로를 다시 불러와 복원하도록 수정합니다. 백엔드에 추가된 `GET /api/tracking/sessions/{sessionId}/track`(GeoJSON LineString)을 연동합니다.

##  배경
- 자유기록 경로(`recordedCoords`)는 앱 메모리에만 있어 강제 종료 시 소실 → 재진입 시 빈 경로 + 출발 마커가 새로 찍힘
- 서버는 GPS 점을 저장하고 있었고, 이번에 조회 API(`/track`)가 추가됨

## 변경 사항
- **`types/api.generated.ts`** — `TRACKING_SESSIONS_BY_SESSIONID_TRACK` 엔드포인트 + `TrackingSessionTrackResponse` 타입 최소 추가 (전체 재생성은 무관한 드리프트·타입에러 유발이라 2줄만)
- **`features/tracking/utils/fetch-session-track.ts` (신규)** — `/track` 호출 → GeoJSON LineString 파싱
  - GeoJSON 좌표 순서 `[경도, 위도]` → `{latitude, longitude}` 로 뒤집어 매핑
  - 저장 점 없음(0~1개)·403/404·깨진 JSON 등은 빈 배열(fail-open)
- **`app/(tabs)/tracking.tsx`** — 세션 복원 이펙트에서 **자유기록 세션**이면 저장된 경로를 조회해 회색 polyline(`recordedCoords`) 복원. fetch 지연 중 새로 도착한 GPS 좌표는 뒤에 유지하도록 병합

## 동작
강제 종료 → 재진입 → 진행 중 자유기록 세션 복원 시 서버에 저장된 지금까지의 이동 경로를 다시 그림 → 회색 경로가 이어짐(출발 마커도 실제 시작점 유지)

## 📂 변경 파일
- `types/api.generated.ts`
- `features/tracking/utils/fetch-session-track.ts` (신규)
- `app/(tabs)/tracking.tsx`

## ✅ 체크리스트
- [x] TypeScript 타입체크 통과 (관련 파일)
- [x] Prettier 포맷 통과
- [x] 파싱 로직 단위 테스트 6/6 통과 (좌표 순서·빈/깨진 응답 처리)
- [ ] 실기기 — 자유기록 중 강제 종료 후 재진입 시 회색 경로 복원 확인
- [ ] 경로 방향/좌표가 뒤바뀌지 않는지 확인 (GeoJSON lng/lat 순서)

## 📝 참고
- `altitudes`(고도 배열)는 경로 그리기엔 불필요해 이번엔 사용하지 않았습니다. 고도 그래프 등에 필요하면 추가 연동 가능.
- typecheck 시 `react-native-compressor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 활성 이동 기록 세션을 다시 열 때, 이전에 저장된 이동 경로를 자동으로 복원합니다.
  * 복원된 경로는 현재 새로 기록되는 위치 정보와 자연스럽게 이어집니다.

* **버그 수정**
  * 저장된 경로가 없거나 손상된 경우에도 기록 화면이 중단되지 않고 정상적으로 시작됩니다.
  * 경로 조회에 실패해도 현재 위치 기록을 계속 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->