### PR TITLE
fix: 근처 산 조회 좌표를 트래킹 탭 진입 시 1회로 고정

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -180,12 +180,18 @@ export default function TrackingScreen() {
     top: number;
     height: number;
   } | null>(null);
-  // 사용자 현재 위치 — useNearbyMountain API용 (실제 GPS에서만 업데이트)
+  // 사용자 현재 위치 — 코스 진행률/고도 계산용 (실제 GPS에서만 업데이트)
 
   const [userLocation, setUserLocation] = useState<{
     latitude: number;
     longitude: number;
     altitude: number | null;
+  } | null>(null);
+  // 근처 산 조회(useNearbyMountain) 전용 좌표 — 진입 시 1회만 설정
+  // 트래킹 중 GPS 틱마다 좌표가 바뀌면 쿼리 키가 매번 달라져 API가 반복 호출됨
+  const [nearbyQueryCoord, setNearbyQueryCoord] = useState<{
+    lat: number;
+    lng: number;
   } | null>(null);
   // 현재 위치 마커 전용 — 시뮬/GPS 둘 다 업데이트 (잦은 리렌더 격리)
   const [markerCoord, setMarkerCoord] = useState<{
@@ -235,6 +241,10 @@ export default function TrackingScreen() {
           longitude: loc.coords.longitude,
           altitude: loc.coords.altitude,
         });
+        setNearbyQueryCoord({
+          lat: loc.coords.latitude,
+          lng: loc.coords.longitude,
+        });
         setMarkerCoord({
           latitude: loc.coords.latitude,
           longitude: loc.coords.longitude,
@@ -246,8 +256,8 @@ export default function TrackingScreen() {
   }, []);
 
   const { data: nearbyData, isLoading: isNearbyLoading } = useNearbyMountain({
-    lat: userLocation?.latitude ?? null,
-    lng: userLocation?.longitude ?? null,
+    lat: nearbyQueryCoord?.lat ?? null,
+    lng: nearbyQueryCoord?.lng ?? null,
   });
 
   const handlePhotoWindow = useCallback((payload: PhotoWindowPayload) => {

--- a/features/tracking/hooks/use-nearby-mountain.ts
+++ b/features/tracking/hooks/use-nearby-mountain.ts
@@ -18,6 +18,10 @@ export function useNearbyMountain({ lat, lng }: Params) {
       return res.data;
     },
     enabled: lat !== null && lng !== null,
-    staleTime: 1000 * 60 * 5, // 5분
+    // 좌표가 트래킹 탭 진입 시 1회만 설정되므로 재조회해도 같은 결과 — 세션당 1회 조회 정책
+    // (refetchOnReconnect는 기본값 유지: 최초 조회가 실패한 경우 네트워크 복구 시 재시도 필요)
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
Closes #165

## 변경 내용

트래킹 중 `/tracking/nearby-mountain` API가 GPS 수신(약 2초)마다 호출되던 문제를 수정했습니다.

- `useNearbyMountain`에 넘기던 좌표를 `userLocation`(GPS 틱마다 갱신) 대신 새 상태 `nearbyQueryCoord`로 분리
- `nearbyQueryCoord`는 트래킹 탭 진입 시 최초 위치 확인(`getCurrentPositionAsync`)에서 **1회만 설정** → 쿼리 키가 고정되어 세션당 1회 조회
- `userLocation`은 코스 진행률/고도 계산 등 기존 용도로 그대로 유지

## 동작 변화

| | 이전 | 이후 |
|---|---|---|
| 트래킹 전 | 진입 시 1회 조회 | 동일 (진입 시 1회) |
| 트래킹 중 | GPS 틱마다 재조회 (시간당 ~1,800회) | 추가 조회 없음 |

트래킹 전에는 `userLocation`이 최초 1회만 설정되므로(watch는 트래킹 중에만 동작) 기존 동작과 완전히 동일하고, 트래킹 중의 불필요한 재조회만 제거됩니다.

## 검증

- `npx tsc --noEmit` 통과
- `npx eslint app/(tabs)/tracking.tsx` — 신규 경고/에러 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * GPS 위치가 업데이트되어도 주변 산 검색 결과가 불필요하게 변경되지 않도록 개선했습니다.
  * 초기 위치를 기준으로 주변 산을 조회하면서, 이동 경로 진행률은 최신 위치를 사용하도록 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 시뮬레이터 검증 (iPhone 17 Pro, dev client + 위치 시뮬레이션)

`queryFn`에 임시 카운트 로그를 심고 관악산 인근 이동 경로를 시뮬레이션하며 Metro 로그로 요청 횟수를 측정:

| 시나리오 | nearby-mountain 요청 | 결과 |
|---|---|---|
| 트래킹 탭 진입 | 1회 | ✅ |
| 트래킹 중 GPS 이동 (2초 간격 tick 누적) | 추가 0회 | ✅ |
| 백그라운드 → 포어그라운드 복귀 | 추가 0회 (`staleTime: Infinity` 반영분 포함) | ✅ |

수정 전 코드라면 GPS tick마다 요청이 발생했을 조건에서 fetch는 최초 1회로 고정됨을 확인.
