### PR TITLE
fix: 포어그라운드/백그라운드 GPS 스트림 배타 제어 및 소켓 전송 throttle

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -67,6 +67,7 @@ import * as Location from "expo-location";
 import { Tabs, useLocalSearchParams } from "expo-router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
+  AppState,
   LayoutChangeEvent,
   Linking,
   StyleSheet,
@@ -102,6 +103,9 @@ const MIN_SEGMENT_COORDS = 8;
 const MAX_LOCATION_ACCURACY_M = 30; // 정확도(m)가 이보다 나쁘면서 크게 튄 좌표는 버림
 const MIN_JUMP_M = 20; // 이보다 작은 이동은 속도 판정에서 제외 (정지 시 노이즈)
 const MAX_SPEED_MPS = 30; // 이보다 빠른 이동(≈108km/h)은 비현실적 → 튐 좌표로 간주
+
+// 소켓 GPS 전송 최소 간격 — 경로 기록(2초)보다 낮은 해상도로 충분해 전송량만 줄임
+const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
@@ -199,6 +203,8 @@ export default function TrackingScreen() {
   const backgroundedAtRef = useRef<number | null>(null);
   // 위치 업데이트 중복 방지 — foreground watch + background task 동시 수신 대비
   const lastLocationTsRef = useRef(0);
+  // 소켓 GPS 전송 throttle — 마지막 전송 시각
+  const lastPublishTsRef = useRef(0);
   // 직전에 채택된 좌표 — GPS 튐 좌표 필터링용 (누적 경로 왜곡 방지)
   const lastAcceptedCoordRef = useRef<{
     latitude: number;
@@ -308,7 +314,11 @@ export default function TrackingScreen() {
       setRecordedCoords((prev) => [...prev, { latitude, longitude }]);
 
       const sid = sessionIdRef.current;
-      if (sid != null) {
+      if (
+        sid != null &&
+        timestamp - lastPublishTsRef.current >= MIN_GPS_PUBLISH_INTERVAL_MS
+      ) {
+        lastPublishTsRef.current = timestamp;
         publishGps(sid, {
           lat: latitude,
           lng: longitude,
@@ -318,6 +328,30 @@ export default function TrackingScreen() {
       }
     },
     [publishGps],
+  );
+
+  // 백그라운드 task 전용 핸들러 — 포어그라운드에서는 watch가 담당하므로 무시
+  // (두 스트림이 동시에 처리되면 좌표·publish가 이중으로 발생)
+  const handleBackgroundLocationUpdate = useCallback(
+    (loc: {
+      latitude: number;
+      longitude: number;
+      altitude: number | null;
+      accuracy?: number | null;
+      timestamp: number;
+    }) => {
+      if (AppState.currentState === "active") return;
+      handleLocationUpdate(loc);
+    },
+    [handleLocationUpdate],
+  );
+
+  // 포어그라운드 여부 — 위치 스트림 배타 제어용 (active ↔ background/inactive)
+  const [isAppActive, setIsAppActive] = useState(
+    AppState.currentState === "active",
+  );
+  useAppState(
+    useCallback((state) => setIsAppActive(state === "active"), []),
   );
 
   // 포어그라운드 FCM 수신 (백그라운드는 OS가 시스템 알림으로 자동 처리)
@@ -362,8 +396,9 @@ export default function TrackingScreen() {
       // GPS 추적 재시작 — 백그라운드 포함
       sessionIdRef.current = activeSession.sessionId;
       lastLocationTsRef.current = 0;
+      lastPublishTsRef.current = 0;
       lastAcceptedCoordRef.current = null;
-      setLocationTaskCallback(handleLocationUpdate);
+      setLocationTaskCallback(handleBackgroundLocationUpdate);
       startLocationTask().catch((err) =>
         console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
       );
@@ -782,9 +817,10 @@ export default function TrackingScreen() {
 
   // 포어그라운드 실시간 위치 추적 — 앱이 열려 있는 동안 마커/경로 갱신을 담당.
   // 백그라운드 task는 "항상" 위치 권한이 있어야 시작되므로, 권한을 "앱 사용 중"만
-  // 허용한 경우 마커가 갱신되지 않던 문제를 해결한다. (화면이 꺼졌을 때는 백그라운드 task가 담당)
+  // 허용한 경우 마커가 갱신되지 않던 문제를 해결한다.
+  // 백그라운드 진입 시에는 watch를 해제해 task와의 이중 GPS 스트림을 방지한다.
   useEffect(() => {
-    if (!isTracking) return;
+    if (!isTracking || !isAppActive) return;
     let sub: Location.LocationSubscription | null = null;
     let cancelled = false;
     (async () => {
@@ -819,7 +855,7 @@ export default function TrackingScreen() {
       cancelled = true;
       sub?.remove();
     };
-  }, [isTracking, handleLocationUpdate]);
+  }, [isTracking, isAppActive, handleLocationUpdate]);
 
   const startCountdown = (freeMode = false) => {
     setIsFreeMode(freeMode === true); // 이벤트 객체 등 non-boolean 방지
@@ -860,8 +896,9 @@ export default function TrackingScreen() {
                 // GPS 추적 시작 — 백그라운드 포함
                 setRecordedCoords([]);
                 lastLocationTsRef.current = 0;
+                lastPublishTsRef.current = 0;
                 lastAcceptedCoordRef.current = null;
-                setLocationTaskCallback(handleLocationUpdate);
+                setLocationTaskCallback(handleBackgroundLocationUpdate);
                 startLocationTask().catch((err) => {
                   console.warn("[Location] 백그라운드 위치 시작 실패:", err);
                 });


### PR DESCRIPTION
Closes #166

## 변경 내용

트래킹 중 포어그라운드 watch와 백그라운드 task가 동시에 최고 정확도로 돌면서 배터리를 이중으로 소모하고 소켓 GPS 전송이 의도(2초)보다 잦아지던 문제를 수정했습니다.

### 1. 위치 스트림 배타 제어

- **포어그라운드(active)**: `watchPositionAsync`만 위치를 처리 — AppState가 active가 아니면 watch 구독을 해제
- **백그라운드/inactive**: task만 처리 — task 콜백을 `handleBackgroundLocationUpdate`로 감싸 `AppState.currentState === "active"`일 때는 무시

task 자체는 트래킹 중 계속 등록 상태로 유지합니다(앱 강제 종료·백그라운드 전환 대비). 바뀐 것은 "어느 스트림의 업데이트를 채택하느냐"뿐입니다.

### 2. 소켓 GPS 전송 throttle

`publishGps` 호출에 최소 전송 간격 3초(`MIN_GPS_PUBLISH_INTERVAL_MS`) 가드를 추가했습니다. 마커·경로 기록(`recordedCoords`)은 기존대로 채택된 모든 좌표를 반영하고, 서버 전송량만 줄입니다. 세션 시작/복원 시 throttle 기준 시각을 초기화합니다.

## 이슈 제안 중 반영하지 않은 것

`accuracy: BestForNavigation → High` 하향은 트래킹 품질에 영향을 줄 수 있는 제품 결정이라 이번 PR에서 제외했습니다. 필요하면 별도로 논의 후 적용을 권장합니다.

## 검증

- `npx tsc --noEmit` 통과
- `npx eslint app/(tabs)/tracking.tsx` — 신규 경고/에러 없음 (기존 경고 12건 동일)


## 시뮬레이터 검증 (iPhone 17 Pro, dev client + 위치 시뮬레이션)

임시 카운트 로그(tick/publish/bg-drop/watch 구독·해제)를 심고 #169와 로컬 머지한 상태(충돌 없음)에서 측정:

- **전송 throttle**: GPS tick이 정확히 2초 간격으로 들어오는 조건에서 publish는 4초 간격으로만 발생 — 45초간 tick 21회 vs publish 11회 (약 절반으로 감소, 3초 가드 정상 동작)
- **포어그라운드 배타 제어**: active 상태 동안 백그라운드 task가 전달한 좌표는 전부 무시되고 watch만 처리됨
- **백그라운드 전환/복귀**: 홈 이동 시 `watch 구독 해제 → task 좌표 채택`, 앱 복귀 시 `watch 재구독` 시퀀스 확인

한계: 배터리 영향과 장시간 백그라운드 task 동작은 시뮬레이터 특성상 실기기 확인을 권장.
