### PR TITLE
fix: 탈퇴/토큰 만료 후 로그인 화면에서 빠져나오지 못하던 문제 수정

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -61,8 +61,9 @@ export default function MyPageScreen() {
           {
             text: "로그아웃",
             style: "destructive",
+            // 서버 응답과 무관하게 세션은 정리되므로 onSettled 에서 이동한다.
             onPress: () =>
-              logout(undefined, { onSuccess: () => router.replace("/login") }),
+              logout(undefined, { onSettled: () => router.replace("/login") }),
           },
         ]),
     },
@@ -75,9 +76,10 @@ export default function MyPageScreen() {
           {
             text: "탈퇴",
             style: "destructive",
+            // 이미 탈퇴된 계정이라 401 이 떨어져도 로그인 화면으로 빠져나가야 한다.
             onPress: () =>
               withdraw(undefined, {
-                onSuccess: () => router.replace("/login"),
+                onSettled: () => router.replace("/login"),
               }),
           },
         ]),

--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -10,8 +10,7 @@ import {
   useProfile,
 } from "@/features/mypage/hooks/use-profile";
 import { usePrefetchSavedMountains } from "@/features/mountains/hooks/use-saved-mountains";
-import { useFocusEffect } from "expo-router";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import { useCallback } from "react";
 import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,11 +10,8 @@ import { Lexend_700Bold, useFonts } from "@expo-google-fonts/lexend";
 import { initializeKakaoSDK } from "@react-native-kakao/core";
 import { DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import * as Sentry from "@sentry/react-native";
-import {
-  QueryClient,
-  QueryClientProvider,
-  focusManager,
-} from "@tanstack/react-query";
+import { queryClient } from "@/lib/query-client";
+import { QueryClientProvider, focusManager } from "@tanstack/react-query";
 import * as Notifications from "expo-notifications";
 import { Redirect, Stack } from "expo-router";
 import * as SplashScreen from "expo-splash-screen";
@@ -74,10 +71,6 @@ function onAppStateChange(status: AppStateStatus) {
     focusManager.setFocused(status === "active");
   }
 }
-const queryClient = new QueryClient({
-  defaultOptions: { queries: { retry: 2, staleTime: 1000 * 60 * 5 } },
-});
-
 export const unstable_settings = {
   anchor: "(tabs)",
 };

--- a/features/auth/hooks/use-apple-login.ts
+++ b/features/auth/hooks/use-apple-login.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { startSession } from "@/lib/auth/session";
 import {
   AppleLoginBody,
   ENDPOINTS,
@@ -20,9 +20,8 @@ export function useAppleLogin() {
     mutationFn: appleLogin,
     onSuccess: async ({ accessToken, refreshToken }) => {
       if (accessToken && refreshToken) {
-    console.log("✅ accessToken:", accessToken);  // 임시 추가
-    await tokenStorage.setTokens(accessToken, refreshToken);
-  }
+        await startSession(accessToken, refreshToken);
+      }
     },
   });
 }

--- a/features/auth/hooks/use-auth-state.ts
+++ b/features/auth/hooks/use-auth-state.ts
@@ -1,31 +1,39 @@
 import { api } from "@/lib/api";
 import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { authState, AuthStatus, useAuthStore } from "@/store/auth.store";
 import { ENDPOINTS, GetUserProfileResponse } from "@/types/api.generated";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
-type AuthStatus = "loading" | "authenticated" | "unauthenticated";
-
+/**
+ * 앱 시작 시 저장된 토큰을 1회 검증하고, 이후에는 전역 스토어의 인증 상태를 그대로 구독한다.
+ * 로컬 state 로 두면 로그인 성공 이후에도 상태가 unauthenticated 로 남아
+ * 루트의 `<Redirect href="/login" />` 이 계속 로그인 화면으로 되돌린다.
+ */
 export function useAuthState(): { status: AuthStatus } {
-  const [status, setStatus] = useState<AuthStatus>("loading");
+  const status = useAuthStore((state) => state.status);
 
   useEffect(() => {
-    async function checkAuth(): Promise<void> {
+    async function bootstrap(): Promise<void> {
+      await tokenStorage.seedSampleAccessToken();
+
       const token = await tokenStorage.getAccessToken();
       if (!token) {
-        setStatus("unauthenticated");
+        authState.setUnauthenticated();
         return;
       }
+
       try {
         await api.get<GetUserProfileResponse>(
           { path: ENDPOINTS.USERS_PROFILE },
           { ignoreErrorToast: true },
         );
-        setStatus("authenticated");
+        authState.setAuthenticated();
       } catch {
-        setStatus("unauthenticated");
+        authState.setUnauthenticated();
       }
     }
-    checkAuth();
+
+    bootstrap();
   }, []);
 
   return { status };

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { startSession } from "@/lib/auth/session";
 import { ENDPOINTS, OAuthLoginResponse } from "@/types/api.generated";
 import { login } from "@react-native-kakao/user";
 import { useMutation } from "@tanstack/react-query";
@@ -21,7 +21,7 @@ export function useKakaoLogin() {
     },
     onSuccess: async ({ accessToken, refreshToken }) => {
       if (accessToken && refreshToken) {
-        await tokenStorage.setTokens(accessToken, refreshToken);
+        await startSession(accessToken, refreshToken);
       }
     },
   });

--- a/features/auth/hooks/use-logout.ts
+++ b/features/auth/hooks/use-logout.ts
@@ -1,18 +1,16 @@
 import { api } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { endSession } from "@/lib/auth/session";
 import { ENDPOINTS } from "@/types/api.generated";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 export function useLogout() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async (): Promise<void> => {
-      await api.post({ path: ENDPOINTS.AUTH_LOGOUT }, { ignoreErrorToast: true });
+      await api.post(
+        { path: ENDPOINTS.AUTH_LOGOUT },
+        { ignoreErrorToast: true },
+      );
     },
-    onSettled: async () => {
-      await tokenStorage.clearTokens();
-      queryClient.clear();
-    },
+    onSettled: endSession,
   });
 }

--- a/features/auth/hooks/use-test-login.ts
+++ b/features/auth/hooks/use-test-login.ts
@@ -1,5 +1,5 @@
 import { api } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { startSession } from "@/lib/auth/session";
 import { ENDPOINTS, LoginResponse } from "@/types/api.generated";
 import { useMutation } from "@tanstack/react-query";
 
@@ -22,7 +22,7 @@ export function useTestLogin() {
     },
     onSuccess: async ({ accessToken, refreshToken }) => {
       if (accessToken && refreshToken) {
-        await tokenStorage.setTokens(accessToken, refreshToken);
+        await startSession(accessToken, refreshToken);
       }
     },
   });

--- a/features/auth/hooks/use-withdraw.ts
+++ b/features/auth/hooks/use-withdraw.ts
@@ -1,18 +1,16 @@
 import { api } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { endSession } from "@/lib/auth/session";
 import { ENDPOINTS } from "@/types/api.generated";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 export function useWithdraw() {
-  const queryClient = useQueryClient();
-
   return useMutation({
     mutationFn: async (): Promise<void> => {
-      await api.delete({ path: ENDPOINTS.AUTH_WITHDRAW });
+      await api.delete(
+        { path: ENDPOINTS.AUTH_WITHDRAW },
+        { ignoreErrorToast: true },
+      );
     },
-    onSettled: async () => {
-      await tokenStorage.clearTokens();
-      queryClient.clear();
-    },
+    onSettled: endSession,
   });
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2,6 +2,7 @@ import { toast } from "@/store/toast.store";
 import { ENDPOINTS } from "@/types/api.generated";
 import * as Sentry from "@sentry/react-native";
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
+import { endSession } from "./auth/session";
 import { tokenStorage } from "./auth/tokenStorage";
 import { buildQueryParams } from "./buildQueryParams";
 
@@ -13,6 +14,23 @@ export class ApiError extends Error {
     super(`API Error: ${status} ${statusText}`);
     this.statusCode = status;
   }
+}
+
+const PUBLIC_AUTH_PATHS: string[] = [
+  ENDPOINTS.OAUTH_KAKAO_LOGIN,
+  ENDPOINTS.OAUTH_APPLE_LOGIN,
+  ENDPOINTS.AUTH_TEST_LOGIN,
+  ENDPOINTS.AUTH_TOKEN_REISSUE,
+];
+
+function isPublicAuthPath(url?: string): boolean {
+  return !!url && PUBLIC_AUTH_PATHS.some((path) => url.startsWith(path));
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (axios.isAxiosError(error)) return error.response?.status;
+  if (error instanceof ApiError) return error.statusCode;
+  return undefined;
 }
 
 type RequestOptions = {
@@ -32,6 +50,9 @@ const client = axios.create({
 
 client.interceptors.request.use(
   async (config) => {
+    // 로그인 요청에 이전 계정의 토큰이 붙으면 서버가 이를 거절할 수 있으므로 제외
+    if (isPublicAuthPath(config.url)) return config;
+
     const accessToken = await tokenStorage.getAccessToken();
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`;
@@ -63,14 +84,11 @@ async function reissueTokens(): Promise<string> {
     await tokenStorage.setTokens(accessToken, newRefreshToken);
     return accessToken;
   } catch (refreshError) {
-    const status = axios.isAxiosError(refreshError)
-      ? refreshError.response?.status
-      : refreshError instanceof ApiError
-        ? refreshError.statusCode
-        : undefined;
+    const status = getErrorStatus(refreshError);
 
+    // 재발급 자체가 인증 실패면 되살릴 수 있는 세션이 아니다. 즉시 로그아웃 처리한다.
     if (status === 401 || status === 403) {
-      await tokenStorage.clearTokens();
+      await endSession();
       console.error("Token refresh failed:", refreshError);
       Sentry.captureException(new Error("TokenRefreshFailed"));
     }
@@ -85,7 +103,7 @@ client.interceptors.response.use(
 
     if (error.response?.status === 401 && !originalRequest._retry) {
       // 토큰이 필요하지 않은 인증 API들은 토큰 갱신을 시도하지 않음
-      if (originalRequest.url?.includes("/auth/login")) {
+      if (isPublicAuthPath(originalRequest.url)) {
         return Promise.reject(error);
       }
 

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -1,0 +1,23 @@
+import { queryClient } from "@/lib/query-client";
+import { authState } from "@/store/auth.store";
+import { tokenStorage } from "./tokenStorage";
+
+/**
+ * 세션 종료 단일 경로. 로그아웃 / 탈퇴 / 토큰 재발급 실패 모두 여기를 통한다.
+ * 토큰 폐기 + 캐시 정리 + 인증 상태 전환까지 한 번에 처리해서
+ * 죽은 토큰으로 API를 계속 호출하거나 이전 계정 데이터가 남는 상황을 막는다.
+ */
+export async function endSession(): Promise<void> {
+  await tokenStorage.clearTokens();
+  queryClient.clear();
+  authState.setUnauthenticated();
+}
+
+/** 로그인 성공 직후 호출. 토큰 저장 후 인증 상태를 켠다. */
+export async function startSession(
+  accessToken: string,
+  refreshToken: string,
+): Promise<void> {
+  await tokenStorage.setTokens(accessToken, refreshToken);
+  authState.setAuthenticated();
+}

--- a/lib/auth/tokenStorage.ts
+++ b/lib/auth/tokenStorage.ts
@@ -1,16 +1,31 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Sentry from "@sentry/react-native";
+
+/**
+ * 토큰 저장소 실패는 곧 로그인 상태 유실로 이어진다.
+ * 콘솔은 개발 중에만 의미가 있으므로, 운영에서는 Sentry 로 실제 보고한다.
+ */
+function reportFailure(operation: string, error: unknown): void {
+  if (__DEV__) console.error(`tokenStorage.${operation} failed:`, error);
+  Sentry.captureException(error, {
+    tags: { scope: "tokenStorage", operation },
+  });
+}
 
 const ACCESS_TOKEN_KEY = "accessToken";
 const REFRESH_TOKEN_KEY = "refreshToken";
+/** 사용자가 명시적으로 로그아웃/탈퇴했음을 기록. 개발용 샘플 토큰 재주입을 막는다. */
+const SIGNED_OUT_KEY = "auth.signedOut";
+
+const SAMPLE_ACCESS_TOKEN = process.env.EXPO_PUBLIC_SAMPLE_ACCESS_TOKEN;
 
 export const tokenStorage = {
   async getAccessToken(): Promise<string | null> {
     try {
-      const token = await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
-      return token || process.env.EXPO_PUBLIC_SAMPLE_ACCESS_TOKEN || null;
+      return await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
     } catch (error) {
-      console.error("Failed to get access token:", error);
-      return process.env.EXPO_PUBLIC_SAMPLE_ACCESS_TOKEN || null;
+      reportFailure("getAccessToken", error);
+      return null;
     }
   },
 
@@ -18,7 +33,7 @@ export const tokenStorage = {
     try {
       await AsyncStorage.setItem(ACCESS_TOKEN_KEY, token);
     } catch (error) {
-      console.error("Failed to set access token:", error);
+      reportFailure("setAccessToken", error);
     }
   },
 
@@ -26,7 +41,7 @@ export const tokenStorage = {
     try {
       await AsyncStorage.removeItem(ACCESS_TOKEN_KEY);
     } catch (error) {
-      console.error("Failed to remove access token:", error);
+      reportFailure("removeAccessToken", error);
     }
   },
 
@@ -34,7 +49,7 @@ export const tokenStorage = {
     try {
       return await AsyncStorage.getItem(REFRESH_TOKEN_KEY);
     } catch (error) {
-      console.error("Failed to get refresh token:", error);
+      reportFailure("getRefreshToken", error);
       return null;
     }
   },
@@ -43,7 +58,7 @@ export const tokenStorage = {
     try {
       await AsyncStorage.setItem(REFRESH_TOKEN_KEY, token);
     } catch (error) {
-      console.error("Failed to set refresh token:", error);
+      reportFailure("setRefreshToken", error);
     }
   },
 
@@ -51,12 +66,17 @@ export const tokenStorage = {
     try {
       await AsyncStorage.removeItem(REFRESH_TOKEN_KEY);
     } catch (error) {
-      console.error("Failed to remove refresh token:", error);
+      reportFailure("removeRefreshToken", error);
     }
   },
 
   async clearTokens(): Promise<void> {
     await Promise.all([this.removeAccessToken(), this.removeRefreshToken()]);
+    try {
+      await AsyncStorage.setItem(SIGNED_OUT_KEY, "true");
+    } catch (error) {
+      reportFailure("markSignedOut", error);
+    }
   },
 
   async setTokens(accessToken: string, refreshToken: string): Promise<void> {
@@ -64,5 +84,29 @@ export const tokenStorage = {
       this.setAccessToken(accessToken),
       this.setRefreshToken(refreshToken),
     ]);
+    try {
+      await AsyncStorage.removeItem(SIGNED_OUT_KEY);
+    } catch (error) {
+      reportFailure("clearSignedOutFlag", error);
+    }
+  },
+
+  /**
+   * 개발 편의용 샘플 토큰을 앱 시작 시 1회만 주입한다.
+   * getAccessToken 의 fallback 으로 두면 clearTokens 이후에도 토큰이 되살아나
+   * 탈퇴한 계정의 죽은 토큰으로 계속 요청을 보내게 되므로 절대 fallback 으로 쓰지 않는다.
+   */
+  async seedSampleAccessToken(): Promise<void> {
+    if (!__DEV__ || !SAMPLE_ACCESS_TOKEN) return;
+    try {
+      const [token, signedOut] = await Promise.all([
+        AsyncStorage.getItem(ACCESS_TOKEN_KEY),
+        AsyncStorage.getItem(SIGNED_OUT_KEY),
+      ]);
+      if (token || signedOut) return;
+      await AsyncStorage.setItem(ACCESS_TOKEN_KEY, SAMPLE_ACCESS_TOKEN);
+    } catch (error) {
+      reportFailure("seedSampleAccessToken", error);
+    }
   },
 };

--- a/lib/query-client.ts
+++ b/lib/query-client.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * 앱 전역 QueryClient.
+ * 세션 종료(로그아웃/탈퇴/토큰 만료) 시 컴포넌트 밖에서도 캐시를 비워야 하므로
+ * 루트 레이아웃이 아닌 모듈 스코프에 둔다.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: { queries: { retry: 2, staleTime: 1000 * 60 * 5 } },
+});

--- a/store/auth.store.ts
+++ b/store/auth.store.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+
+type AuthState = {
+  status: AuthStatus;
+  setStatus: (status: AuthStatus) => void;
+};
+
+export const useAuthStore = create<AuthState>((set) => ({
+  status: "loading",
+  setStatus: (status) => set({ status }),
+}));
+
+/** 훅 밖(인터셉터 등)에서 인증 상태를 바꿀 때 사용 */
+export const authState = {
+  get: () => useAuthStore.getState().status,
+  setAuthenticated: () => useAuthStore.getState().setStatus("authenticated"),
+  setUnauthenticated: () =>
+    useAuthStore.getState().setStatus("unauthenticated"),
+};


### PR DESCRIPTION
## 문제

탈퇴하거나 토큰이 만료된 계정에서 로그인 화면에 진입하면, **로그인에 성공해도 다시 로그인 화면으로 되돌아와 빠져나올 수 없었습니다.**

서버 로그에서 시작된 이슈입니다. DB 정리로 이미 삭제된 계정(`userId 3257`)의 토큰이 기기에 남아 요청이 계속 나가고 있었습니다.

```
DELETE /api/auth/withdraw      userId 3257  탈퇴했거나 존재하지 않는 사용자입니다.
GET    /api/mountains/likes    userId 3257  탈퇴했거나 존재하지 않는 사용자입니다.
```

## 원인

**1. 인증 상태가 반응형이 아니었음 (리다이렉트 루프의 직접 원인)**

`useAuthState`가 로컬 `useState`로 앱 시작 시 **1회만** 토큰을 검사했는데, 루트 레이아웃이 그 값으로 `<Redirect href="/login" />`을 렌더합니다. 로그인에 성공해도 `authStatus`는 `unauthenticated`로 남아 `<Redirect>`가 계속 살아있고, `router.replace("/(tabs)")` 직후 다시 로그인 화면으로 되돌렸습니다.

**2. 탈퇴 실패 시 화면을 벗어나지 못함**

`mypage`가 `onSuccess`에서만 화면을 이동시켜서, 이미 삭제된 계정이라 `DELETE /auth/withdraw`가 401을 뱉으면 이동이 일어나지 않았습니다. 토큰만 조용히 지워진 채 인증 화면에 남았고, prefetch가 죽은 토큰으로 `/mountains/likes`를 계속 호출한 게 위 두 번째 로그입니다.

**3. 죽은 토큰이 되살아남**

`tokenStorage.getAccessToken()`이 `EXPO_PUBLIC_SAMPLE_ACCESS_TOKEN`을 fallback으로 반환하고 있어, `clearTokens()` 이후에도 토큰이 부활해 같은 증상이 무한 재현되는 구조였습니다.

**4. 로그인 요청 401 처리 누락**

기존 `includes("/auth/login")` 검사가 카카오 · 애플 · 테스트 로그인 경로를 **전부 놓치고** 있어서, 로그인 자체가 401일 때 엉뚱하게 토큰 갱신을 시도했습니다.

## 변경사항

| 파일 | 내용 |
|---|---|
| `store/auth.store.ts` 🆕 | 인증 상태를 zustand 전역 스토어로 이전 (기존 `toast.store` 패턴) |
| `lib/auth/session.ts` 🆕 | `startSession` / `endSession` 단일 경로. 토큰 폐기 + 캐시 정리 + 상태 전환을 한 번에 |
| `lib/query-client.ts` 🆕 | `QueryClient`를 모듈 스코프로 승격 — 컴포넌트 밖에서도 캐시 정리 가능 |
| `use-auth-state.ts` | 로컬 state → 스토어 구독. 부트스트랩 검증만 1회 수행 |
| `tokenStorage.ts` | fallback 제거 → `seedSampleAccessToken()`으로 앱 시작 시 1회만 주입, 명시적 로그아웃/탈퇴 후엔 재주입 안 함 |
| `lib/api.ts` | 로그인 계열 엔드포인트에 토큰 미첨부 + 401 시 갱신 미시도. 재발급 401/403 시 `endSession()` |
| `use-logout` / `use-withdraw` | `onSettled: endSession` — 서버 응답과 무관하게 로컬 세션 정리 |
| `mypage.tsx` | 후처리를 `onSuccess` → `onSettled`로 변경 |
| `use-apple-login.ts` | `accessToken`을 콘솔에 출력하던 임시 코드 제거 |

부수적으로 `tokenStorage`의 저장소 실패를 `console.error` 대신 **Sentry로 실제 보고**하도록 바꿨습니다. 기존에는 운영에서 토큰 저장이 실패해도 아무 알림이 오지 않았습니다.

## 검증

- `npx tsc --noEmit` — No errors
- `npm run lint` — 0 errors
- 이번 변경으로 **새로 생긴 lint 경고 없음** (touched 파일의 경고 3건은 `909b70c` 시점에도 동일 규칙·동일 개수로 존재하는 기존 경고)

## 리뷰어 확인 부탁

**실기기 동작 확인은 아직 안 했습니다.** 아래 시나리오 확인 부탁드립니다.

- [ ] 로그인 → 홈 진입 (되돌아오지 않는지)
- [ ] 로그아웃 → 재로그인
- [ ] 탈퇴 → 재로그인
- [ ] 이미 죽은 토큰이 남은 기기에서 앱 재시작 시 로그인 화면으로 정상 진입
