### PR TITLE
fix: 사진 없는 포토 리포트가 세모피드에 공개되던 문제 수정 (#175)

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -178,6 +178,11 @@ export default function RecordScreen() {
   const photoReportShotRef = useRef<ViewShot | null>(null);
   const mapRef = useRef<NaverMapViewRef>(null);
   const activeTabPublic = isPublicByTab[activeTab];
+  // 사진이 없는 탭은 빈 카드가 캡처돼 세모피드에 올라가므로 저장/공개를 막는다
+  const canShareActiveTab =
+    activeTab === "클라이브"
+      ? displayPhotos.length > 0
+      : photoReportSource != null;
   const trackCoords = parseTrack(recordDetail?.track);
 
   const captureCard = async (tab: RecordTab) => {
@@ -265,6 +270,7 @@ export default function RecordScreen() {
   }, []);
 
   const handleSavePress = async () => {
+    if (!canShareActiveTab) return;
     try {
       const imageUri = await captureCard(activeTab);
       if (!imageUri) return;
@@ -285,6 +291,7 @@ export default function RecordScreen() {
   };
 
   const handleTogglePublic = async () => {
+    if (!canShareActiveTab) return;
     try {
       const semoFeedId = await ensureSemoFeed(activeTab);
       if (!semoFeedId) return;
@@ -770,12 +777,14 @@ export default function RecordScreen() {
               </TouchableOpacity>
             </View>
 
-            <CliveBottomBar
-              isPublic={activeTabPublic}
-              isToggling={isToggling}
-              onTogglePublic={handleTogglePublic}
-              onSave={handleSavePress}
-            />
+            {photoReportSource != null && (
+              <CliveBottomBar
+                isPublic={activeTabPublic}
+                isToggling={isToggling}
+                onTogglePublic={handleTogglePublic}
+                onSave={handleSavePress}
+              />
+            )}
           </View>
         )}
       </ScrollView>


### PR DESCRIPTION
Closes #175

## 문제

포토 리포트에 사진이 등록되지 않은 상태에서도 공개 토글이 동작해, 기본 배경만 깔린 빈 카드가 세모피드에 게시됐습니다.

## 원인

클라이브 탭과 포토 리포트 탭의 가드가 비대칭이었습니다.

```tsx
// 클라이브 (:700) — 사진 없으면 하단 바 자체를 렌더하지 않음
{displayPhotos.length > 0 && <CliveBottomBar ... />}

// 포토 리포트 (:773) — 가드 없음
<CliveBottomBar ... />
```

사진이 없으면 `photoReportSource` 가 `null` 이고 배경은 `photoReportSource ?? PhotoReportBg` 로 기본 이미지가 깔립니다. 스탯 오버레이도 `photoReportSource != null` 일 때만 그려지므로, 캡처 결과물은 아무 정보 없는 배경 한 장입니다.

## 변경사항

- 포토 리포트 하단 바에 `photoReportSource != null` 가드 적용 (클라이브와 동일)
- `handleTogglePublic` / `handleSavePress` 진입부에 `canShareActiveTab` 검사 추가 — UI를 숨기는 것만으로는 렌더 타이밍 틈이 남아 실제 업로드 경로에서도 차단

사진이 추가되면 바가 다시 나타나고, 그 전에는 `편집하기` 로 사진을 넣는 경로만 남습니다.

## 검증

- `npx tsc --noEmit` — 통과
- `npx eslint` — 0 errors, 새로 생긴 경고 없음

**실기기 확인은 하지 않았습니다.** 빈 포토 리포트에서 하단 바가 사라지는지, 사진 추가 후 정상 공개되는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 활성 탭에 공유 가능한 사진이 없을 때 저장 및 공개 기능이 실행되지 않도록 개선했습니다.
  * 포토 리포트에 사진이 없는 경우 관련 하단 메뉴가 표시되지 않도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->