### PR TITLE
fix: 트래킹 지도 카메라가 관악산 데모 좌표에 고정되던 문제 수정 (#176)

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -829,12 +829,19 @@ export default function TrackingScreen() {
   }, [courseDetail?.polyline, isTracking]);
 
   // 진입 시 카메라를 근처 산으로 1회 이동 — 근처 산이 없으면 현위치
-  // 코스 선택 시엔 위 전체맞춤 effect가 담당하므로 제외
   const didInitialCameraMoveRef = useRef(false);
+  // 사용자가 먼저 지도를 움직였으면 뒤늦게 도착한 좌표로 덮어쓰지 않음
+  const didUserMoveMapRef = useRef(false);
   const nearbyMountain = nearbyData?.mountain;
   useEffect(() => {
-    if (didInitialCameraMoveRef.current) return;
-    if (isTracking || courseCoords.length >= 2) return;
+    if (didInitialCameraMoveRef.current || didUserMoveMapRef.current) return;
+    // 트래킹이 시작되면 초기 이동은 포기 — 종료 후 카메라가 뒤늦게 튀는 것 방지
+    if (isTracking) {
+      didInitialCameraMoveRef.current = true;
+      return;
+    }
+    // 코스가 선택돼 있으면 위 전체맞춤 effect가 담당 (polyline 로딩 중 이중 이동 방지)
+    if (selectedCourseId != null || courseCoords.length >= 2) return;
 
     const target =
       nearbyMountain?.latitude != null && nearbyMountain?.longitude != null
@@ -855,6 +862,7 @@ export default function TrackingScreen() {
     didInitialCameraMoveRef.current = true;
     mapRef.current?.animateCameraTo({ ...target, duration: 500 });
   }, [
+    selectedCourseId,
     nearbyMountain,
     isNearbyLoading,
     userLocation,
@@ -1344,7 +1352,10 @@ export default function TrackingScreen() {
             right: 0,
           }}
           onCameraChanged={({ reason }) => {
-            if (reason === "Gesture") setIsFollowingUser(false);
+            if (reason === "Gesture") {
+              didUserMoveMapRef.current = true;
+              setIsFollowingUser(false);
+            }
           }}
         >
           {staticMapOverlays}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -108,7 +108,7 @@ const MAX_SPEED_MPS = 30; // 이보다 빠른 이동(≈108km/h)은 비현실적
 // 소켓 GPS 전송 최소 간격 — 경로 기록(2초)보다 낮은 해상도로 충분해 전송량만 줄임
 const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 
-// GPS 응답 전까지만 쓰는 임시 중심 좌표(서울시청). 위치를 받으면 바로 현위치로 이동한다.
+// GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
 
 // 두 좌표 간 거리(m) — Haversine
@@ -828,20 +828,39 @@ export default function TrackingScreen() {
     return () => clearTimeout(timer);
   }, [courseDetail?.polyline, isTracking]);
 
-  // 진입 후 첫 위치 수신 시 카메라를 현위치로 1회 이동.
-  // 코스가 선택돼 있으면 위 전체맞춤 effect가 카메라를 담당하므로 건너뛴다.
+  // 진입 시 카메라를 근처 산으로 1회 이동 — 근처 산이 없으면 현위치
+  // 코스 선택 시엔 위 전체맞춤 effect가 담당하므로 제외
   const didInitialCameraMoveRef = useRef(false);
+  const nearbyMountain = nearbyData?.mountain;
   useEffect(() => {
     if (didInitialCameraMoveRef.current) return;
-    if (!userLocation || isTracking || courseCoords.length >= 2) return;
+    if (isTracking || courseCoords.length >= 2) return;
+
+    const target =
+      nearbyMountain?.latitude != null && nearbyMountain?.longitude != null
+        ? {
+            latitude: nearbyMountain.latitude,
+            longitude: nearbyMountain.longitude,
+            zoom: 12,
+          }
+        : !isNearbyLoading && userLocation
+          ? {
+              latitude: userLocation.latitude,
+              longitude: userLocation.longitude,
+              zoom: 15,
+            }
+          : null;
+    if (!target) return;
+
     didInitialCameraMoveRef.current = true;
-    mapRef.current?.animateCameraTo({
-      latitude: userLocation.latitude,
-      longitude: userLocation.longitude,
-      zoom: 15,
-      duration: 500,
-    });
-  }, [userLocation, isTracking, courseCoords.length]);
+    mapRef.current?.animateCameraTo({ ...target, duration: 500 });
+  }, [
+    nearbyMountain,
+    isNearbyLoading,
+    userLocation,
+    isTracking,
+    courseCoords.length,
+  ]);
 
   // 트래킹 시작/종료 시 follow 모드 토글
   // 트래킹 중(코스·자유기록 공통): 현위치가 지도 중앙에 오도록 follow 활성

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -108,6 +108,9 @@ const MAX_SPEED_MPS = 30; // 이보다 빠른 이동(≈108km/h)은 비현실적
 // 소켓 GPS 전송 최소 간격 — 경로 기록(2초)보다 낮은 해상도로 충분해 전송량만 줄임
 const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 
+// GPS 응답 전까지만 쓰는 임시 중심 좌표(서울시청). 위치를 받으면 바로 현위치로 이동한다.
+const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
+
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
   a: { latitude: number; longitude: number },
@@ -825,6 +828,21 @@ export default function TrackingScreen() {
     return () => clearTimeout(timer);
   }, [courseDetail?.polyline, isTracking]);
 
+  // 진입 후 첫 위치 수신 시 카메라를 현위치로 1회 이동.
+  // 코스가 선택돼 있으면 위 전체맞춤 effect가 카메라를 담당하므로 건너뛴다.
+  const didInitialCameraMoveRef = useRef(false);
+  useEffect(() => {
+    if (didInitialCameraMoveRef.current) return;
+    if (!userLocation || isTracking || courseCoords.length >= 2) return;
+    didInitialCameraMoveRef.current = true;
+    mapRef.current?.animateCameraTo({
+      latitude: userLocation.latitude,
+      longitude: userLocation.longitude,
+      zoom: 15,
+      duration: 500,
+    });
+  }, [userLocation, isTracking, courseCoords.length]);
+
   // 트래킹 시작/종료 시 follow 모드 토글
   // 트래킹 중(코스·자유기록 공통): 현위치가 지도 중앙에 오도록 follow 활성
   // (사용자가 직접 지도를 조작하면 onCameraChanged에서 follow 해제)
@@ -1295,11 +1313,7 @@ export default function TrackingScreen() {
         <NaverMapView
           ref={mapRef}
           style={styles.map}
-          camera={{
-            latitude: 37.4449,
-            longitude: 126.9636,
-            zoom: 12,
-          }}
+          initialCamera={FALLBACK_CAMERA}
           mapPadding={{
             bottom: isTracking
               ? trackingSheetHeight


### PR DESCRIPTION
Closes #176
Closes #184

## 문제

트래킹 탭 지도가 항상 관악산 중심으로 잡히고, 사용자가 움직여도 되돌아왔습니다. 현위치로 이동하지 않았습니다.

## 원인

`NaverMapView` 에 **`camera`** prop 을 상수로 넘기고 있었습니다.

```tsx
camera={{ latitude: 37.4449, longitude: 126.9636, zoom: 12 }}
```

`camera` 는 controlled prop 이라 리렌더마다 해당 좌표가 재적용됩니다. 라이브러리 타입 정의에도 `initialCamera` 는 "`camera` 를 사용하지 않을 때만 사용해야합니다" 라고 명시돼 있고, 네이티브 구현(`RNCNaverMapViewImpl.mm`)에서 `initialCamera` 는 `_initialCameraSet` 플래그로 최초 1회만 적용됩니다. 즉 기존 코드는 `animateCameraTo` 로 옮겨도 다음 리렌더에서 관악산으로 되돌아가는 구조였습니다.

좌표 `37.4449, 126.9636` 은 `features/tracking/constants/demo-gwanaksan.ts` 의 전시 데모용 하드코딩 값과 정확히 일치합니다. 데모 잔재로 보입니다.

## 변경사항

- `camera` → `initialCamera` 로 교체해 카메라 고정 해제
- 진입 후 첫 위치 수신 시 현위치로 1회 이동하는 effect 추가. 코스가 선택된 경우엔 기존 전체맞춤 effect 가 카메라를 담당하므로 건너뜀
- GPS 응답 전 임시 중심은 관악산 대신 `FALLBACK_CAMERA`(서울시청) 사용

## 검증

- `npx tsc --noEmit` — 통과
- `npx eslint` — 0 errors, 경고 12개는 변경 전과 동일한 개수·종류

**실기기 확인은 하지 않았습니다.** 진입 시 현위치로 잡히는지, 지도 조작이 되돌아오지 않는지, 코스 선택 시 전체맞춤이 정상 동작하는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 트래킹 화면에 진입하면 주변 산을 기준으로 지도가 자동으로 이동합니다.
  * 주변 산을 찾을 수 없는 경우 현재 위치를 기준으로 지도가 표시됩니다.
  * 코스가 로드되었거나 트래킹이 진행 중일 때는 기존 지도 위치를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## 코드리뷰 반영 (`ff99571`)

CodeRabbit 지적 3건을 반영하고, 시뮬레이터에서 각각 재현을 시도했습니다.

| 지적 | 재현 | 조치 |
|---|---|---|
| 코스 선택 시 카메라 이중 이동 | **재현됨** (#184) | `selectedCourseId` 를 가드·deps 에 추가 |
| 트래킹 종료 후 카메라 튐 | 재현 안 됨 | `isTracking` 진입 시 초기 이동 완료 처리 (방어) |
| 사용자 제스처 덮어쓰기 | 재현 안 됨 | `didUserMoveMapRef` 로 제스처 후 자동 이동 차단 (방어) |

### 재현된 건 (#184)

`selectedCourseId` 는 마운트 시점에 이미 설정되는데 가드는 `courseCoords.length` 만 봤습니다. polyline 로딩 중에는 길이가 0이라 초기 이동이 실행되고, 로딩 후 전체맞춤이 다시 이동합니다. 경합이 아니라 **코스를 골라 진입하면 항상** 발생합니다.

polyline 이 오지 않는 `courseId=999999` 로 진입해 전체맞춤 effect 를 배제하면 초기 이동 결과만 고정됩니다.

- 수정 전 — 지도가 **관악산(연주대)** 중심
- 수정 후 — 지도가 **FALLBACK(서울시청)** 유지

### 재현되지 않은 2건

초기 카메라 이동이 탭 진입 1초 내에 끝나 `didInitialCameraMoveRef` 가 곧바로 `true` 가 됩니다. `useNearbyMountain` 이 `staleTime: Infinity` 라 재진입 시엔 캐시에서 즉시 나옵니다. 두 건 모두 근처 산·GPS 응답이 **트래킹 시작 이후에** 도착하는 좁은 경합에서만 성립합니다.

제스처 건은 끌어놓은 직후와 응답 도착 후 스크린샷의 SHA 가 완전히 동일했습니다. 방어 코드로서 해롭지 않아 유지했습니다.
