### PR TITLE
fix: 자유 기록을 근처 산 반경 안에서만 시작하도록 제한 (#179)

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -7,6 +7,7 @@ import { CountdownOverlay } from "@/features/tracking/components/countdown-overl
 import { CourseSelectSheet } from "@/features/tracking/components/course-select-sheet";
 import { DifficultyRatingModal } from "@/features/tracking/components/difficulty-rating-modal";
 import { FreeRecordConfirmModal } from "@/features/tracking/components/free-record-confirm-modal";
+import { NoNearbyMountainModal } from "@/features/tracking/components/no-nearby-mountain-modal";
 import { PhotoWindowBanner } from "@/features/tracking/components/photo-window-banner";
 import { StopConfirmModal } from "@/features/tracking/components/stop-confirm-modal";
 import { SummitSheet } from "@/features/tracking/components/summit-sheet";
@@ -111,6 +112,11 @@ const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 // GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
 
+// 자유 기록을 해당 산에 귀속시킬 수 있는 최대 거리(산 중심 좌표 기준).
+// nearby-mountain API는 거리와 무관하게 가장 가까운 산을 돌려주므로,
+// 이 값이 없으면 산과 멀리 떨어진 곳의 기록도 그 산에 붙는다.
+const FREE_RECORD_MAX_DISTANCE_M = 3000;
+
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
   a: { latitude: number; longitude: number },
@@ -183,6 +189,8 @@ export default function TrackingScreen() {
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
+  const [showNoNearbyMountainModal, setShowNoNearbyMountainModal] =
+    useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
   const [barLayout, setBarLayout] = useState<{
     top: number;
@@ -935,12 +943,35 @@ export default function TrackingScreen() {
     setCountdown(3);
   };
 
-  const handleFreeRecord = () => startCountdown(true);
+  // 현위치 ~ 근처 산 중심 좌표 거리(m). 좌표가 없으면 판정 불가로 null
+  const nearbyMountainDistanceM = useMemo(() => {
+    if (!userLocation) return null;
+    const latitude = nearbyMountain?.latitude;
+    const longitude = nearbyMountain?.longitude;
+    if (latitude == null || longitude == null) return null;
+    return haversineMeters(userLocation, { latitude, longitude });
+  }, [userLocation, nearbyMountain]);
+
+  const handleFreeRecord = () => {
+    // 코스 상세에서 산을 명시적으로 골라 진입한 경우엔 그 산의 좌표를 알 수 없어 거리 판정에서 제외
+    if (mountainIdParameter) {
+      startCountdown(true);
+      return;
+    }
+    if (
+      nearbyMountain?.mountainId == null ||
+      nearbyMountainDistanceM == null ||
+      nearbyMountainDistanceM > FREE_RECORD_MAX_DISTANCE_M
+    ) {
+      setShowNoNearbyMountainModal(true);
+      return;
+    }
+    startCountdown(true);
+  };
 
   useEffect(() => {
     if (countdown === null) return;
     if (countdown === 0) {
-      setIsTracking(true);
       setCountdown(null);
 
       // 트래킹 세션 시작 API 호출
@@ -948,49 +979,57 @@ export default function TrackingScreen() {
       const mountainId = mountainIdParameter
         ? Number(mountainIdParameter)
         : nearbyData?.mountain?.mountainId;
-      if (mountainId != null) {
-        startSession(
-          {
-            mountainId,
-            courseId: isFreeMode
-              ? undefined
-              : (selectedCourseId_num ?? undefined),
-            isFreeRecording: isFreeMode,
-          },
-          {
-            onSuccess: (data) => {
-              if (!isMountedRef.current) return;
-              if (data.sessionId != null) {
-                const sid = data.sessionId;
-                setSessionId(sid);
-                sessionIdRef.current = sid;
-                // 세션 ID 확정 후 웹소켓 연결 및 photo-window 구독
-                connectSocket(sid);
-                // GPS 추적 시작 — 백그라운드 포함
-                setRecordedCoords([]);
-                lastLocationTsRef.current = 0;
-                lastPublishTsRef.current = 0;
-                lastAcceptedCoordRef.current = null;
-                setLocationTaskCallback(handleBackgroundLocationUpdate);
-                startLocationTask().catch((err) => {
-                  console.warn("[Location] 백그라운드 위치 시작 실패:", err);
-                });
-              }
-            },
-            onError: (err: any) => {
-              if (!isMountedRef.current) return;
-              console.warn(
-                "[Tracking] 세션 시작 실패:",
-                err?.response?.data ?? err?.message ?? err,
-              );
-              Sentry.captureException(new Error("TrackingSessionStartFailed"));
-              // API 실패 시 트래킹 상태 롤백
-              setIsTracking(false);
-              setIsFreeMode(false);
-            },
-          },
-        );
+
+      // 산이 없으면 세션을 만들 수 없다. isTracking을 켜두면 세션·GPS·소켓이
+      // 전부 죽은 채 화면만 트래킹 중인 좀비 상태가 되므로 여기서 중단한다.
+      if (mountainId == null) {
+        setIsFreeMode(false);
+        setShowNoNearbyMountainModal(true);
+        return;
       }
+
+      setIsTracking(true);
+      startSession(
+        {
+          mountainId,
+          courseId: isFreeMode
+            ? undefined
+            : (selectedCourseId_num ?? undefined),
+          isFreeRecording: isFreeMode,
+        },
+        {
+          onSuccess: (data) => {
+            if (!isMountedRef.current) return;
+            if (data.sessionId != null) {
+              const sid = data.sessionId;
+              setSessionId(sid);
+              sessionIdRef.current = sid;
+              // 세션 ID 확정 후 웹소켓 연결 및 photo-window 구독
+              connectSocket(sid);
+              // GPS 추적 시작 — 백그라운드 포함
+              setRecordedCoords([]);
+              lastLocationTsRef.current = 0;
+              lastPublishTsRef.current = 0;
+              lastAcceptedCoordRef.current = null;
+              setLocationTaskCallback(handleBackgroundLocationUpdate);
+              startLocationTask().catch((err) => {
+                console.warn("[Location] 백그라운드 위치 시작 실패:", err);
+              });
+            }
+          },
+          onError: (err: any) => {
+            if (!isMountedRef.current) return;
+            console.warn(
+              "[Tracking] 세션 시작 실패:",
+              err?.response?.data ?? err?.message ?? err,
+            );
+            Sentry.captureException(new Error("TrackingSessionStartFailed"));
+            // API 실패 시 트래킹 상태 롤백
+            setIsTracking(false);
+            setIsFreeMode(false);
+          },
+        },
+      );
       return;
     }
     const timer = setTimeout(
@@ -1537,6 +1576,12 @@ export default function TrackingScreen() {
           setShowFreeRecordModal(false);
           startCountdown();
         }}
+      />
+
+      {/* 근처에 산이 없어 자유 기록을 시작할 수 없을 때 */}
+      <NoNearbyMountainModal
+        visible={showNoNearbyMountainModal}
+        onClose={() => setShowNoNearbyMountainModal(false)}
       />
 
       {/* 기록 종료 확인 모달 */}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -112,10 +112,9 @@ const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 // GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
 
-// 자유 기록을 해당 산에 귀속시킬 수 있는 최대 거리(산 중심 좌표 기준).
-// nearby-mountain API는 거리와 무관하게 가장 가까운 산을 돌려주므로,
-// 이 값이 없으면 산과 멀리 떨어진 곳의 기록도 그 산에 붙는다.
-const FREE_RECORD_MAX_DISTANCE_M = 3000;
+// 자유 기록을 산에 귀속시킬 최대 거리 — nearby API는 거리 무관하게 최근접 산을 돌려줌
+// 산 좌표가 정상 기준이라 등산로 입구(정상까지 3~5km)를 감안해 넉넉히 잡음
+const FREE_RECORD_MAX_DISTANCE_M = 5000;
 
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
@@ -943,7 +942,7 @@ export default function TrackingScreen() {
     setCountdown(3);
   };
 
-  // 현위치 ~ 근처 산 중심 좌표 거리(m). 좌표가 없으면 판정 불가로 null
+  // 현위치 ~ 근처 산 거리(m), 좌표 없으면 null
   const nearbyMountainDistanceM = useMemo(() => {
     if (!userLocation) return null;
     const latitude = nearbyMountain?.latitude;
@@ -953,7 +952,7 @@ export default function TrackingScreen() {
   }, [userLocation, nearbyMountain]);
 
   const handleFreeRecord = () => {
-    // 코스 상세에서 산을 명시적으로 골라 진입한 경우엔 그 산의 좌표를 알 수 없어 거리 판정에서 제외
+    // 산을 골라 진입한 경우엔 좌표를 알 수 없어 거리 판정 제외
     if (mountainIdParameter) {
       startCountdown(true);
       return;
@@ -980,8 +979,7 @@ export default function TrackingScreen() {
         ? Number(mountainIdParameter)
         : nearbyData?.mountain?.mountainId;
 
-      // 산이 없으면 세션을 만들 수 없다. isTracking을 켜두면 세션·GPS·소켓이
-      // 전부 죽은 채 화면만 트래킹 중인 좀비 상태가 되므로 여기서 중단한다.
+      // 산이 없으면 세션 생성 불가 — isTracking만 켜면 GPS·소켓 없이 화면만 트래킹 중이 됨
       if (mountainId == null) {
         setIsFreeMode(false);
         setShowNoNearbyMountainModal(true);
@@ -1578,7 +1576,7 @@ export default function TrackingScreen() {
         }}
       />
 
-      {/* 근처에 산이 없어 자유 기록을 시작할 수 없을 때 */}
+      {/* 근처에 산이 없을 때 */}
       <NoNearbyMountainModal
         visible={showNoNearbyMountainModal}
         onClose={() => setShowNoNearbyMountainModal(false)}

--- a/features/tracking/components/no-nearby-mountain-modal.tsx
+++ b/features/tracking/components/no-nearby-mountain-modal.tsx
@@ -1,0 +1,60 @@
+import { Modal, Text, TouchableOpacity, View } from "react-native";
+
+const MODAL_BORDER_RADIUS = 16;
+const MODAL_MAX_WIDTH = 320;
+// 배경 오버레이 투명도
+const OVERLAY_COLOR = "rgba(0,0,0,0.4)";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export function NoNearbyMountainModal({ visible, onClose }: Props) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      {/* 어두운 오버레이 */}
+      <View
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: OVERLAY_COLOR }}
+      >
+        {/* 모달 본체 */}
+        <View
+          className="w-full bg-fill-normal"
+          style={{
+            maxWidth: MODAL_MAX_WIDTH,
+            borderRadius: MODAL_BORDER_RADIUS,
+            marginHorizontal: 16,
+          }}
+        >
+          {/* 타이틀 + 설명 */}
+          <View className="gap-2 px-5 pb-4 pt-5">
+            <Text className="typo-heading-1-semi-bold text-label-normal">
+              근처에 산이 없어요
+            </Text>
+            <Text className="typo-body-1-normal-regular text-label-normal">
+              자유 기록은 산 근처에서만 시작할 수 있어요. 산으로 이동한 뒤 다시
+              시도해 주세요.
+            </Text>
+          </View>
+
+          {/* 확인 */}
+          <View className="px-4 pb-4">
+            <TouchableOpacity
+              className="items-center justify-center rounded-[10px] bg-label-normal"
+              style={{ height: 48 }}
+              onPress={onClose}
+            >
+              <Text className="typo-label-large text-common-100">확인</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}


### PR DESCRIPTION
Closes #179

> [!IMPORTANT]
> base 가 `main` 이 아니라 **`fix/map-camera-pin` (#178)** 입니다. #178 이 추가한 `nearbyMountain` 을 그대로 사용하고 같은 파일의 인접 영역을 수정해서 스택으로 쌓았습니다. **#178 머지 후에 머지해 주세요** (머지되면 base 가 자동으로 `main` 으로 바뀝니다).

## 문제

자유 기록이 거리와 무관하게 "가장 가까운 산"에 귀속됐습니다. 도심에서 시작한 기록이 수십 km 떨어진 산의 기록으로 남습니다.

## 변경사항

**1. 반경 검사 추가**

```tsx
const FREE_RECORD_MAX_DISTANCE_M = 5000;   // 5km
```

`handleFreeRecord` 에서 현위치 ↔ 근처 산 중심 좌표 거리를 `haversineMeters()`(기존 헬퍼)로 계산해 임계값을 넘으면 시작을 막고 안내 모달을 띄웁니다.

코스 상세에서 산을 명시적으로 골라 진입한 경우(`mountainIdParameter`)는 그 산의 좌표를 알 수 없어 거리 판정에서 제외했습니다.

**2. 좀비 트래킹 상태 제거**

```diff
-setIsTracking(true);
 const mountainId = ...
-if (mountainId != null) { startSession(...) }
+if (mountainId == null) { /* 안내 후 중단 */ return; }
+setIsTracking(true);
+startSession(...)
```

기존에는 `mountainId` 가 없어도 `isTracking` 이 켜져 화면만 트래킹 중이고 세션·GPS·소켓은 전부 죽은 상태가 됐습니다.

**3. `NoNearbyMountainModal` 신규**

기존 `StopConfirmModal` · `FreeRecordConfirmModal` 과 동일한 구조·상수(`borderRadius` 16, `maxWidth` 320, 오버레이 `rgba(0,0,0,0.4)`, 버튼 높이 48)로 맞췄습니다. 선택지가 없어 버튼은 `확인` 하나입니다.

## 리뷰 포인트

- **임계 거리 5km 근거** — 산 좌표가 정상 기준인데 사용자는 등산로 입구에서 기록을 시작합니다 (정상↔입구: 관악산 3~4km, 북한산 3~5km). 값을 키워도 "어느 산인지"는 API가 정하므로 엉뚱한 산에 붙을 위험은 커지지 않고, 도심 한복판(최근접 산까지 10km+)은 여전히 차단됩니다. `FREE_RECORD_MAX_DISTANCE_M` 한 줄로 조정 가능합니다
- **반경 밖 동작을 "차단"으로 정했습니다.** `CreateTrackingSessionRequest.mountainId` 가 필수라 "산에 묶이지 않은 자유 기록"은 현재 API로 불가능합니다. 허용하려면 백엔드에서 optional 전환이 필요합니다
- 이번 PR에서 손대지 않은 것 — `FreeRecordConfirmModal` 은 `setShowFreeRecordModal(true)` 호출부가 없어 도달 불가능한 죽은 UI이고, `onConfirm` 이 `startCountdown()` 을 인자 없이 불러 `freeMode` 가 `false` 로 들어갑니다. 별도 정리 필요 (#179 본문에 기록)

## 검증

- `npx tsc --noEmit` — 통과
- `npx eslint` — 0 errors, 경고 12개는 변경 전과 동일

**실기기 확인은 하지 않았습니다.** 산에서 멀리 떨어진 위치에서 자유 기록 시작 시 모달이 뜨는지, 산 근처에서는 정상 시작되는지 확인 부탁드립니다.

