### PR TITLE
fix: 1분 미만 세션은 기록으로 저장하지 않고 폐기 (#182)

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -7,6 +7,7 @@ import { CountdownOverlay } from "@/features/tracking/components/countdown-overl
 import { CourseSelectSheet } from "@/features/tracking/components/course-select-sheet";
 import { DifficultyRatingModal } from "@/features/tracking/components/difficulty-rating-modal";
 import { FreeRecordConfirmModal } from "@/features/tracking/components/free-record-confirm-modal";
+import { NoNearbyMountainModal } from "@/features/tracking/components/no-nearby-mountain-modal";
 import { PhotoWindowBanner } from "@/features/tracking/components/photo-window-banner";
 import { StopConfirmModal } from "@/features/tracking/components/stop-confirm-modal";
 import { SummitSheet } from "@/features/tracking/components/summit-sheet";
@@ -111,6 +112,11 @@ const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 // GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
 
+// 자유 기록을 해당 산에 귀속시킬 수 있는 최대 거리(산 중심 좌표 기준).
+// nearby-mountain API는 거리와 무관하게 가장 가까운 산을 돌려주므로,
+// 이 값이 없으면 산과 멀리 떨어진 곳의 기록도 그 산에 붙는다.
+const FREE_RECORD_MAX_DISTANCE_M = 3000;
+
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
   a: { latitude: number; longitude: number },
@@ -183,6 +189,8 @@ export default function TrackingScreen() {
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
+  const [showNoNearbyMountainModal, setShowNoNearbyMountainModal] =
+    useState(false);
   // 그라데이션 바 레이아웃 (map 영역 내 좌표)
   const [barLayout, setBarLayout] = useState<{
     top: number;
@@ -935,12 +943,35 @@ export default function TrackingScreen() {
     setCountdown(3);
   };
 
-  const handleFreeRecord = () => startCountdown(true);
+  // 현위치 ~ 근처 산 중심 좌표 거리(m). 좌표가 없으면 판정 불가로 null
+  const nearbyMountainDistanceM = useMemo(() => {
+    if (!userLocation) return null;
+    const latitude = nearbyMountain?.latitude;
+    const longitude = nearbyMountain?.longitude;
+    if (latitude == null || longitude == null) return null;
+    return haversineMeters(userLocation, { latitude, longitude });
+  }, [userLocation, nearbyMountain]);
+
+  const handleFreeRecord = () => {
+    // 코스 상세에서 산을 명시적으로 골라 진입한 경우엔 그 산의 좌표를 알 수 없어 거리 판정에서 제외
+    if (mountainIdParameter) {
+      startCountdown(true);
+      return;
+    }
+    if (
+      nearbyMountain?.mountainId == null ||
+      nearbyMountainDistanceM == null ||
+      nearbyMountainDistanceM > FREE_RECORD_MAX_DISTANCE_M
+    ) {
+      setShowNoNearbyMountainModal(true);
+      return;
+    }
+    startCountdown(true);
+  };
 
   useEffect(() => {
     if (countdown === null) return;
     if (countdown === 0) {
-      setIsTracking(true);
       setCountdown(null);
 
       // 트래킹 세션 시작 API 호출
@@ -948,49 +979,57 @@ export default function TrackingScreen() {
       const mountainId = mountainIdParameter
         ? Number(mountainIdParameter)
         : nearbyData?.mountain?.mountainId;
-      if (mountainId != null) {
-        startSession(
-          {
-            mountainId,
-            courseId: isFreeMode
-              ? undefined
-              : (selectedCourseId_num ?? undefined),
-            isFreeRecording: isFreeMode,
-          },
-          {
-            onSuccess: (data) => {
-              if (!isMountedRef.current) return;
-              if (data.sessionId != null) {
-                const sid = data.sessionId;
-                setSessionId(sid);
-                sessionIdRef.current = sid;
-                // 세션 ID 확정 후 웹소켓 연결 및 photo-window 구독
-                connectSocket(sid);
-                // GPS 추적 시작 — 백그라운드 포함
-                setRecordedCoords([]);
-                lastLocationTsRef.current = 0;
-                lastPublishTsRef.current = 0;
-                lastAcceptedCoordRef.current = null;
-                setLocationTaskCallback(handleBackgroundLocationUpdate);
-                startLocationTask().catch((err) => {
-                  console.warn("[Location] 백그라운드 위치 시작 실패:", err);
-                });
-              }
-            },
-            onError: (err: any) => {
-              if (!isMountedRef.current) return;
-              console.warn(
-                "[Tracking] 세션 시작 실패:",
-                err?.response?.data ?? err?.message ?? err,
-              );
-              Sentry.captureException(new Error("TrackingSessionStartFailed"));
-              // API 실패 시 트래킹 상태 롤백
-              setIsTracking(false);
-              setIsFreeMode(false);
-            },
-          },
-        );
+
+      // 산이 없으면 세션을 만들 수 없다. isTracking을 켜두면 세션·GPS·소켓이
+      // 전부 죽은 채 화면만 트래킹 중인 좀비 상태가 되므로 여기서 중단한다.
+      if (mountainId == null) {
+        setIsFreeMode(false);
+        setShowNoNearbyMountainModal(true);
+        return;
       }
+
+      setIsTracking(true);
+      startSession(
+        {
+          mountainId,
+          courseId: isFreeMode
+            ? undefined
+            : (selectedCourseId_num ?? undefined),
+          isFreeRecording: isFreeMode,
+        },
+        {
+          onSuccess: (data) => {
+            if (!isMountedRef.current) return;
+            if (data.sessionId != null) {
+              const sid = data.sessionId;
+              setSessionId(sid);
+              sessionIdRef.current = sid;
+              // 세션 ID 확정 후 웹소켓 연결 및 photo-window 구독
+              connectSocket(sid);
+              // GPS 추적 시작 — 백그라운드 포함
+              setRecordedCoords([]);
+              lastLocationTsRef.current = 0;
+              lastPublishTsRef.current = 0;
+              lastAcceptedCoordRef.current = null;
+              setLocationTaskCallback(handleBackgroundLocationUpdate);
+              startLocationTask().catch((err) => {
+                console.warn("[Location] 백그라운드 위치 시작 실패:", err);
+              });
+            }
+          },
+          onError: (err: any) => {
+            if (!isMountedRef.current) return;
+            console.warn(
+              "[Tracking] 세션 시작 실패:",
+              err?.response?.data ?? err?.message ?? err,
+            );
+            Sentry.captureException(new Error("TrackingSessionStartFailed"));
+            // API 실패 시 트래킹 상태 롤백
+            setIsTracking(false);
+            setIsFreeMode(false);
+          },
+        },
+      );
       return;
     }
     const timer = setTimeout(
@@ -1537,6 +1576,12 @@ export default function TrackingScreen() {
           setShowFreeRecordModal(false);
           startCountdown();
         }}
+      />
+
+      {/* 근처에 산이 없어 자유 기록을 시작할 수 없을 때 */}
+      <NoNearbyMountainModal
+        visible={showNoNearbyMountainModal}
+        onClose={() => setShowNoNearbyMountainModal(false)}
       />
 
       {/* 기록 종료 확인 모달 */}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -112,10 +112,9 @@ const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 // GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
 
-// 자유 기록을 해당 산에 귀속시킬 수 있는 최대 거리(산 중심 좌표 기준).
-// nearby-mountain API는 거리와 무관하게 가장 가까운 산을 돌려주므로,
-// 이 값이 없으면 산과 멀리 떨어진 곳의 기록도 그 산에 붙는다.
-const FREE_RECORD_MAX_DISTANCE_M = 3000;
+// 자유 기록을 산에 귀속시킬 최대 거리 — nearby API는 거리 무관하게 최근접 산을 돌려줌
+// 산 좌표가 정상 기준이라 등산로 입구(정상까지 3~5km)를 감안해 넉넉히 잡음
+const FREE_RECORD_MAX_DISTANCE_M = 5000;
 
 // 두 좌표 간 거리(m) — Haversine
 function haversineMeters(
@@ -943,7 +942,7 @@ export default function TrackingScreen() {
     setCountdown(3);
   };
 
-  // 현위치 ~ 근처 산 중심 좌표 거리(m). 좌표가 없으면 판정 불가로 null
+  // 현위치 ~ 근처 산 거리(m), 좌표 없으면 null
   const nearbyMountainDistanceM = useMemo(() => {
     if (!userLocation) return null;
     const latitude = nearbyMountain?.latitude;
@@ -953,7 +952,7 @@ export default function TrackingScreen() {
   }, [userLocation, nearbyMountain]);
 
   const handleFreeRecord = () => {
-    // 코스 상세에서 산을 명시적으로 골라 진입한 경우엔 그 산의 좌표를 알 수 없어 거리 판정에서 제외
+    // 산을 골라 진입한 경우엔 좌표를 알 수 없어 거리 판정 제외
     if (mountainIdParameter) {
       startCountdown(true);
       return;
@@ -980,8 +979,7 @@ export default function TrackingScreen() {
         ? Number(mountainIdParameter)
         : nearbyData?.mountain?.mountainId;
 
-      // 산이 없으면 세션을 만들 수 없다. isTracking을 켜두면 세션·GPS·소켓이
-      // 전부 죽은 채 화면만 트래킹 중인 좀비 상태가 되므로 여기서 중단한다.
+      // 산이 없으면 세션 생성 불가 — isTracking만 켜면 GPS·소켓 없이 화면만 트래킹 중이 됨
       if (mountainId == null) {
         setIsFreeMode(false);
         setShowNoNearbyMountainModal(true);
@@ -1578,7 +1576,7 @@ export default function TrackingScreen() {
         }}
       />
 
-      {/* 근처에 산이 없어 자유 기록을 시작할 수 없을 때 */}
+      {/* 근처에 산이 없을 때 */}
       <NoNearbyMountainModal
         visible={showNoNearbyMountainModal}
         onClose={() => setShowNoNearbyMountainModal(false)}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -24,6 +24,7 @@ import {
   TRACKING_SHEET_HEIGHT,
 } from "@/features/tracking/constants";
 import { useActiveTrackingSession } from "@/features/tracking/hooks/use-active-tracking-session";
+import { useAbandonTrackingSession } from "@/features/tracking/hooks/use-abandon-tracking-session";
 import { useCompleteTrackingSession } from "@/features/tracking/hooks/use-complete-tracking-session";
 import { useCourseDetail } from "@/features/tracking/hooks/use-course-detail";
 import { useLiveActivityCourse } from "@/features/tracking/hooks/use-live-activity-course";
@@ -111,6 +112,9 @@ const MIN_GPS_PUBLISH_INTERVAL_MS = 3000;
 
 // GPS 응답 전 임시 중심 좌표 (서울시청)
 const FALLBACK_CAMERA = { latitude: 37.5665, longitude: 126.978, zoom: 12 };
+
+// 이보다 짧은 세션은 기록으로 남기지 않고 abandon 처리
+const MIN_RECORD_DURATION_SEC = 60;
 
 // 자유 기록을 산에 귀속시킬 최대 거리 — nearby API는 거리 무관하게 최근접 산을 돌려줌
 // 산 좌표가 정상 기준이라 등산로 입구(정상까지 3~5km)를 감안해 넉넉히 잡음
@@ -382,6 +386,7 @@ export default function TrackingScreen() {
   const { mutate: pauseSession } = usePauseTrackingSession();
   const { mutate: resumeSession } = useResumeTrackingSession();
   const { mutate: completeSession } = useCompleteTrackingSession();
+  const { mutate: abandonSession } = useAbandonTrackingSession();
   const { mutateAsync: savePhoto } = useSaveTrackingPhoto();
   const { mutate: saveDifficultyFeedback } = useSaveDifficultyFeedback();
   const { data: activeSession, refetch: refetchActiveSession } =
@@ -1295,19 +1300,41 @@ export default function TrackingScreen() {
   /** StopConfirmModal → 난이도 체감 화면으로 전환 */
   const finishTracking = () => {
     setShowStopModal(false);
-    // 기록 종료 시 항상 세션 완료 API 호출 (정상 인증 여부와 무관)
+
+    // complete는 등산 기록을 생성하므로 짧은 세션은 abandon으로 폐기
+    const tooShortToRecord = elapsedSeconds < MIN_RECORD_DURATION_SEC;
+
     if (sessionId != null) {
-      completeSession(sessionId, {
-        onSuccess: (data) => {
-          if (data.hikingRecordId != null)
-            setHikingRecordId(data.hikingRecordId);
-        },
-        onError: (err) => {
-          console.warn("[Tracking] 세션 종료 실패:", err);
-          Sentry.captureException(new Error("TrackingSessionCompleteFailed"));
-        },
-      });
+      if (tooShortToRecord) {
+        abandonSession(sessionId, {
+          onError: (err) => {
+            console.warn("[Tracking] 세션 폐기 실패:", err);
+            Sentry.captureException(new Error("TrackingSessionAbandonFailed"));
+          },
+        });
+      } else {
+        completeSession(sessionId, {
+          onSuccess: (data) => {
+            if (data.hikingRecordId != null)
+              setHikingRecordId(data.hikingRecordId);
+          },
+          onError: (err) => {
+            console.warn("[Tracking] 세션 종료 실패:", err);
+            Sentry.captureException(new Error("TrackingSessionCompleteFailed"));
+          },
+        });
+      }
     }
+
+    // 기록이 남지 않으므로 난이도 평가 단계도 건너뛴다
+    if (tooShortToRecord) {
+      completeTracking(null);
+      toast.show(
+        `${MIN_RECORD_DURATION_SEC / 60}분 미만은 기록으로 저장되지 않아요`,
+      );
+      return;
+    }
+
     // 자유기록은 난이도 평가 없이 바로 종료
     if (isFreeMode) {
       completeTracking(null);

--- a/features/tracking/components/no-nearby-mountain-modal.tsx
+++ b/features/tracking/components/no-nearby-mountain-modal.tsx
@@ -1,0 +1,60 @@
+import { Modal, Text, TouchableOpacity, View } from "react-native";
+
+const MODAL_BORDER_RADIUS = 16;
+const MODAL_MAX_WIDTH = 320;
+// 배경 오버레이 투명도
+const OVERLAY_COLOR = "rgba(0,0,0,0.4)";
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+};
+
+export function NoNearbyMountainModal({ visible, onClose }: Props) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      {/* 어두운 오버레이 */}
+      <View
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: OVERLAY_COLOR }}
+      >
+        {/* 모달 본체 */}
+        <View
+          className="w-full bg-fill-normal"
+          style={{
+            maxWidth: MODAL_MAX_WIDTH,
+            borderRadius: MODAL_BORDER_RADIUS,
+            marginHorizontal: 16,
+          }}
+        >
+          {/* 타이틀 + 설명 */}
+          <View className="gap-2 px-5 pb-4 pt-5">
+            <Text className="typo-heading-1-semi-bold text-label-normal">
+              근처에 산이 없어요
+            </Text>
+            <Text className="typo-body-1-normal-regular text-label-normal">
+              자유 기록은 산 근처에서만 시작할 수 있어요. 산으로 이동한 뒤 다시
+              시도해 주세요.
+            </Text>
+          </View>
+
+          {/* 확인 */}
+          <View className="px-4 pb-4">
+            <TouchableOpacity
+              className="items-center justify-center rounded-[10px] bg-label-normal"
+              style={{ height: 48 }}
+              onPress={onClose}
+            >
+              <Text className="typo-label-large text-common-100">확인</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/features/tracking/hooks/use-abandon-tracking-session.ts
+++ b/features/tracking/hooks/use-abandon-tracking-session.ts
@@ -1,0 +1,22 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ACTIVE_SESSION_KEY } from "./use-active-tracking-session";
+
+/** 세션을 기록으로 남기지 않고 폐기 — complete와 달리 hikingRecord를 만들지 않음 */
+export function useAbandonTrackingSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (sessionId: number): Promise<void> => {
+      await api.post(
+        { path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_ABANDON(sessionId) },
+        { ignoreErrorToast: true },
+      );
+    },
+    onSettled: () => {
+      // 성공/실패와 무관하게 활성 세션 갱신
+      queryClient.invalidateQueries({ queryKey: ACTIVE_SESSION_KEY });
+    },
+  });
+}


### PR DESCRIPTION
Closes #182

> [!IMPORTANT]
> base 가 `main` 이 아니라 **`fix/free-record-mountain-radius` (#180)** 입니다. `tracking.tsx` 를 함께 수정해서 스택으로 쌓았습니다. 머지 순서: **#178 → #180 → 이 PR**. 앞 PR 이 머지되면 base 가 자동으로 내려옵니다.

## 문제

트래킹을 시작했다가 바로 종료해도 등산 기록이 생성됐습니다. 몇 초짜리 세션이 기록 목록에 남고 거리·칼로리로 집계됩니다.

## 변경사항

**1. 임계값 미만이면 `abandon`**

```tsx
const MIN_RECORD_DURATION_SEC = 60;

const tooShortToRecord = elapsedSeconds < MIN_RECORD_DURATION_SEC;
if (tooShortToRecord) {
  abandonSession(sessionId, { ... });   // 기록 생성 없이 세션만 정리
} else {
  completeSession(sessionId, { ... });  // 기존 경로
}
```

`POST /api/tracking/sessions/{sessionId}/abandon` 은 API 에 이미 있었는데 **앱 어디에서도 호출하지 않고 있었습니다.** 이번에 `useAbandonTrackingSession` 훅을 추가해 연결했습니다.

**2. 난이도 평가 건너뛰기 + 안내**

기록이 생성되지 않으니 `hikingRecordId` 도 없습니다. 난이도 평가 모달을 띄우면 저장할 대상이 없으므로 건너뛰고, 토스트로 알립니다.

> 1분 미만은 기록으로 저장되지 않아요

## 리뷰 포인트

- **임계값 1분이 적절한지** — `MIN_RECORD_DURATION_SEC` 한 줄로 조정됩니다
- **안내 시점** — 지금은 종료를 누른 *뒤* 토스트입니다. 종료 확인 모달(`StopConfirmModal`)에서 미리 "1분 미만이라 저장되지 않아요" 로 문구를 바꾸는 방식도 가능한데, 모달이 다른 흐름과 공유돼 있어 이번엔 건드리지 않았습니다
- `abandon` 실패 시에도 로컬 트래킹 상태는 정리합니다 (`onSettled` 로 활성 세션 쿼리 무효화). 세션이 서버에 남더라도 앱이 멈추지 않게 하는 쪽을 택했습니다

## 칼로리 관련

프론트에는 칼로리 계산 로직이 **없습니다.** `recordDetail.calories` 를 표시만 합니다 (`app/record/[id].tsx:465`, `photo-report-edit.tsx:143`). 짧은 세션이 기록으로 남지 않게 되면 증상은 줄지만, 산식 자체는 서버 확인이 필요합니다.

## 검증

- `npx tsc --noEmit` — 통과
- `npx eslint` — 0 errors, 경고 12개는 변경 전과 동일

**실기기 확인은 하지 않았습니다.** 시작 후 1분 내 종료 시 기록이 안 생기는지, 1분 넘겼을 때는 정상 저장되는지 확인 부탁드립니다.
