### PR TITLE
fix: 회원가입 미완료 상태로 앱 재진입되는 문제 수정 및 건너뛰기 제거

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -179,6 +179,9 @@ function RootLayout(): React.JSX.Element | null {
             />
           </Stack>
           {authStatus === "unauthenticated" && <Redirect href="/login" />}
+          {authStatus === "needsOnboarding" && (
+            <Redirect href="/onboarding" />
+          )}
           <Toast />
           <AppUpdateGate />
           <StatusBar style="dark" />

--- a/features/auth/hooks/use-apple-login.ts
+++ b/features/auth/hooks/use-apple-login.ts
@@ -18,9 +18,9 @@ async function appleLogin(body: AppleLoginBody): Promise<OAuthLoginResponse> {
 export function useAppleLogin() {
   return useMutation({
     mutationFn: appleLogin,
-    onSuccess: async ({ accessToken, refreshToken }) => {
+    onSuccess: async ({ accessToken, refreshToken, onboardingCompleted }) => {
       if (accessToken && refreshToken) {
-        await startSession(accessToken, refreshToken);
+        await startSession(accessToken, refreshToken, !!onboardingCompleted);
       }
     },
   });

--- a/features/auth/hooks/use-auth-state.ts
+++ b/features/auth/hooks/use-auth-state.ts
@@ -27,7 +27,12 @@ export function useAuthState(): { status: AuthStatus } {
           { path: ENDPOINTS.USERS_PROFILE },
           { ignoreErrorToast: true },
         );
-        authState.setAuthenticated();
+        const onboardingPending = await tokenStorage.isOnboardingPending();
+        if (onboardingPending) {
+          authState.setNeedsOnboarding();
+        } else {
+          authState.setAuthenticated();
+        }
       } catch {
         authState.setUnauthenticated();
       }

--- a/features/auth/hooks/use-kakao-login.ts
+++ b/features/auth/hooks/use-kakao-login.ts
@@ -19,9 +19,9 @@ export function useKakaoLogin() {
 
       return data;
     },
-    onSuccess: async ({ accessToken, refreshToken }) => {
+    onSuccess: async ({ accessToken, refreshToken, onboardingCompleted }) => {
       if (accessToken && refreshToken) {
-        await startSession(accessToken, refreshToken);
+        await startSession(accessToken, refreshToken, !!onboardingCompleted);
       }
     },
   });

--- a/features/auth/hooks/use-test-login.ts
+++ b/features/auth/hooks/use-test-login.ts
@@ -20,9 +20,9 @@ export function useTestLogin() {
       });
       return res.data;
     },
-    onSuccess: async ({ accessToken, refreshToken }) => {
+    onSuccess: async ({ accessToken, refreshToken, onboardingCompleted }) => {
       if (accessToken && refreshToken) {
-        await startSession(accessToken, refreshToken);
+        await startSession(accessToken, refreshToken, !!onboardingCompleted);
       }
     },
   });

--- a/features/onboarding/components/onboarding-exercise-detail-screen.tsx
+++ b/features/onboarding/components/onboarding-exercise-detail-screen.tsx
@@ -10,6 +10,8 @@ import {
 import { useOnboardingStore } from "@/features/onboarding/store/onboarding-store";
 import { useSubmitOnboardingFromStore } from "@/features/onboarding/store/use-submit-onboarding-from-store";
 import { ApiError } from "@/lib/api";
+import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { authState } from "@/store/auth.store";
 import { toast } from "@/store/toast.store";
 import { router } from "expo-router";
 import { useState } from "react";
@@ -40,6 +42,8 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
       router.replace("/(tabs)");
     } catch (e) {
       if (e instanceof ApiError && e.statusCode === 409) {
+        await tokenStorage.setOnboardingPending(false);
+        authState.setAuthenticated();
         toast.show("이미 등록된 사용자입니다.");
         router.replace("/(tabs)");
       } else {

--- a/features/onboarding/components/onboarding-screen.tsx
+++ b/features/onboarding/components/onboarding-screen.tsx
@@ -237,16 +237,9 @@ export function OnboardingScreen() {
           keyboardShouldPersistTaps="handled"
           keyboardDismissMode="on-drag"
         >
-          <View className="flex-row items-center justify-between">
-            <Text className="text-label-normal typo-heading-1-semi-bold">
-              프로필 정보를 입력해 주세요
-            </Text>
-            <Pressable onPress={() => router.replace("/(tabs)")} hitSlop={8}>
-              <Text className="typo-body-2-normal-regular text-label-subtler">
-                건너뛰기
-              </Text>
-            </Pressable>
-          </View>
+          <Text className="text-label-normal typo-heading-1-semi-bold">
+            프로필 정보를 입력해 주세요
+          </Text>
 
           <View className="mt-6 gap-6">
             {/* 아바타 */}

--- a/features/onboarding/hooks/use-submit-onboarding.ts
+++ b/features/onboarding/hooks/use-submit-onboarding.ts
@@ -1,8 +1,11 @@
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
+import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { authState } from "@/store/auth.store";
 import { useOnboardingStore } from "@/features/onboarding/store/onboarding-store";
 import { ENDPOINTS, RegisterOnboardingRequest } from "@/types/api.generated";
 import { router } from "expo-router";
 import { useMutation } from "@tanstack/react-query";
+import * as Sentry from "@sentry/react-native";
 
 export function useSubmitOnboarding() {
   const reset = useOnboardingStore((s) => s.reset);
@@ -11,8 +14,19 @@ export function useSubmitOnboarding() {
     mutationFn: async (body: RegisterOnboardingRequest): Promise<void> => {
       await api.post({ path: ENDPOINTS.USERS_ONBOARDING, body }, { ignoreErrorToast: true });
     },
-    onSuccess: () => {
+    onSuccess: async () => {
+      await tokenStorage.setOnboardingPending(false);
+      authState.setAuthenticated();
       reset();
+    },
+    onError: (error) => {
+      const statusCode = error instanceof ApiError ? error.statusCode : undefined;
+      // 409(이미 등록된 사용자)는 화면에서 정상 케이스로 처리하므로 노이즈 제외
+      if (statusCode === 409) return;
+      Sentry.captureException(error, {
+        tags: { scope: "onboarding", operation: "submitOnboarding" },
+        extra: { statusCode },
+      });
     },
     mutationKey: [ENDPOINTS.USERS_ONBOARDING],
   });

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -13,11 +13,21 @@ export async function endSession(): Promise<void> {
   authState.setUnauthenticated();
 }
 
-/** 로그인 성공 직후 호출. 토큰 저장 후 인증 상태를 켠다. */
+/**
+ * 로그인 성공 직후 호출. 토큰 저장 후 인증 상태를 켠다.
+ * onboardingCompleted 가 false 면, 다음 앱 재시작 시에도 온보딩 화면으로
+ * 돌아갈 수 있도록 로컬에 "온보딩 미완료" 표시를 남겨둔다.
+ */
 export async function startSession(
   accessToken: string,
   refreshToken: string,
+  onboardingCompleted: boolean,
 ): Promise<void> {
   await tokenStorage.setTokens(accessToken, refreshToken);
-  authState.setAuthenticated();
+  await tokenStorage.setOnboardingPending(!onboardingCompleted);
+  if (onboardingCompleted) {
+    authState.setAuthenticated();
+  } else {
+    authState.setNeedsOnboarding();
+  }
 }

--- a/lib/auth/tokenStorage.ts
+++ b/lib/auth/tokenStorage.ts
@@ -16,6 +16,8 @@ const ACCESS_TOKEN_KEY = "accessToken";
 const REFRESH_TOKEN_KEY = "refreshToken";
 /** 사용자가 명시적으로 로그아웃/탈퇴했음을 기록. 개발용 샘플 토큰 재주입을 막는다. */
 const SIGNED_OUT_KEY = "auth.signedOut";
+/** 로그인은 됐지만 온보딩(회원가입 마지막 단계)이 아직 안 끝났음을 기록 */
+const ONBOARDING_PENDING_KEY = "auth.onboardingPending";
 
 const SAMPLE_ACCESS_TOKEN = process.env.EXPO_PUBLIC_SAMPLE_ACCESS_TOKEN;
 
@@ -74,6 +76,7 @@ export const tokenStorage = {
     await Promise.all([this.removeAccessToken(), this.removeRefreshToken()]);
     try {
       await AsyncStorage.setItem(SIGNED_OUT_KEY, "true");
+      await AsyncStorage.removeItem(ONBOARDING_PENDING_KEY);
     } catch (error) {
       reportFailure("markSignedOut", error);
     }
@@ -88,6 +91,28 @@ export const tokenStorage = {
       await AsyncStorage.removeItem(SIGNED_OUT_KEY);
     } catch (error) {
       reportFailure("clearSignedOutFlag", error);
+    }
+  },
+
+  /** 온보딩이 아직 안 끝난 상태로 표시(true) / 완료 처리(false) */
+  async setOnboardingPending(pending: boolean): Promise<void> {
+    try {
+      if (pending) {
+        await AsyncStorage.setItem(ONBOARDING_PENDING_KEY, "true");
+      } else {
+        await AsyncStorage.removeItem(ONBOARDING_PENDING_KEY);
+      }
+    } catch (error) {
+      reportFailure("setOnboardingPending", error);
+    }
+  },
+
+  async isOnboardingPending(): Promise<boolean> {
+    try {
+      return (await AsyncStorage.getItem(ONBOARDING_PENDING_KEY)) === "true";
+    } catch (error) {
+      reportFailure("isOnboardingPending", error);
+      return false;
     }
   },
 

--- a/store/auth.store.ts
+++ b/store/auth.store.ts
@@ -1,6 +1,10 @@
 import { create } from "zustand";
 
-export type AuthStatus = "loading" | "authenticated" | "unauthenticated";
+export type AuthStatus =
+  | "loading"
+  | "authenticated"
+  | "unauthenticated"
+  | "needsOnboarding";
 
 type AuthState = {
   status: AuthStatus;
@@ -18,4 +22,7 @@ export const authState = {
   setAuthenticated: () => useAuthStore.getState().setStatus("authenticated"),
   setUnauthenticated: () =>
     useAuthStore.getState().setStatus("unauthenticated"),
+  /** 토큰은 유효하지만 회원가입(온보딩)이 끝나지 않은 상태 */
+  setNeedsOnboarding: () =>
+    useAuthStore.getState().setStatus("needsOnboarding"),
 };


### PR DESCRIPTION
## Summary
- 온보딩(회원가입) 마지막 단계 제출이 실패해도 소셜 로그인 시 발급된 토큰은 유효하게 남아있어, 앱을 재시작하면 온보딩 완료 여부를 확인하지 않고 그대로 메인 화면(`/(tabs)`)으로 들여보내던 문제 수정
  - 로그인 응답의 `onboardingCompleted`를 로컬(AsyncStorage)에 기록해두고, 앱 부트스트랩(`use-auth-state.ts`) 시 토큰 유효성과 함께 확인
  - 미완료 상태면 `needsOnboarding` 인증 상태로 전환해 `/onboarding`으로 리다이렉트
  - 온보딩 성공(및 409 "이미 등록된 사용자" 케이스) 시 완료 표시로 전환
  - 온보딩 제출 실패 시 원인 추적을 위해 Sentry 로깅 추가 (기존엔 실패해도 아무 기록이 안 남았음)
- 프로필 입력 화면(`onboarding-screen.tsx`)의 "건너뛰기" 버튼 제거 — 회원가입 없이 메인 화면으로 바로 진입할 수 있던 경로를 막음

## Test plan
- [ ] 소셜 로그인 → 회원가입 마지막 단계에서 네트워크를 끄는 등으로 제출 실패 유도 → 앱 재실행 시 메인화면이 아닌 온보딩 화면으로 돌아가는지 확인
- [ ] 회원가입 정상 완료 후 앱 재실행 시 메인화면으로 정상 진입하는지 확인
- [ ] 이미 가입된 계정으로 재로그인 시 정상적으로 메인화면 진입하는지 확인
- [ ] 프로필 입력 화면에서 "건너뛰기" 버튼이 더 이상 노출되지 않는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 온보딩을 완료하지 않은 신규 로그인 사용자는 자동으로 온보딩 화면으로 이동합니다.
  * 로그인 과정에서 온보딩 완료 상태가 유지되어 다음 화면이 올바르게 표시됩니다.
* **개선 사항**
  * 온보딩 화면에서 건너뛰기 기능이 제거되었습니다.
  * 온보딩 완료 후 인증 상태가 즉시 갱신됩니다.
* **버그 수정**
  * 이미 등록된 사용자 처리 시 안내 후 정상적으로 메인 화면으로 이동합니다.
  * 온보딩 제출 오류 처리가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->