### PR TITLE
fix: 세모피드 그리드 20개 이후 사진이 로드되지 않던 문제 수정

### DIFF
--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -1,7 +1,7 @@
 import { ResetIcon } from "@/components/icons/reset-icon";
 import { SemoFeedResponse } from "@/types/api.generated";
 import { Image } from "expo-image";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 import { Gesture, GestureDetector } from "react-native-gesture-handler";
 import Animated, {
@@ -42,7 +42,13 @@ const OVERSCAN = 1; // 화면 밖 여유분 (셀 단위)
 // 메인 그리드
 // ─────────────────────────────────────────────
 export function FeedHomeView() {
-  const { data: semofeedData, refetch } = useSemofeed();
+  const {
+    data: semofeedData,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useSemofeed();
 
   const feedItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
 
@@ -125,6 +131,8 @@ export function FeedHomeView() {
   // 가상화: 화면에 보일 셀 범위 계산
   // ─────────────────────────────────────────────
   const cells: React.ReactElement[] = [];
+  // 뷰포트가 현재 로드된 나선의 가장 바깥 링에 닿았는지 (다음 페이지 로드 트리거)
+  let touchesEdge = false;
 
   if (screen.w > 0 && screen.h > 0) {
     // "지금 화면 왼쪽 위가 그리드의 어느 픽셀 지점인가"
@@ -141,6 +149,14 @@ export function FeedHomeView() {
       feedItems.length > 0
         ? Math.ceil((Math.sqrt(feedItems.length) - 1) / 2)
         : 0;
+
+    touchesEdge =
+      Math.max(
+        Math.abs(colStart),
+        Math.abs(colEnd),
+        Math.abs(rowStart),
+        Math.abs(rowEnd),
+      ) >= maxRing;
 
     for (let col = colStart; col <= colEnd; col++) {
       if (Math.abs(col) > maxRing) continue;
@@ -160,6 +176,13 @@ export function FeedHomeView() {
       }
     }
   }
+
+  // 뷰포트가 로드된 영역의 가장자리에 닿으면 다음 페이지 로드
+  useEffect(() => {
+    if (touchesEdge && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [touchesEdge, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   // ─────────────────────────────────────────────
   // 렌더


### PR DESCRIPTION
## Summary
- `useSemofeed`가 `useInfiniteQuery`로 페이지당 20개씩(`size: 20`) 가져오도록 되어있었지만, 다음 페이지를 요청하는 `fetchNextPage` 호출이 화면(`feed-home-view.tsx`)에 전혀 연결되어 있지 않아 첫 페이지(20개) 이후로는 사진이 아무리 많아도 더 불러와지지 않던 문제 수정
- 나선형(spiral) 그리드 뷰포트가 현재 로드된 최외곽 링에 닿으면 자동으로 `fetchNextPage()`를 호출하도록 `useEffect` 추가
- `isFetchingNextPage`/`hasNextPage` 가드를 넣어 중복 요청 및 더 이상 가져올 페이지가 없을 때의 불필요한 호출 방지

## Test plan
- [ ] 세모피드 탭에서 사진이 20개보다 많은 계정으로 그리드를 계속 드래그했을 때 21번째 이후 사진도 정상적으로 로드되는지 확인
- [ ] 빠르게 플릭(flick)해서 멀리 이동해도 순차적으로 다음 페이지들이 로드되는지 확인
- [ ] 사진이 20개 이하인 계정에서는 기존과 동일하게 정상 동작하는지 확인
- [ ] 우측 하단 리셋 버튼 동작에 영향 없는지 확인