### PR TITLE
feat: 자유 기록 종료 시 코스 이름을 입력받아 홈에 표시

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -4,6 +4,7 @@ import { isLiveActivityEnabled } from "@/constants/platform";
 import { useProfile } from "@/features/mypage/hooks/use-profile";
 import { CollapsedCourseCard } from "@/features/tracking/components/collapsed-course-card";
 import { CountdownOverlay } from "@/features/tracking/components/countdown-overlay";
+import { CourseNameInputModal } from "@/features/tracking/components/course-name-input-modal";
 import { CourseSelectSheet } from "@/features/tracking/components/course-select-sheet";
 import { DifficultyRatingModal } from "@/features/tracking/components/difficulty-rating-modal";
 import { FreeRecordConfirmModal } from "@/features/tracking/components/free-record-confirm-modal";
@@ -178,6 +179,12 @@ export default function TrackingScreen() {
   // TODO: 실제 구현 시 GPS 좌표 기반으로 정상 도달 여부 판단
   const [isAtSummit, setIsAtSummit] = useState(false); // 목 값 (GPS 연동 전까지 false)
   const [showSummitSheet, setShowSummitSheet] = useState(false);
+  // 자유기록 종료 후 코스 이름 입력 모달
+  const [showCourseNameModal, setShowCourseNameModal] = useState(false);
+  // 사용자가 입력한 자유기록 코스 이름 (미입력 시 null)
+  const [freeRecordCourseName, setFreeRecordCourseName] = useState<
+    string | null
+  >(null);
   const [trackingSheetHeight, setTrackingSheetHeight] = useState(
     TRACKING_SHEET_HEIGHT,
   );
@@ -944,6 +951,7 @@ export default function TrackingScreen() {
 
   const startCountdown = (freeMode = false) => {
     setIsFreeMode(freeMode === true); // 이벤트 객체 등 non-boolean 방지
+    setFreeRecordCourseName(null);
     setCountdown(3);
   };
 
@@ -1297,37 +1305,44 @@ export default function TrackingScreen() {
     }
   };
 
-  /** StopConfirmModal → 난이도 체감 화면으로 전환 */
+  /**
+   * 세션을 COMPLETED로 마감한다.
+   * 자유기록은 사용자가 입력한 기록 이름을 함께 보내고, 비워 보내면 서버가 기본 이름을 채운다.
+   * 코스 기록은 코스명으로 표시되므로 이름을 보내지 않는다.
+   */
+  const runCompleteSession = (name?: string) => {
+    if (sessionId == null) return;
+    completeSession(
+      { sessionId, name },
+      {
+        onSuccess: (data) => {
+          if (data.hikingRecordId != null) setHikingRecordId(data.hikingRecordId);
+        },
+        onError: (err) => {
+          console.warn("[Tracking] 세션 종료 실패:", err);
+          Sentry.captureException(new Error("TrackingSessionCompleteFailed"));
+        },
+      },
+    );
+  };
+
+  /** StopConfirmModal → 기록 이름 입력 / 난이도 체감 화면으로 전환 */
   const finishTracking = () => {
     setShowStopModal(false);
 
     // complete는 등산 기록을 생성하므로 짧은 세션은 abandon으로 폐기
     const tooShortToRecord = elapsedSeconds < MIN_RECORD_DURATION_SEC;
 
-    if (sessionId != null) {
-      if (tooShortToRecord) {
+    // 기록이 남지 않으므로 이름 입력·난이도 평가 단계도 건너뛴다
+    if (tooShortToRecord) {
+      if (sessionId != null) {
         abandonSession(sessionId, {
           onError: (err) => {
             console.warn("[Tracking] 세션 폐기 실패:", err);
             Sentry.captureException(new Error("TrackingSessionAbandonFailed"));
           },
         });
-      } else {
-        completeSession(sessionId, {
-          onSuccess: (data) => {
-            if (data.hikingRecordId != null)
-              setHikingRecordId(data.hikingRecordId);
-          },
-          onError: (err) => {
-            console.warn("[Tracking] 세션 종료 실패:", err);
-            Sentry.captureException(new Error("TrackingSessionCompleteFailed"));
-          },
-        });
       }
-    }
-
-    // 기록이 남지 않으므로 난이도 평가 단계도 건너뛴다
-    if (tooShortToRecord) {
       completeTracking(null);
       toast.show(
         `${MIN_RECORD_DURATION_SEC / 60}분 미만은 기록으로 저장되지 않아요`,
@@ -1335,11 +1350,13 @@ export default function TrackingScreen() {
       return;
     }
 
-    // 자유기록은 난이도 평가 없이 바로 종료
+    // 자유기록은 이름을 complete 요청에 실어 보내야 하므로 입력을 먼저 받는다
     if (isFreeMode) {
-      completeTracking(null);
+      setShowCourseNameModal(true);
       return;
     }
+
+    runCompleteSession();
     setShowDifficultyRating(true);
   };
 
@@ -1367,6 +1384,7 @@ export default function TrackingScreen() {
     stopLocationTask().catch(() => {});
     disconnectSocket();
     setShowDifficultyRating(false);
+    setShowCourseNameModal(false);
     setIsTracking(false);
     setIsPaused(false);
     setIsFreeMode(false);
@@ -1380,6 +1398,21 @@ export default function TrackingScreen() {
     summitPhotoWindowRef.current = null;
     setCollapsed(false);
     setRecordedCoords([]);
+  };
+
+  /** 입력한 이름으로 자유기록을 마감 */
+  const handleCourseNameSubmit = (name: string) => {
+    setFreeRecordCourseName(name);
+    setShowCourseNameModal(false);
+    runCompleteSession(name);
+    completeTracking(null);
+  };
+
+  /** 이름 입력 건너뛰기 — 서버 기본 이름으로 마감 */
+  const handleCourseNameSkip = () => {
+    setShowCourseNameModal(false);
+    runCompleteSession();
+    completeTracking(null);
   };
 
   // GPS로 정상 부근 감지 시 자동으로 정상 시트 표시
@@ -1614,6 +1647,15 @@ export default function TrackingScreen() {
         visible={showStopModal}
         onCancel={() => setShowStopModal(false)}
         onConfirm={finishTracking}
+      />
+
+      {/* 자유기록 코스 이름 입력 모달 */}
+      <CourseNameInputModal
+        visible={showCourseNameModal}
+        initialValue={freeRecordCourseName ?? ""}
+        mountainName={nearbyData?.mountain?.name}
+        onCancel={handleCourseNameSkip}
+        onSubmit={handleCourseNameSubmit}
       />
 
       {/* 난이도 체감 모달 */}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1400,18 +1400,15 @@ export default function TrackingScreen() {
     setRecordedCoords([]);
   };
 
-  /** 입력한 이름으로 자유기록을 마감 */
+  /**
+   * 입력한 이름으로 자유기록을 마감.
+   * 비워두고 저장하면 이름 없이 보내 서버 기본 이름으로 저장된다.
+   */
   const handleCourseNameSubmit = (name: string) => {
-    setFreeRecordCourseName(name);
+    const trimmed = name.trim();
+    setFreeRecordCourseName(trimmed || null);
     setShowCourseNameModal(false);
-    runCompleteSession(name);
-    completeTracking(null);
-  };
-
-  /** 이름 입력 건너뛰기 — 서버 기본 이름으로 마감 */
-  const handleCourseNameSkip = () => {
-    setShowCourseNameModal(false);
-    runCompleteSession();
+    runCompleteSession(trimmed || undefined);
     completeTracking(null);
   };
 
@@ -1653,9 +1650,8 @@ export default function TrackingScreen() {
       <CourseNameInputModal
         visible={showCourseNameModal}
         initialValue={freeRecordCourseName ?? ""}
-        mountainName={nearbyData?.mountain?.name}
-        onCancel={handleCourseNameSkip}
         onSubmit={handleCourseNameSubmit}
+        onDismiss={() => handleCourseNameSubmit("")}
       />
 
       {/* 난이도 체감 모달 */}

--- a/components/course-bottom-sheet.tsx
+++ b/components/course-bottom-sheet.tsx
@@ -4,6 +4,9 @@ import { GetUserHikingRecordResponse } from "@/types/api.generated";
 import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { ChevronRightIcon } from "./icons/chevron-right-icon";
 
+// 이름도 코스도 없는 기록의 최종 표시명
+const FREE_RECORD_FALLBACK_NAME = "자유 기록";
+
 function formatHikedAt(dateStr?: string): string {
   if (!dateStr) return "";
   const d = new Date(dateStr);
@@ -158,13 +161,17 @@ function CourseItem({
   mountainId?: number;
   onPress?: () => void;
 }) {
-  // 자유기록 등 목록 요약 API의 distance/duration이 비어있는 경우 상세 API로 폴백
-  const needsDetailFallback = !course.distance || !course.duration;
+  // 목록 요약 API는 자유기록의 이름(recordName)을 내려주지 않고 distance/duration도
+  // 비어있는 경우가 있어, 부족한 값은 상세 API로 폴백한다
+  const needsDetailFallback =
+    !course.courseName || !course.distance || !course.duration;
   const { data: recordDetail } = useHikingRecordDetail(
     needsDetailFallback ? (course.hikingRecordId ?? null) : null,
   );
   const distanceMeters = course.distance || recordDetail?.distanceMeters;
   const durationSeconds = course.duration || recordDetail?.durationSeconds;
+  const displayName =
+    course.courseName || recordDetail?.recordName || FREE_RECORD_FALLBACK_NAME;
 
   return (
     <TouchableOpacity
@@ -185,12 +192,10 @@ function CourseItem({
             className="text-common-0 typo-body-1-normal-semi-bold"
             numberOfLines={1}
           >
-            {course.courseName}
+            {displayName}
           </Text>
           <Text className="text-label-subtler typo-caption-1-medium">
-            {!!distanceMeters && (
-              <>{(distanceMeters / 1000).toFixed(1)}km · </>
-            )}
+            {!!distanceMeters && <>{(distanceMeters / 1000).toFixed(1)}km · </>}
             {!!durationSeconds && (
               <>
                 {formatDuration(durationSeconds)} ·{" "}

--- a/features/home/hooks/use-hiking-record-detail.ts
+++ b/features/home/hooks/use-hiking-record-detail.ts
@@ -11,6 +11,8 @@ export type RecordPhotoMarker = {
 
 export type HikingRecordDetail = {
   hikingRecordId: number;
+  /** 자유기록 이름 — 목록 API는 courseName만 주고 이 값을 내려주지 않는다 */
+  recordName?: string;
   distanceMeters?: number;
   durationSeconds?: number;
   maxAltitudeMeters?: number;

--- a/features/tracking/components/course-name-input-modal.tsx
+++ b/features/tracking/components/course-name-input-modal.tsx
@@ -1,0 +1,159 @@
+import { XIcon } from "@/components/icons/x-icon";
+import { RECORD_NAME_MAX_LENGTH } from "@/features/tracking/constants";
+import { useEffect, useState } from "react";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+
+const MODAL_BORDER_RADIUS = 16;
+const MODAL_MAX_WIDTH = 320;
+// 배경 오버레이 투명도 — StopConfirmModal과 동일
+const OVERLAY_COLOR = "rgba(0,0,0,0.4)";
+
+type Props = {
+  visible: boolean;
+  /** 수정 진입 시 기존 이름, 새로 입력하는 경우 빈 문자열 */
+  initialValue?: string;
+  /** placeholder 기본값 생성용 */
+  mountainName?: string;
+  onCancel: () => void;
+  onSubmit: (name: string) => void;
+};
+
+export function CourseNameInputModal({
+  visible,
+  initialValue = "",
+  mountainName,
+  onCancel,
+  onSubmit,
+}: Props) {
+  const [value, setValue] = useState(initialValue);
+  const [isFocused, setIsFocused] = useState(false);
+
+  // 열릴 때마다 기존 이름으로 초기화 (이전 입력값 잔류 방지)
+  useEffect(() => {
+    if (visible) setValue(initialValue);
+  }, [visible, initialValue]);
+
+  const isEditing = initialValue.length > 0;
+  const trimmed = value.trim();
+  const canSubmit = trimmed.length > 0 && trimmed !== initialValue;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      {/* 어두운 오버레이 */}
+      <View
+        className="flex-1 items-center justify-center"
+        style={{ backgroundColor: OVERLAY_COLOR }}
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          className="w-full items-center"
+        >
+          {/* 모달 본체 */}
+          <View
+            className="w-full bg-fill-normal"
+            style={{
+              maxWidth: MODAL_MAX_WIDTH,
+              borderRadius: MODAL_BORDER_RADIUS,
+              marginHorizontal: 16,
+            }}
+          >
+            {/* 타이틀 + 설명 */}
+            <View className="gap-2 px-5 pb-4 pt-5">
+              <Text className="text-label-normal typo-heading-1-semi-bold">
+                {isEditing
+                  ? "코스 이름을 수정할까요?"
+                  : "코스 이름을 정할까요?"}
+              </Text>
+              <Text className="text-label-subtle typo-body-1-normal-regular">
+                입력한 이름으로 홈의 다녀온 코스에 표시돼요.
+                {!isEditing && " 건너뛰면 기본 이름으로 저장돼요."}
+              </Text>
+            </View>
+
+            {/* 입력 필드 */}
+            <View className="gap-2 px-5 pb-1">
+              <View
+                className={`h-12 flex-row items-center gap-2 rounded-[10px] border bg-fill-normal px-3 ${
+                  isFocused ? "border-line-primary" : "border-line-subtle"
+                }`}
+              >
+                <TextInput
+                  className="flex-1 text-label-normal typo-body-1-reading-regular"
+                  value={value}
+                  onChangeText={setValue}
+                  placeholder={
+                    mountainName ? `${mountainName} 자유 기록` : "자유 기록"
+                  }
+                  placeholderTextColor="#73798c"
+                  maxLength={RECORD_NAME_MAX_LENGTH}
+                  returnKeyType="done"
+                  autoFocus
+                  onFocus={() => setIsFocused(true)}
+                  onBlur={() => setIsFocused(false)}
+                  onSubmitEditing={() => canSubmit && onSubmit(trimmed)}
+                  style={{ paddingVertical: 0 }}
+                />
+                {value.length > 0 && (
+                  <TouchableOpacity
+                    onPress={() => setValue("")}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <XIcon size={20} color="#1a1b1f" />
+                  </TouchableOpacity>
+                )}
+              </View>
+              <Text className="text-label-subtler typo-caption-1-regular">
+                {RECORD_NAME_MAX_LENGTH}글자까지 입력할 수 있어요
+              </Text>
+            </View>
+
+            {/* 버튼 행 */}
+            <View className="flex-row gap-2 px-4 pb-4 pt-4">
+              {/* 건너뛰기 / 취소 */}
+              <TouchableOpacity
+                className="flex-1 items-center justify-center rounded-[10px] bg-fill-stronger"
+                style={{ height: 48 }}
+                onPress={onCancel}
+              >
+                <Text className="text-label-subtle typo-label-large">
+                  {isEditing ? "취소" : "건너뛰기"}
+                </Text>
+              </TouchableOpacity>
+
+              {/* 저장 */}
+              <TouchableOpacity
+                className={`flex-1 items-center justify-center rounded-[10px] ${
+                  canSubmit ? "bg-label-normal" : "bg-fill-disabled"
+                }`}
+                style={{ height: 48 }}
+                disabled={!canSubmit}
+                onPress={() => onSubmit(trimmed)}
+              >
+                <Text
+                  className={`typo-label-large ${
+                    canSubmit ? "text-common-100" : "text-label-disabled"
+                  }`}
+                >
+                  저장
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </View>
+    </Modal>
+  );
+}

--- a/features/tracking/components/course-name-input-modal.tsx
+++ b/features/tracking/components/course-name-input-modal.tsx
@@ -1,4 +1,3 @@
-import { XIcon } from "@/components/icons/x-icon";
 import { RECORD_NAME_MAX_LENGTH } from "@/features/tracking/constants";
 import { useEffect, useState } from "react";
 import {
@@ -15,42 +14,38 @@ const MODAL_BORDER_RADIUS = 16;
 const MODAL_MAX_WIDTH = 320;
 // 배경 오버레이 투명도 — StopConfirmModal과 동일
 const OVERLAY_COLOR = "rgba(0,0,0,0.4)";
+// 비워두면 서버가 채우는 기본 이름 형식 — 입력 없이 저장해도 된다는 힌트
+const DEFAULT_NAME_HINT = "260723_닉네임의코스1";
 
 type Props = {
   visible: boolean;
   /** 수정 진입 시 기존 이름, 새로 입력하는 경우 빈 문자열 */
   initialValue?: string;
-  /** placeholder 기본값 생성용 */
-  mountainName?: string;
-  onCancel: () => void;
+  /** 비우고 저장하면 빈 문자열이 넘어온다 (서버 기본 이름으로 저장) */
   onSubmit: (name: string) => void;
+  /** 하드웨어 back 등으로 닫힌 경우 — 이름 없이 저장과 동일하게 처리 */
+  onDismiss: () => void;
 };
 
 export function CourseNameInputModal({
   visible,
   initialValue = "",
-  mountainName,
-  onCancel,
   onSubmit,
+  onDismiss,
 }: Props) {
   const [value, setValue] = useState(initialValue);
-  const [isFocused, setIsFocused] = useState(false);
 
   // 열릴 때마다 기존 이름으로 초기화 (이전 입력값 잔류 방지)
   useEffect(() => {
     if (visible) setValue(initialValue);
   }, [visible, initialValue]);
 
-  const isEditing = initialValue.length > 0;
-  const trimmed = value.trim();
-  const canSubmit = trimmed.length > 0 && trimmed !== initialValue;
-
   return (
     <Modal
       visible={visible}
       transparent
       animationType="fade"
-      onRequestClose={onCancel}
+      onRequestClose={onDismiss}
     >
       {/* 어두운 오버레이 */}
       <View
@@ -63,94 +58,42 @@ export function CourseNameInputModal({
         >
           {/* 모달 본체 */}
           <View
-            className="w-full bg-fill-normal"
+            className="w-full gap-3 bg-fill-normal px-5 py-5"
             style={{
               maxWidth: MODAL_MAX_WIDTH,
               borderRadius: MODAL_BORDER_RADIUS,
               marginHorizontal: 16,
             }}
           >
-            {/* 타이틀 + 설명 */}
-            <View className="gap-2 px-5 pb-4 pt-5">
-              <Text className="text-label-normal typo-heading-1-semi-bold">
-                {isEditing
-                  ? "코스 이름을 수정할까요?"
-                  : "코스 이름을 정할까요?"}
-              </Text>
-              <Text className="text-label-subtle typo-body-1-normal-regular">
-                입력한 이름으로 홈의 다녀온 코스에 표시돼요.
-                {!isEditing && " 건너뛰면 기본 이름으로 저장돼요."}
-              </Text>
-            </View>
+            {/* 타이틀 */}
+            <Text className="text-center text-label-normal typo-body-1-normal-semi-bold">
+              자유기록 이름을 정해주세요
+            </Text>
 
             {/* 입력 필드 */}
-            <View className="gap-2 px-5 pb-1">
-              <View
-                className={`h-12 flex-row items-center gap-2 rounded-[10px] border bg-fill-normal px-3 ${
-                  isFocused ? "border-line-primary" : "border-line-subtle"
-                }`}
-              >
-                <TextInput
-                  className="flex-1 text-label-normal typo-body-1-reading-regular"
-                  value={value}
-                  onChangeText={setValue}
-                  placeholder={
-                    mountainName ? `${mountainName} 자유 기록` : "자유 기록"
-                  }
-                  placeholderTextColor="#73798c"
-                  maxLength={RECORD_NAME_MAX_LENGTH}
-                  returnKeyType="done"
-                  autoFocus
-                  onFocus={() => setIsFocused(true)}
-                  onBlur={() => setIsFocused(false)}
-                  onSubmitEditing={() => canSubmit && onSubmit(trimmed)}
-                  style={{ paddingVertical: 0 }}
-                />
-                {value.length > 0 && (
-                  <TouchableOpacity
-                    onPress={() => setValue("")}
-                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  >
-                    <XIcon size={20} color="#1a1b1f" />
-                  </TouchableOpacity>
-                )}
-              </View>
-              <Text className="text-label-subtler typo-caption-1-regular">
-                {RECORD_NAME_MAX_LENGTH}글자까지 입력할 수 있어요
-              </Text>
+            <View className="h-12 justify-center rounded-[10px] border border-line-subtle bg-fill-strong px-3">
+              <TextInput
+                className="text-label-normal typo-body-1-reading-regular"
+                value={value}
+                onChangeText={setValue}
+                placeholder={DEFAULT_NAME_HINT}
+                placeholderTextColor="#8b92a6"
+                maxLength={RECORD_NAME_MAX_LENGTH}
+                returnKeyType="done"
+                autoFocus
+                onSubmitEditing={() => onSubmit(value.trim())}
+                style={{ paddingVertical: 0 }}
+              />
             </View>
 
-            {/* 버튼 행 */}
-            <View className="flex-row gap-2 px-4 pb-4 pt-4">
-              {/* 건너뛰기 / 취소 */}
-              <TouchableOpacity
-                className="flex-1 items-center justify-center rounded-[10px] bg-fill-stronger"
-                style={{ height: 48 }}
-                onPress={onCancel}
-              >
-                <Text className="text-label-subtle typo-label-large">
-                  {isEditing ? "취소" : "건너뛰기"}
-                </Text>
-              </TouchableOpacity>
-
-              {/* 저장 */}
-              <TouchableOpacity
-                className={`flex-1 items-center justify-center rounded-[10px] ${
-                  canSubmit ? "bg-label-normal" : "bg-fill-disabled"
-                }`}
-                style={{ height: 48 }}
-                disabled={!canSubmit}
-                onPress={() => onSubmit(trimmed)}
-              >
-                <Text
-                  className={`typo-label-large ${
-                    canSubmit ? "text-common-100" : "text-label-disabled"
-                  }`}
-                >
-                  저장
-                </Text>
-              </TouchableOpacity>
-            </View>
+            {/* 저장하기 — 비워둬도 저장 가능(서버 기본 이름) */}
+            <TouchableOpacity
+              className="h-12 items-center justify-center rounded-[10px] bg-label-normal"
+              activeOpacity={0.8}
+              onPress={() => onSubmit(value.trim())}
+            >
+              <Text className="text-common-100 typo-label-large">저장하기</Text>
+            </TouchableOpacity>
           </View>
         </KeyboardAvoidingView>
       </View>

--- a/features/tracking/constants/index.ts
+++ b/features/tracking/constants/index.ts
@@ -148,6 +148,9 @@ export const LOCATION_BUTTON_GAP = 18;
 export const TRACKING_SHEET_HEIGHT = 220;
 
 
+/** 자유기록 기록 이름 최대 길이 — 서버 검증 한도(초과 시 400) */
+export const RECORD_NAME_MAX_LENGTH = 30;
+
 export const COLLAPSED_PEEK_HEIGHT = 24;
 export const FLOATING_CARD_GAP = 16;
 export const FLOATING_CARD_HORIZONTAL_MARGIN = 16;

--- a/features/tracking/hooks/use-complete-tracking-session.ts
+++ b/features/tracking/hooks/use-complete-tracking-session.ts
@@ -3,13 +3,28 @@ import { ENDPOINTS, TrackingSessionResponse } from "@/types/api.generated";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ACTIVE_SESSION_KEY } from "./use-active-tracking-session";
 
+type CompleteParams = {
+  sessionId: number;
+  /**
+   * 자유기록의 기록 이름. 생략하면 서버가 `260723_등산왕의코스1` 형태로 채운다.
+   * 코스 기록은 코스명으로 표시되므로 보내도 무시된다.
+   */
+  name?: string;
+};
+
 export function useCompleteTrackingSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (sessionId: number): Promise<TrackingSessionResponse> => {
+    mutationFn: async ({
+      sessionId,
+      name,
+    }: CompleteParams): Promise<TrackingSessionResponse> => {
+      const trimmed = name?.trim();
       const res = await api.post<TrackingSessionResponse>({
         path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_COMPLETE(sessionId),
+        // 이름이 없으면 body 자체를 생략 — 서버가 기본 이름을 채운다
+        ...(trimmed ? { body: { name: trimmed } } : {}),
       });
       return res.data;
     },

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1716,28 +1716,6 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-compressor (1.16.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-safe-area-context (5.6.2):
@@ -2668,7 +2646,6 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
-  - react-native-compressor (from `../node_modules/react-native-compressor`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-view-shot (from `../node_modules/react-native-view-shot`)
@@ -2885,8 +2862,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
-  react-native-compressor:
-    :path: "../node_modules/react-native-compressor"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -3072,7 +3047,6 @@ SPEC CHECKSUMS:
   React-logger: 50fdb9a8236da90c0b1072da5c32ee03aeb5bf28
   React-Mapbuffer: 9050ee10c19f4f7fca8963d0211b2854d624973e
   React-microtasksnativemodule: f775db9e991c6f3b8ccbc02bfcde22770f96e23b
-  react-native-compressor: dca167f2e6e48e5e9efa165e30ee0ae4c6445de8
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
   react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2

--- a/ios/semosan.xcodeproj/project.pbxproj
+++ b/ios/semosan.xcodeproj/project.pbxproj
@@ -11,11 +11,11 @@
 		10BE4E2D651B7E442D3322E6 /* libPods-semosan.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEEBEE1FB64461746792160 /* libPods-semosan.a */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		4A732CF95E76DA32F805FA8A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */; };
 		58E4E904FF7A4F8E91FFD44A /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0915453EF2B7459C92BFD452 /* SwiftUI.framework */; };
 		5924807866955ACF8228BF7A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = ED0FDB9639E5FC65402DB80F /* PrivacyInfo.xcprivacy */; };
 		62AA5F0527CE7EF046B086D9 /* SemosanWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69DB1C917F4FFF3242AA9628 /* SemosanWidgetBundle.swift */; };
 		693D45F803EE4908BCAFAFA8 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 43040695C0354B4EA32E7480 /* InfoPlist.strings */; };
-		4A732CF95E76DA32F805FA8A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* SemosanLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87D6279DA4FA6101E8B8853A /* SemosanLiveActivityAttributes.swift */; };
 		B15883B685E09F4ACB7111FB /* SemosanLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = F062AF6F8F169DC8CB336099 /* SemosanLiveActivity.swift */; };
 		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
@@ -53,10 +53,10 @@
 		30A54906D1126612186FF146 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = SemosanWidget/Assets.xcassets; sourceTree = "<group>"; };
 		41BBCF6E2CE0497EA17A760B /* WidgetKit.framework */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		43040695C0354B4EA32E7480 /* InfoPlist.strings */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		69DB1C917F4FFF3242AA9628 /* SemosanWidgetBundle.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = SemosanWidgetBundle.swift; path = SemosanWidget/SemosanWidgetBundle.swift; sourceTree = "<group>"; };
 		6AEEBEE1FB64461746792160 /* libPods-semosan.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-semosan.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		87D6279DA4FA6101E8B8853A /* SemosanLiveActivityAttributes.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = SemosanLiveActivityAttributes.swift; path = SemosanWidget/SemosanLiveActivityAttributes.swift; sourceTree = "<group>"; };
+		9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.plist.strings; name = InfoPlist.strings; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		A8A28D9327D64115B3E69FC8 /* SemosanWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = undefined; name = SemosanWidget.appex; path = SemosanWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = semosan/SplashScreen.storyboard; sourceTree = "<group>"; };
 		AB01D059CE2A77403C4309E5 /* Lexend-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Lexend-SemiBold.ttf"; path = "SemosanWidget/Lexend-SemiBold.ttf"; sourceTree = "<group>"; };
@@ -120,6 +120,15 @@
 			name = ExpoModulesProviders;
 			sourceTree = "<group>";
 		};
+		4C05F667C69F443D24AEDE69 /* en.lproj */ = {
+			isa = PBXGroup;
+			children = (
+				9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */,
+			);
+			name = en.lproj;
+			path = "";
+			sourceTree = "<group>";
+		};
 		67C638EDC16DEAE4F5E487C4 /* semosan */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,15 +185,6 @@
 				43040695C0354B4EA32E7480 /* InfoPlist.strings */,
 			);
 			name = ko.lproj;
-			path = "";
-			sourceTree = "<group>";
-		};
-		4C05F667C69F443D24AEDE69 /* en.lproj */ = {
-			isa = PBXGroup;
-			children = (
-				9C724FB1E1D716DDCC15E71E /* InfoPlist.strings */,
-			);
-			name = en.lproj;
 			path = "";
 			sourceTree = "<group>";
 		};

--- a/package-lock.json
+++ b/package-lock.json
@@ -133,6 +133,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1535,6 +1536,7 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2454,6 +2456,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.9.tgz",
       "integrity": "sha512-3gtUX0e584MYkKBQMgSECMvE1Dwzg+eONefDQ0wxVSe5YMBsZwdN5pL7UapwWBlV8+i8QCztF9TP947tEjZAGA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.1",
         "@firebase/logger": "0.5.0",
@@ -2520,6 +2523,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.9.tgz",
       "integrity": "sha512-e5LzqjO69/N2z7XcJeuMzIp4wWnW696dQeaHAUpQvGk89gIWHAIvG6W+mA3UotGW6jBoqdppEJ9DnuwbcBByug==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.9",
         "@firebase/component": "0.7.1",
@@ -2535,7 +2539,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.1",
@@ -2986,6 +2991,7 @@
       "integrity": "sha512-/gnejm7MKkVIXnSJGpc9L2CvvvzJvtDPeAEq5jAwgVlf/PeNxot+THx/bpD20wQ8uL5sz0xqgXy1nisOYMU+mw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -4112,6 +4118,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
       "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "merge-options": "^3.0.4"
       },
@@ -4133,6 +4140,7 @@
       "resolved": "https://registry.npmjs.org/@react-native-firebase/app/-/app-24.0.0.tgz",
       "integrity": "sha512-rLWNd8/4FjKYV7PeDR9uiT5vwYWdJ7dJ1yiIIaZ/eL+Y56Ij2iXbqRCUu4zWkvu/ZrJfaGOyT12Vhy1SLy0NMg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "firebase": "12.10.0"
       },
@@ -4549,6 +4557,7 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
       "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.17.2",
         "escape-string-regexp": "^4.0.0",
@@ -5131,6 +5140,7 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -5224,6 +5234,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.9.tgz",
       "integrity": "sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.100.9"
       },
@@ -5388,6 +5399,7 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5465,6 +5477,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -6063,6 +6076,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6831,6 +6845,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8159,6 +8174,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8355,6 +8371,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8578,6 +8595,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.37.tgz",
       "integrity": "sha512-afzbtO4i/K9ZCrzyLgEOaXW56w/yuAK61JkCOMrw/S/VFCAp6YwKWA494X5mIcrVmRAmclv/ec7ga8ndTkzhxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.27",
@@ -8664,6 +8682,7 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.14.tgz",
       "integrity": "sha512-BUZm9mkl/TX7zNaN0N4C83ws7mEnesCFiKhqK+rMZwTD2+Q4wWB2kBltqnC/LrCRaMyRi40XxhCRVwuKnJkxXQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.14",
         "@expo/env": "~2.0.12"
@@ -8789,6 +8808,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
       "integrity": "sha512-QQzunE2Mxk45AsCWm3tK7OpVljbtVnKD58q4/qliev+cbye1IOduUnRIdD+P7DyButw17G9MTX795kgaQiz5hQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -8877,6 +8897,7 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
       "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
@@ -11411,6 +11432,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -11719,9 +11741,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11741,9 +11760,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -11765,9 +11781,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11787,9 +11800,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -13412,6 +13422,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -13603,6 +13614,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13954,6 +13966,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13973,6 +13986,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -14009,6 +14023,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -14362,6 +14377,7 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -14387,6 +14403,7 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.7.tgz",
       "integrity": "sha512-Q4H6xA3Tn7QL0/E/KjI86I1KK4tcf+ErRE04LH34Etka2oVQhW6oXQ+Q8ZcDCVxiWp5vgbBH6XcH8BOo4w/Rhg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "^7.7.2"
@@ -14414,6 +14431,7 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -14424,6 +14442,7 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -14439,6 +14458,7 @@
       "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
       "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
         "css-tree": "^1.1.3",
@@ -14484,6 +14504,7 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -14516,6 +14537,7 @@
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
       "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -14626,6 +14648,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15773,6 +15796,7 @@
       "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-5.4.0.tgz",
       "integrity": "sha512-6BzO0DV19t6KUEXYfvHJ73d3y8bBDcd0wNLfoZRX817obJ8YX5Vev8Xh3+k9601tHE8qRJ/586iLt0byuY2THw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^13.0.6",
@@ -15954,6 +15978,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -16203,6 +16228,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16308,7 +16334,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -16425,6 +16452,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17301,6 +17329,7 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },


### PR DESCRIPTION
## 작업 내용

자유 기록은 코스가 없어 홈의 다녀온 코스 목록에 이름이 **빈 줄**로 나왔습니다. `POST /api/tracking/sessions/{sessionId}/complete`가 body로 `name`을 받게 되어, 종료 시 이름을 입력받아 함께 보내도록 했습니다.

- `CourseNameInputModal` 추가 — `StopConfirmModal`과 같은 규격(320px, radius 16, 오버레이 40%, 48px 2버튼)
- 이름은 `complete` body로만 보낼 수 있어, 기존 **"종료 → 후처리"** 순서를 **"이름 입력 → 종료"** 로 변경
- `complete` 호출을 `runCompleteSession(name?)`으로 분리해 세 경로가 같은 에러 처리와 `hikingRecordId` 세팅을 공유

| 케이스 | 동작 |
| --- | --- |
| 1분 미만 | `abandon` — 이름 입력 없음 (기존과 동일) |
| 코스 기록 | `complete` (이름 없이) → 난이도 평가 |
| 자유 기록 | **이름 입력 팝업** → 저장 시 `complete { name }`, 건너뛰기 시 body 생략 |

- 건너뛰면 body 자체를 생략 → 서버가 기본 이름(`260723_등산왕의코스1`)을 채움
- 입력 길이를 서버 검증 한도에 맞춰 **30자로 제한** (초과 시 400이 나던 것을 애초에 차단)

### 홈 목록 표시

`GET /api/hiking-records/me/mountains/{mountainId}` 응답(`GetUserHikingRecordResponse`)에 `recordName`이 없어, 자유 기록은 목록에서 이름을 알 수 없습니다. 이름은 상세 API `GET /api/hiking-records/{id}`의 `recordName`에만 있습니다.

`CourseItem`이 이미 `distance`/`duration`이 비면 상세 API로 폴백하고 있어 여기에 이름도 얹었습니다 — `courseName` → `recordName` → `"자유 기록"` 순으로 표시.

## 확인 방법

트래킹 탭 → `자유 기록하기` → **1분 이상** 기록 → `기록 종료` → `종료` → 이름 입력 팝업

이후 홈 → 지도에서 해당 산 핀 → 다녀온 코스 목록에서 입력한 이름 확인.

> 자유 기록은 근처 산 반경 안에서만 시작되므로, 시뮬레이터에서는 위치를 산 좌표로 옮겨야 합니다.

## 리뷰 포인트

**1. 백엔드 요청이 필요합니다.** 목록 API 응답에 `recordName`을 추가해 주시면 상세 API 폴백은 타지 않습니다. 지금은 목록 항목 수만큼 상세 요청이 추가로 나가는 임시 조치입니다.

**2. 사후 수정 진입점은 없습니다.** 모달 자체는 `initialValue`를 주면 "수정할까요?" + "취소/저장"으로 동작하도록 만들어 뒀지만, 기록 생성 후 이름만 바꾸는 API가 없어 홈 쪽 진입점은 붙이지 않았습니다.

**3. `chore : ios 설정 파일 업데이트`, `chore : 패키지 의존성 업데이트`** 두 커밋은 로컬 `main`에 있던 미푸시 커밋이라 이 PR에 함께 올라갑니다.

## 스크린샷

### 홈 · 다녀온 코스 목록

### 코스 이름 입력 팝업 (신규)

| 자유기록 팝업창 | 코스반영 확인 |
| --- | --- |
| <img width="280" alt="디자인 시안" src="https://github.com/user-attachments/assets/e478dc56-73d1-40fe-a2e7-26f17f4d6cf5" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/07452e90-e4b9-49bc-b1bb-06b21c163d45" /> |
