### PR TITLE
fix: 권한 관리에서 음성 안내 토글 제거

### DIFF
--- a/app/mypage/permissions.tsx
+++ b/app/mypage/permissions.tsx
@@ -68,12 +68,11 @@ function ToggleSwitch({ value, onValueChange }: { value: boolean; onValueChange:
   );
 }
 
-type NotificationKey = 'push' | 'liveActivity' | 'voice';
+type NotificationKey = 'push' | 'liveActivity';
 
 const NOTIFICATION_ITEMS: { key: NotificationKey; label: string; toastMessage: string }[] = [
   { key: 'push', label: '푸시 알림', toastMessage: '푸시 알림을 활성화했어요' },
   { key: 'liveActivity', label: '라이브 액티비티', toastMessage: '라이브 액티비티를 활성화했어요' },
-  { key: 'voice', label: '음성 안내', toastMessage: '음성 안내를 활성화했어요' },
 ];
 
 const DEVICE_PERMISSION_KEYS = [
@@ -89,7 +88,6 @@ export default function PermissionsScreen() {
   const [notifications, setNotifications] = useState<Record<NotificationKey, boolean>>({
     push: false,
     liveActivity: false,
-    voice: false,
   });
 
   useEffect(() => {
@@ -97,7 +95,6 @@ export default function PermissionsScreen() {
     setNotifications({
       push: settings.pushNotificationEnabled,
       liveActivity: settings.liveActivityEnabled,
-      voice: settings.voiceEnabled,
     });
   }, [settings]);
 

--- a/features/mypage/hooks/use-update-notification.ts
+++ b/features/mypage/hooks/use-update-notification.ts
@@ -2,12 +2,11 @@ import { api } from '@/lib/api';
 import { ENDPOINTS } from '@/types/api.generated';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-type NotificationKey = 'push' | 'liveActivity' | 'voice';
+type NotificationKey = 'push' | 'liveActivity';
 
 const ENDPOINT_MAP: Record<NotificationKey, string> = {
   push: ENDPOINTS.USERS_NOTIFICATION_SETTINGS_PUSH,
   liveActivity: ENDPOINTS.USERS_NOTIFICATION_SETTINGS_LIVE_ACTIVITY,
-  voice: ENDPOINTS.USERS_NOTIFICATION_SETTINGS_VOICE,
 };
 
 export function useUpdateNotification() {


### PR DESCRIPTION
## 작업 내용

권한 관리 → 알림 설정에서 `음성 안내` 토글을 제거했습니다.

앱에 실제 음성 안내(TTS) 기능이 없습니다. `expo-speech` 등 음성 재생 코드가 한 군데도 없고, 토글은 `PATCH /api/users/notification-settings/voice`를 호출하기만 할 뿐 앱 동작에 아무 영향이 없었습니다.

- [`app/mypage/permissions.tsx`](app/mypage/permissions.tsx) — `음성 안내` 행 제거. `NotificationKey` 유니온, 로컬 state 초기값, 서버 설정 매핑에서 `voice` 함께 정리
- [`features/mypage/hooks/use-update-notification.ts`](features/mypage/hooks/use-update-notification.ts) — `voice` 분기 제거. 이 훅의 유일한 소비처가 권한 관리 화면이라 행이 빠지면서 도달 불가 코드가 됨

**남겨둔 것**

- `useNotificationSettings`의 `voiceEnabled` 응답 필드 — 서버가 여전히 내려주는 값이라 타입은 정확한 상태로 유지
- 온보딩의 `voiceEnabled` 등록 — 별개 플로우라 이번 범위에서 제외

## 스크린샷

| After |
| --- |
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/c13b640e-3cf2-4832-9032-095679d8a487" /> |

## 확인 방법

마이페이지 → `권한 관리`

- 알림 설정에 `푸시 알림`, `라이브 액티비티` 두 항목만 표시
- 섹션 구분선과 `기기 권한` 섹션은 그대로 유지

iOS 시뮬레이터에서 확인했습니다.