### PR TITLE
feat: 마이페이지 서비스 섹션에 공지사항·1:1 문의하기 추가

### DIFF
--- a/app/(tabs)/mypage.tsx
+++ b/app/(tabs)/mypage.tsx
@@ -4,13 +4,18 @@ import { MenuChevronIcon } from "@/features/mypage/components/menu-chevron-icon"
 import { MenuRow } from "@/features/mypage/components/menu-row";
 import { ProfileAvatar } from "@/features/mypage/components/profile-avatar";
 import { SectionDivider } from "@/features/mypage/components/section-divider";
-import { APP_VERSION } from "@/features/mypage/constants";
+import {
+  APP_VERSION,
+  INQUIRY_URL,
+  NOTICE_URL,
+} from "@/features/mypage/constants";
 import {
   HIKING_LEVEL_LABEL,
   useProfile,
 } from "@/features/mypage/hooks/use-profile";
 import { usePrefetchSavedMountains } from "@/features/mountains/hooks/use-saved-mountains";
 import { useFocusEffect, useRouter } from "expo-router";
+import * as WebBrowser from "expo-web-browser";
 import { useCallback } from "react";
 import { Alert, ScrollView, Text, TouchableOpacity, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -41,6 +46,14 @@ export default function MyPageScreen() {
   ];
 
   const serviceItems = [
+    {
+      label: "공지사항",
+      onPress: () => WebBrowser.openBrowserAsync(NOTICE_URL),
+    },
+    {
+      label: "1:1 문의하기",
+      onPress: () => WebBrowser.openBrowserAsync(INQUIRY_URL),
+    },
     { label: "권한 관리", onPress: () => router.push("/mypage/permissions") },
     { label: "이용약관", onPress: () => router.push("/mypage/terms") },
     {

--- a/features/mypage/constants/index.ts
+++ b/features/mypage/constants/index.ts
@@ -14,3 +14,8 @@ export const MOCK_USER = {
 
 import Constants from 'expo-constants';
 export const APP_VERSION = Constants.expoConfig?.version ?? '1.0.0';
+
+/** 공지사항 — 외부 링크 모음 페이지 */
+export const NOTICE_URL = "https://linktr.ee/semosan0504";
+/** 1:1 문의하기 — 외부 문의 폼 */
+export const INQUIRY_URL = "https://smore.im/form/EBucAafRsC#_q=Oty6phXY";


### PR DESCRIPTION
## 작업 내용

마이페이지 **서비스** 섹션 최상단에 `공지사항`, `1:1 문의하기` 두 항목을 추가했습니다. 시안대로 `권한 관리` 위에 배치했습니다.

- URL은 [`features/mypage/constants/index.ts`](features/mypage/constants/index.ts)에 `NOTICE_URL` / `INQUIRY_URL` 상수로 분리
- 기존 `이용약관` 화면과 동일하게 `WebBrowser.openBrowserAsync`로 앱 내 브라우저에서 열립니다 (사파리로 튕겨나가지 않고 상단 닫기 버튼으로 복귀)
- 행 전체가 터치 영역이라 화살표뿐 아니라 어디를 눌러도 열립니다 — `MenuRow` 기본 동작으로, 나머지 항목들과 같습니다

| 항목 | 연결 |
| --- | --- |
| 공지사항 | https://linktr.ee/semosan0504 |
| 1:1 문의하기 | https://smore.im/form/EBucAafRsC |

## 스크린샷

| 구현 |
| --- |
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/76d1a08d-a741-4a1c-a586-219d7e9273de" /> |

## 확인 방법

마이페이지 탭 → 서비스 섹션

- `공지사항` → linktr.ee 세모산 링크트리 페이지 (앱 다운받기 / 고객센터 / 소개페이지 / 세모산 가이드)
- `1:1 문의하기` → smore.im 문의 폼 Q1 화면

둘 다 iOS 시뮬레이터에서 실제로 열리는 것을 확인했습니다. 문의 폼은 제출하지 않고 닫았습니다.

