### PR TITLE
fix: 온보딩 상태 저장소 오류를 완료 상태와 혼동하지 않도록 수정

### DIFF
--- a/features/auth/hooks/use-auth-state.ts
+++ b/features/auth/hooks/use-auth-state.ts
@@ -28,6 +28,10 @@ export function useAuthState(): { status: AuthStatus } {
           { ignoreErrorToast: true },
         );
         const onboardingPending = await tokenStorage.isOnboardingPending();
+        if (onboardingPending === null) {
+          authState.setUnauthenticated();
+          return;
+        }
         if (onboardingPending) {
           authState.setNeedsOnboarding();
         } else {

--- a/features/onboarding/components/onboarding-exercise-detail-screen.tsx
+++ b/features/onboarding/components/onboarding-exercise-detail-screen.tsx
@@ -42,7 +42,11 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
       router.replace("/(tabs)");
     } catch (e) {
       if (e instanceof ApiError && e.statusCode === 409) {
-        await tokenStorage.setOnboardingPending(false);
+        const saved = await tokenStorage.setOnboardingPending(false);
+        if (!saved) {
+          toast.show("잠시후 다시 시도해주십시오.");
+          return;
+        }
         authState.setAuthenticated();
         toast.show("이미 등록된 사용자입니다.");
         router.replace("/(tabs)");

--- a/features/onboarding/hooks/use-submit-onboarding.ts
+++ b/features/onboarding/hooks/use-submit-onboarding.ts
@@ -15,7 +15,8 @@ export function useSubmitOnboarding() {
       await api.post({ path: ENDPOINTS.USERS_ONBOARDING, body }, { ignoreErrorToast: true });
     },
     onSuccess: async () => {
-      await tokenStorage.setOnboardingPending(false);
+      const saved = await tokenStorage.setOnboardingPending(false);
+      if (!saved) return;
       authState.setAuthenticated();
       reset();
     },

--- a/lib/auth/tokenStorage.ts
+++ b/lib/auth/tokenStorage.ts
@@ -94,25 +94,28 @@ export const tokenStorage = {
     }
   },
 
-  /** 온보딩이 아직 안 끝난 상태로 표시(true) / 완료 처리(false) */
-  async setOnboardingPending(pending: boolean): Promise<void> {
+  /** 온보딩이 아직 안 끝난 상태로 표시(true) / 완료 처리(false). 저장 성공 여부를 반환한다. */
+  async setOnboardingPending(pending: boolean): Promise<boolean> {
     try {
       if (pending) {
         await AsyncStorage.setItem(ONBOARDING_PENDING_KEY, "true");
       } else {
         await AsyncStorage.removeItem(ONBOARDING_PENDING_KEY);
       }
+      return true;
     } catch (error) {
       reportFailure("setOnboardingPending", error);
+      return false;
     }
   },
 
-  async isOnboardingPending(): Promise<boolean> {
+  /** 저장소 읽기 실패는 완료(false)와 구분해야 하므로 null 을 반환한다. */
+  async isOnboardingPending(): Promise<boolean | null> {
     try {
       return (await AsyncStorage.getItem(ONBOARDING_PENDING_KEY)) === "true";
     } catch (error) {
       reportFailure("isOnboardingPending", error);
-      return false;
+      return null;
     }
   },
 


### PR DESCRIPTION
## 배경

#185 코드리뷰(coderabbit)에서 지적된 후속 수정입니다.

`tokenStorage.setOnboardingPending`/`isOnboardingPending`이 AsyncStorage 오류를 조용히 삼켜 `false`로 반환하고 있었습니다. 이 때문에 저장소 오류가 발생해도 "온보딩 완료" 상태와 구분되지 않아, 부트스트랩·온보딩 제출 성공·409 처리 경로에서 실제로는 온보딩이 끝나지 않은 사용자가 인증 완료 상태로 잘못 확정될 수 있었습니다.

## 변경 사항

- `tokenStorage.setOnboardingPending`: 저장 성공 여부(`boolean`)를 반환하도록 변경
- `tokenStorage.isOnboardingPending`: 읽기 실패 시 `false` 대신 `null`(완료 상태와 구분되는 값)을 반환하도록 변경
- `use-auth-state.ts` (부트스트랩): `isOnboardingPending()`이 `null`이면 인증 상태를 확정하지 않고 `unauthenticated` 처리
- `use-submit-onboarding.ts` (온보딩 제출 성공 경로): 저장 실패 시 `setAuthenticated()`/`reset()` 호출하지 않음
- `onboarding-exercise-detail-screen.tsx` (409 처리 경로): 저장 실패 시 인증 확정 없이 재시도 토스트만 표시

## 테스트

- `npx tsc --noEmit` 통과