### PR TITLE
fix: 토스트가 가로 중앙에 정렬되지 않던 문제 수정

### DIFF
--- a/components/toast/toast.tsx
+++ b/components/toast/toast.tsx
@@ -13,7 +13,6 @@ const TOAST_PADDING_V = 10;
 const TOAST_PADDING_H = 16;
 const TOAST_GAP = 8;
 const TOAST_BORDER_RADIUS = 12; // radius-xl
-const TOAST_LEFT = 70;
 const TOAST_BOTTOM = 54;
 const TOAST_BG = '#2F323A';       // fill-heavy
 const TOAST_TEXT_COLOR = '#FFFFFF'; // label-normal-inverse
@@ -103,8 +102,10 @@ export default function Toast({ containerClassName, gap = 8 }: Props) {
       pointerEvents="none"
       style={{
         position: 'absolute',
-        left: TOAST_LEFT,
+        left: 0,
+        right: 0,
         bottom: insets.bottom + TOAST_BOTTOM,
+        alignItems: 'center',
         zIndex: 9999,
       }}
     >


### PR DESCRIPTION
## 배경

토스트가 화면 하단에 표시될 때 가로로 중앙 정렬되지 않고 왼쪽으로 치우쳐 보이는 문제.

`left: 70` 고정값으로 위치를 잡고 있어, 토스트 콘텐츠(텍스트) 폭이 달라질 때마다 실제 중앙에서 벗어난 위치에 표시되고 있었습니다.

## 변경 사항

- `components/toast/toast.tsx`: `left: 70` 고정값 제거, `left: 0, right: 0` + `alignItems: 'center'`로 변경해 화면 가로 중앙에 정렬
- 세로 위치(`bottom: insets.bottom + 54`)는 변경 없음