### PR TITLE
fix: 세모피드, 커뮤니티, 산 목록 이미지 로딩 성능 개선

### DIFF
--- a/features/community/components/free-board-screen.tsx
+++ b/features/community/components/free-board-screen.tsx
@@ -21,6 +21,9 @@ export function FreeBoardScreen() {
           if (hasNextPage && !isFetchingNextPage) fetchNextPage();
         }}
         onEndReachedThreshold={0.5}
+        windowSize={7}
+        initialNumToRender={8}
+        maxToRenderPerBatch={8}
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={refetch} />
         }

--- a/features/community/components/free-board-search-screen.tsx
+++ b/features/community/components/free-board-search-screen.tsx
@@ -75,6 +75,9 @@ export function FreeBoardSearchScreen(): React.JSX.Element {
         renderItem={({ item }) => <PostItem post={item} />}
         ListEmptyComponent={renderEmpty}
         contentContainerStyle={{ flexGrow: 1 }}
+        windowSize={7}
+        initialNumToRender={8}
+        maxToRenderPerBatch={8}
       />
     </View>
   );

--- a/features/community/components/post-avatar.tsx
+++ b/features/community/components/post-avatar.tsx
@@ -1,5 +1,6 @@
 import { UserIcon } from "@/components/icons/user-icon";
-import { Image, View } from "react-native";
+import { Image } from "expo-image";
+import { View } from "react-native";
 
 type AvatarSize = "sm" | "md" | "lg";
 
@@ -25,6 +26,8 @@ export function PostAvatar({ size = "md", imageUrl }: PostAvatarProps) {
         <Image
           source={{ uri: imageUrl }}
           style={{ width: container, height: container }}
+          contentFit="cover"
+          cachePolicy="memory-disk"
         />
       ) : (
         <UserIcon size={icon} color="#A4ABC0" />

--- a/features/community/components/post-body.tsx
+++ b/features/community/components/post-body.tsx
@@ -183,6 +183,8 @@ export function PostBody({
                       source={{ uri: img.imageUrl }}
                       style={{ width: 148, height: 148, borderRadius: 12 }}
                       contentFit="cover"
+                      cachePolicy="memory-disk"
+                      transition={100}
                     />
                   ) : (
                     <View

--- a/features/community/components/post-item.tsx
+++ b/features/community/components/post-item.tsx
@@ -3,11 +3,16 @@ import { HeartIcon } from "@/components/icons/heart-icon";
 import { formatDate } from "@/lib/utils";
 import { FreePostListResponse } from "@/types/api.generated";
 import { useRouter } from "expo-router";
+import { memo } from "react";
 import { Pressable, Text, View } from "react-native";
 import { StatItem } from "./stat-item";
 import { Thumbnail } from "./thumbnail";
 
-export function PostItem({ post }: { post: FreePostListResponse }) {
+export const PostItem = memo(function PostItem({
+  post,
+}: {
+  post: FreePostListResponse;
+}) {
   const hasImage = !!post.thumbnailUrl;
   const router = useRouter();
   return (
@@ -48,4 +53,4 @@ export function PostItem({ post }: { post: FreePostListResponse }) {
       </View>
     </Pressable>
   );
-}
+});

--- a/features/community/components/thumbnail.tsx
+++ b/features/community/components/thumbnail.tsx
@@ -4,7 +4,13 @@ import { View } from "react-native";
 export function Thumbnail({ imageUrl }: { imageUrl: string }) {
   return (
     <View className="size-[68px] overflow-hidden rounded-[4px] bg-fill-neutral">
-      <Image source={{ uri: imageUrl }} style={{ flex: 1 }} contentFit="cover" />
+      <Image
+        source={{ uri: imageUrl }}
+        style={{ flex: 1 }}
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        transition={100}
+      />
     </View>
   );
 }

--- a/features/home/components/feed-cell.tsx
+++ b/features/home/components/feed-cell.tsx
@@ -19,6 +19,7 @@ type FeedCellProps = {
   row: number;
   item?: SemoFeedResponse;
   onPress: (item: SemoFeedResponse) => void;
+  animated?: boolean;
 };
 
 export const FeedCell = memo(function FeedCell({
@@ -26,6 +27,7 @@ export const FeedCell = memo(function FeedCell({
   row,
   item,
   onPress,
+  animated = false,
 }: FeedCellProps) {
   const imageUrl = item?.imageUrl;
 
@@ -35,7 +37,7 @@ export const FeedCell = memo(function FeedCell({
 
   return (
     <Animated.View
-      entering={FadeInDown.duration(300).delay(200)}
+      entering={animated ? FadeInDown.duration(300).delay(200) : undefined}
       className="absolute overflow-hidden rounded-2xl bg-transparent"
       style={{
         left: col * CELL_W + CELL_GAP / 2,
@@ -52,6 +54,8 @@ export const FeedCell = memo(function FeedCell({
               source={{ uri: imageUrl.replace(/"/g, "") }}
               style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
               contentFit="cover"
+              cachePolicy="memory-disk"
+              transition={150}
             />
           )}
         </View>

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -52,6 +52,15 @@ export function FeedHomeView() {
 
   const feedItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
 
+  useEffect(() => {
+    const urls = (semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [])
+      .map((item) => item.imageUrl?.replace(/"/g, ""))
+      .filter((url): url is string => !!url);
+    if (urls.length > 0) {
+      Image.prefetch(urls, { cachePolicy: "memory-disk" });
+    }
+  }, [semofeedData]);
+
   // 화면 크기 (onLayout으로 측정)
   const [screen, setScreen] = useState({ w: 0, h: 0 });
 
@@ -71,17 +80,31 @@ export function FeedHomeView() {
   // 초기 중심 위치 저장 (리셋 버튼용)
   const initPosRef = useRef({ x: 0, y: 0 });
 
+  // 첫 진입 연출이 끝났는지 (이후 드러나는 셀은 등장 애니메이션 생략)
+  const introPlayedRef = useRef(false);
+
   // rAF 스로틀용
   const rafRef = useRef<number | null>(null);
+  const pendingOffsetRef = useRef({ x: 0, y: 0 });
+  const lastBucketRef = useRef({ x: 0, y: 0 });
 
   // ─────────────────────────────────────────────
-  // rAF 스로틀: setOffset을 프레임당 1번으로 묶음
+  // rAF 스로틀: setOffset을 프레임당 최대 1번으로 묶고,
+  // 가시 셀 범위가 바뀔 만큼(반 셀) 움직였을 때만 리렌더
   // ─────────────────────────────────────────────
   const scheduleSetOffset = (x: number, y: number): void => {
+    pendingOffsetRef.current = { x, y };
     if (rafRef.current != null) return; // 이미 예약돼 있으면 무시
     rafRef.current = requestAnimationFrame(() => {
-      setOffset({ x, y });
       rafRef.current = null;
+      const { x: px, y: py } = pendingOffsetRef.current;
+      // OVERSCAN 1셀 여유가 있으므로 반 셀 단위 이동 전까지는 범위 재계산 불필요
+      const bucketX = Math.round(px / (CELL_W / 2));
+      const bucketY = Math.round(py / (CELL_H / 2));
+      const last = lastBucketRef.current;
+      if (bucketX === last.x && bucketY === last.y) return;
+      lastBucketRef.current = { x: bucketX, y: bucketY };
+      setOffset({ x: px, y: py });
     });
   };
 
@@ -171,6 +194,7 @@ export function FeedHomeView() {
             row={row}
             item={feedItems[spiralIdx]}
             onPress={setSelectedItem}
+            animated={!introPlayedRef.current}
           />,
         );
       }
@@ -204,7 +228,16 @@ export function FeedHomeView() {
             translateY.value = initY;
             savedX.value = initX;
             savedY.value = initY;
+            lastBucketRef.current = {
+              x: Math.round(initX / (CELL_W / 2)),
+              y: Math.round(initY / (CELL_H / 2)),
+            };
             setOffset({ x: initX, y: initY });
+            if (!introPlayedRef.current) {
+              setTimeout(() => {
+                introPlayedRef.current = true;
+              }, 600);
+            }
           }}
         >
           {/* 배경 이미지 */}

--- a/features/home/components/feed-home-view.tsx
+++ b/features/home/components/feed-home-view.tsx
@@ -52,11 +52,16 @@ export function FeedHomeView() {
 
   const feedItems = semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [];
 
+  const prefetchedUrlsRef = useRef(new Set<string>());
+
   useEffect(() => {
     const urls = (semofeedData?.pages.flatMap((p) => p.content ?? []) ?? [])
       .map((item) => item.imageUrl?.replace(/"/g, ""))
-      .filter((url): url is string => !!url);
+      .filter(
+        (url): url is string => !!url && !prefetchedUrlsRef.current.has(url),
+      );
     if (urls.length > 0) {
+      urls.forEach((url) => prefetchedUrlsRef.current.add(url));
       Image.prefetch(urls, { cachePolicy: "memory-disk" });
     }
   }, [semofeedData]);

--- a/features/mountains/components/mountain-card.tsx
+++ b/features/mountains/components/mountain-card.tsx
@@ -1,6 +1,7 @@
 import { COURSE_BADGE } from "@/features/mountains/constants/course-badge";
 import { MountainListResponse } from "@/types/api.generated";
 import { Image } from "expo-image";
+import { memo } from "react";
 import { Text, View } from "react-native";
 
 type MountainDifficulty = NonNullable<MountainListResponse["difficulty"]>;
@@ -11,7 +12,11 @@ export const DIFFICULTY_LABEL: Record<MountainDifficulty, string> = {
   HARD: "상",
 };
 
-export function MountainCard({ mountain }: { mountain: MountainListResponse }) {
+export const MountainCard = memo(function MountainCard({
+  mountain,
+}: {
+  mountain: MountainListResponse;
+}) {
   return (
     <View className="flex-row items-center gap-4">
       {mountain.imageUrls?.[0] ? (
@@ -19,6 +24,8 @@ export function MountainCard({ mountain }: { mountain: MountainListResponse }) {
           source={{ uri: mountain.imageUrls[0] }}
           style={{ width: 86, height: 72, borderRadius: 10 }}
           contentFit="cover"
+          cachePolicy="memory-disk"
+          transition={100}
         />
       ) : (
         <View className="h-[72px] w-[86px] rounded-[10px] bg-fill-stronger" />
@@ -51,4 +58,4 @@ export function MountainCard({ mountain }: { mountain: MountainListResponse }) {
       </View>
     </View>
   );
-}
+});

--- a/features/mountains/components/mountain-list.tsx
+++ b/features/mountains/components/mountain-list.tsx
@@ -61,11 +61,7 @@ export function MountainList({
       showsVerticalScrollIndicator={false}
       data={filteredMountains}
       keyExtractor={(mountain) => String(mountain.mountainId)}
-      contentContainerStyle={{
-        gap: 20,
-        paddingHorizontal: 20,
-        paddingVertical: 12,
-      }}
+      contentContainerClassName="gap-5 px-5 py-3"
       renderItem={({ item }) => (
         <TouchableOpacity
           onPress={() => router.push(`/mountains/${item.mountainId}`)}

--- a/features/mountains/components/mountain-list.tsx
+++ b/features/mountains/components/mountain-list.tsx
@@ -1,11 +1,7 @@
 import { MountainCard } from "@/features/mountains/components/mountain-card";
 import { useRouter } from "expo-router";
 import { LoadingSpinner } from "@/components/loading-spinner";
-import {
-  ScrollView,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { FlatList, TouchableOpacity } from "react-native";
 import { useMountains } from "../hooks/use-mountains";
 import {
   Coordinates,
@@ -60,18 +56,27 @@ export function MountainList({
   );
 
   return (
-    <ScrollView className="flex-1" showsVerticalScrollIndicator={false}>
-      <View className="gap-5 px-5 py-3">
-        {filteredMountains.map((mountain) => (
-          <TouchableOpacity
-            key={mountain.mountainId}
-            onPress={() => router.push(`/mountains/${mountain.mountainId}`)}
-            activeOpacity={0.7}
-          >
-            <MountainCard mountain={mountain} />
-          </TouchableOpacity>
-        ))}
-      </View>
-    </ScrollView>
+    <FlatList
+      className="flex-1"
+      showsVerticalScrollIndicator={false}
+      data={filteredMountains}
+      keyExtractor={(mountain) => String(mountain.mountainId)}
+      contentContainerStyle={{
+        gap: 20,
+        paddingHorizontal: 20,
+        paddingVertical: 12,
+      }}
+      renderItem={({ item }) => (
+        <TouchableOpacity
+          onPress={() => router.push(`/mountains/${item.mountainId}`)}
+          activeOpacity={0.7}
+        >
+          <MountainCard mountain={item} />
+        </TouchableOpacity>
+      )}
+      windowSize={7}
+      initialNumToRender={10}
+      maxToRenderPerBatch={10}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- 세모피드: 셀 등장 애니메이션(delay 200ms + duration 300ms)이 팬 중 새로 드러나는 셀과 화면 밖에 나갔다 돌아온 셀마다 매번 재생되어 이미지가 늦게 뜨는 것처럼 보이던 문제 수정 — 첫 진입 연출에만 적용되도록 조건화
- 세모피드: 피드 데이터 도착 시 `Image.prefetch`로 이미지를 미리 캐시에 적재하고, 팬 중 매 프레임 발생하던 가상화 리렌더(`setOffset`)를 가시 셀 범위가 실제로 바뀔 수 있는 반 셀 이동 시에만 발생하도록 개선
- 커뮤니티: `PostAvatar`가 디스크 캐시가 약한 RN 기본 `Image`를 사용하던 것을 `expo-image`로 전환, 목록 썸네일·상세 이미지에 `memory-disk` 캐시 정책 적용
- 커뮤니티: `PostItem` 메모이제이션(페이지 로딩 스피너 토글 시 보이는 행 전체 리렌더 방지) 및 FlatList 렌더 배치 튜닝
- 산 목록: 산 전체(size=1000)를 ScrollView에 한 번에 전부 마운트하던 구조를 FlatList 가상화로 전환(보이는 카드만 렌더), `MountainCard` 메모이제이션 및 캐시 정책 적용
- 참고(백엔드 후속 필요): 이미지 원본이 리사이즈 없이 그대로 내려오고 있음 — 시뮬레이터 이미지 캐시 실측 결과 84장 중 30장이 1MB 초과, 최대 15MB(셀 필요 용량의 수십 배). 썸네일 파이프라인 및 기존 대용량 이미지 재처리 요청 예정

## Test plan
- [ ] 세모피드 첫 진입 시 기존 등장 연출(페이드인)이 유지되는지 확인
- [ ] 팬 중 새로 드러나는 셀 이미지가 지연 없이 표시되고, 한 번 본 셀은 되돌아왔을 때 즉시 표시되는지 확인
- [ ] 셀 탭(디테일 열기), 리셋 버튼, 가장자리 도달 시 다음 페이지 로드(#186)가 기존대로 동작하는지 확인
- [ ] 커뮤니티 목록/검색 스크롤이 부드럽고, 썸네일·아바타가 화면 재방문 시 즉시 표시되는지 확인
- [ ] 산 목록 첫 진입 렌더가 빨라졌는지, 스크롤·지역/난이도/소요시간 필터·정렬이 기존대로 동작하는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **성능 개선**
  * 커뮤니티 게시판과 산 목록의 스크롤 및 목록 렌더링 성능을 개선했습니다.
  * 피드와 목록 이미지의 캐싱 및 사전 로딩을 적용해 표시 속도를 향상했습니다.
  * 게시글과 산 카드의 불필요한 재렌더링을 줄였습니다.
* **사용자 경험**
  * 이미지가 부드러운 전환 효과와 함께 표시됩니다.
  * 홈 피드의 항목 등장 애니메이션과 스크롤 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->