### PR TITLE
feat : 게시글 댓글 및 좋아요 알림

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,25 +24,9 @@ import "../global.css";
 
 // 포어그라운드에서도 알림 배너 표시
 Notifications.setNotificationHandler({
-  handleNotification: async (notification) => {
-    const data = notification.request.content.data as { type?: string } | null;
-    const type = data?.type;
-
-    // 트래킹 푸시: 포어그라운드에서 시스템 배너 차단 (in-app banner 만 노출)
-    // mixed payload 로 백엔드가 notification + data 둘 다 보내므로 중복 방지
-    if (
-      type === "TRACKING_PHOTO_MILESTONE" ||
-      type === "TRACKING_SUMMIT_REACHED"
-    ) {
-      return {
-        shouldShowBanner: true,
-        shouldShowList: true,
-        shouldPlaySound: true,
-        shouldSetBadge: true,
-      };
-    }
-
-    // 그 외 (커뮤니티/세모피드 등): 시스템 배너 그대로 표시
+  handleNotification: async () => {
+    // 모든 타입에 대해 시스템 배너를 그대로 표시한다.
+    // (이전에는 트래킹 타입을 분기했지만 두 갈래가 같은 값을 반환해 동작이 동일했다)
     return {
       shouldShowBanner: true,
       shouldShowList: true,

--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -42,6 +42,15 @@ export function usePushNotification(enabled = true): void {
         typeof remoteMessage.data?.type === "string"
           ? remoteMessage.data.type
           : undefined;
+      // 수신 여부를 확인할 수단이 없어 진단이 어려웠던 지점 (트래킹 훅과 동일하게 로깅)
+      console.log(
+        "[Push] 포어그라운드 수신:",
+        type,
+        "notification:",
+        remoteMessage.notification != null,
+        "data keys:",
+        Object.keys(remoteMessage.data ?? {}).join(","),
+      );
       if (type && TRACKING_TYPES.has(type)) return;
 
       const title =
@@ -66,6 +75,7 @@ export function usePushNotification(enabled = true): void {
     const tapSub = Notifications.addNotificationResponseReceivedListener(
       (response) => {
         const data = extractPushData(response);
+        console.log("[Push] 알림 탭:", data?.type, "extras:", data?.extras);
         if (data) navigateByType(data, router);
       },
     );

--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -7,6 +7,7 @@ import {
   getMessaging,
   getToken,
   onMessage,
+  setAPNSToken,
 } from "@react-native-firebase/messaging";
 import * as Device from "expo-device";
 import * as Notifications from "expo-notifications";
@@ -145,6 +146,14 @@ async function registerFcmToken() {
         "[Push] APNs 토큰:",
         apnsToken ? `있음 (${apnsToken.length}자)` : "null — APNs 등록 실패",
       );
+
+      // 개발 빌드는 APNs 샌드박스를 쓰는데, Firebase SDK의 프로비저닝 프로파일
+      // 기반 자동 판별이 실패하면 FCM이 프로덕션 서버로 보내고 APNs가 조용히
+      // 거절한다(앱에 아무 흔적도 남지 않음). 개발 빌드에서만 환경을 명시한다.
+      if (__DEV__ && apnsToken) {
+        await setAPNSToken(fcmMessaging, apnsToken, "sandbox");
+        console.log("[Push] APNs 토큰 타입을 sandbox로 명시");
+      }
     }
 
     const token = await getToken(fcmMessaging);

--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/react-native";
 import { api } from "@/lib/api";
+import { NotificationTestRequest } from "@/types/api.generated";
 import { getApp } from "@react-native-firebase/app";
 import {
   getMessaging,
@@ -92,28 +93,8 @@ type PushData = {
 };
 
 // 백엔드 NotificationType enum과 동기화
-type NotificationType =
-  | "COMMUNITY_COMMENT"
-  | "COMMUNITY_REPLY"
-  | "COMMUNITY_LIKE"
-  | "COMMUNITY_MENTION"
-  | "FOLLOW_RECEIVED"
-  | "HIKING_INVITE"
-  | "HIKING_INVITE_ACCEPTED"
-  | "HIKING_STARTED"
-  | "HIKING_MEMBER_JOINED"
-  | "HIKING_MEMBER_LEFT"
-  | "HIKING_NEAR_DESTINATION"
-  | "HIKING_OFF_TRAIL"
-  | "HIKING_FINISHED"
-  | "HIKING_CHAT"
-  | "EMERGENCY_SOS"
-  | "WEATHER_WARNING"
-  | "TRAIL_CLOSED"
-  | "SYSTEM_NOTICE"
-  | "SYSTEM_MAINTENANCE"
-  | "APP_UPDATE"
-  | "TRACKING_PHOTO_MILESTONE";
+// (types/api.generated.ts의 NotificationTestRequest.type과 같은 목록)
+type NotificationType = NotificationTestRequest["type"];
 
 // ─── FCM 토큰 등록 ───────────────────────────────────────────
 
@@ -191,31 +172,22 @@ function navigateByType(data: PushData, router: ReturnType<typeof useRouter>) {
   switch (data.type) {
     case "COMMUNITY_COMMENT":
     case "COMMUNITY_REPLY":
-    case "COMMUNITY_LIKE":
-    case "COMMUNITY_MENTION":
+    case "COMMUNITY_POST_LIKE":
       // 자유게시판 게시글 상세 — postId 없으면 이동하지 않음(undefined 경로 방지)
       if (extras.postId != null) {
         push(`/community/free-board/${extras.postId}`);
       }
       break;
 
-    case "HIKING_INVITE":
-    case "HIKING_INVITE_ACCEPTED":
-    case "HIKING_STARTED":
-    case "HIKING_MEMBER_JOINED":
-    case "HIKING_MEMBER_LEFT":
-    case "HIKING_NEAR_DESTINATION":
-    case "HIKING_OFF_TRAIL":
-    case "HIKING_FINISHED":
-    case "HIKING_CHAT":
-    case "EMERGENCY_SOS":
     case "TRACKING_PHOTO_MILESTONE":
+    case "TRACKING_SUMMIT_REACHED":
       router.push("/(tabs)/tracking");
       break;
 
-    // 대응 화면이 아직 없는 타입(FOLLOW_RECEIVED, SYSTEM_*, WEATHER_WARNING 등)은
-    // 존재하지 않는 라우트로 이동하면 unmatched route가 뜨므로 이동하지 않는다.
-    // (알림 센터/프로필 화면 구현 시 여기에 연결)
+    // SEMOFEED_EMOJI는 개별 글로 이동할 라우트가 없어 이동하지 않는다.
+    // 세모피드는 홈 탭 내부 뷰라 `?tab=feed`로 목록까지만 열 수 있고,
+    // 반응이 달린 글이 목록 첫 페이지에 없으면 사용자가 찾을 수 없다.
+    // (세모피드 단건 조회 및 딥링크 지원 시 여기에 연결)
     default:
       break;
   }

--- a/hooks/use-push-notification.ts
+++ b/hooks/use-push-notification.ts
@@ -3,6 +3,7 @@ import { api } from "@/lib/api";
 import { NotificationTestRequest } from "@/types/api.generated";
 import { getApp } from "@react-native-firebase/app";
 import {
+  getAPNSToken,
   getMessaging,
   getToken,
   onMessage,
@@ -109,11 +110,8 @@ type NotificationType = NotificationTestRequest["type"];
 // ─── FCM 토큰 등록 ───────────────────────────────────────────
 
 async function registerFcmToken() {
-  if (!Device.isDevice) {
-    console.log("[Push] 실기기에서만 토큰 등록 가능");
-    return;
-  }
-
+  // 권한 요청은 시뮬레이터에서도 수행한다.
+  // simctl push로 알림 표시·탭 라우팅을 검증하려면 권한이 필요하다.
   const { status: existingStatus } = await Notifications.getPermissionsAsync();
   let finalStatus = existingStatus;
 
@@ -127,11 +125,28 @@ async function registerFcmToken() {
     return;
   }
 
+  // FCM 토큰은 실기기에서만 발급된다
+  if (!Device.isDevice) {
+    console.log("[Push] 실기기에서만 토큰 등록 가능");
+    return;
+  }
+
   try {
     // iOS: Firebase SDK로 FCM 등록 토큰 획득 (APNs 토큰 아님)
     // Android: FCM 토큰 직접 반환
     const app = getApp();
     const fcmMessaging = getMessaging(app);
+
+    // APNs 토큰이 붙지 않으면 FCM 토큰이 발급돼도 iOS로 전달되지 않는다.
+    // 원인 추적이 어려웠던 지점이라 값을 남긴다.
+    if (Platform.OS === "ios") {
+      const apnsToken = await getAPNSToken(fcmMessaging);
+      console.log(
+        "[Push] APNs 토큰:",
+        apnsToken ? `있음 (${apnsToken.length}자)` : "null — APNs 등록 실패",
+      );
+    }
+
     const token = await getToken(fcmMessaging);
 
     await api.post({


### PR DESCRIPTION
## 관련 이슈

없음

## 작업 내용

**게시글 좋아요 알림을 탭해도 아무 화면으로도 이동하지 않던 문제**를 고쳤습니다.

프론트의 `NotificationType` 이 백엔드 enum과 어긋나 있었습니다. 주석에는 *"백엔드 NotificationType enum과 동기화"* 라고 적혀 있었지만 실제로는 손으로 나열된 20여 개가 스펙과 맞지 않았습니다.

| 알림 | 백엔드 타입 | 기존 프론트 | 탭했을 때 |
| --- | --- | --- | --- |
| 게시글 댓글 | `COMMUNITY_COMMENT` | 있음 | 게시글 상세로 이동 |
| **게시글 좋아요** | `COMMUNITY_POST_LIKE` | `COMMUNITY_LIKE` (오타) | **`default:` → 이동 없음** |
| 세모피드 이모지 | `SEMOFEED_EMOJI` | 없음 | `default:` → 이동 없음 |

### 변경 사항

- `COMMUNITY_LIKE` → `COMMUNITY_POST_LIKE` 로 수정. 댓글과 같은 분기를 타서 `extras.postId` 로 게시글 상세로 이동합니다
- 타입 유니온을 손으로 나열하는 대신 `NotificationTestRequest["type"]` 을 참조하도록 변경 — 앞으로 `npm run typegen` 결과를 자동으로 따라갑니다
- 백엔드에 없는 타입 정리 (`HIKING_*` 9개, `EMERGENCY_SOS`, `WEATHER_WARNING`, `FOLLOW_RECEIVED`, `SYSTEM_*` 등 — 도달 불가 코드였습니다)
- `TRACKING_SUMMIT_REACHED` 를 트래킹 탭으로 이동하도록 추가
- `_layout.tsx` 의 알림 핸들러에서 두 갈래가 **완전히 같은 객체를 반환**하던 죽은 분기 정리 (동작 변화 없음)

### 디버깅 인프라

이번 작업 중 원인 추적이 막혔던 지점들을 열어뒀습니다.

- **수신·탭 로그 추가** — 포어그라운드 수신 핸들러에 로그가 없어 *"알림이 안 온 것"* 과 *"왔는데 표시가 안 된 것"* 을 구분할 수 없었습니다. 트래킹 훅(`use-tracking-fcm.ts`)은 이미 같은 로그를 찍고 있어 일관성도 맞습니다
- **알림 권한 요청을 `Device.isDevice` 가드 앞으로 이동** — 권한 요청이 가드 뒤에 있어 **시뮬레이터에서는 권한 요청조차 하지 않았습니다.** 그래서 `simctl push` 로 알림을 검증할 수 없었습니다. FCM 토큰 발급만 실기기 전용으로 남겼고, 실기기 동작은 그대로입니다
- **APNs 토큰 유무 로깅** — FCM 토큰이 발급돼도 APNs 토큰이 안 붙으면 iOS로 전달되지 않는데 구분할 방법이 없었습니다
- **개발 빌드에서 APNs 환경을 `sandbox` 로 명시** — `__DEV__` 한정, 릴리스 영향 없음

## 스크린샷

| 댓글 알림 | 좋아요 알림 |
| --- | --- |
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/b0b7391b-f113-430d-982d-129a030f056d" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/75aa3875-ccba-4286-84e0-2695bc90605e" /> |
| 탭 → 게시글 상세 이동 | 탭 → 게시글 상세 이동 (이번 수정) |

## 확인 방법

권한 요청 위치를 옮긴 덕분에 **시뮬레이터에서 실기기 없이 검증할 수 있습니다.**

```bash
# 앱 실행 → 알림 권한 허용 → 홈 버튼으로 백그라운드
xcrun simctl push booted com.tastyhiking.semosanapp payload.json
```

```json
{
  "Simulator Target Bundle": "com.tastyhiking.semosanapp",
  "aps": { "alert": { "title": "좋아요", "body": "..." }, "badge": 1 },
  "type": "COMMUNITY_POST_LIKE",
  "extras": "{\"postId\":4,\"actorId\":1}"
}
```

`type` 을 `COMMUNITY_COMMENT` 로 바꾸면 댓글 알림입니다.

**검증 결과** — 두 타입 모두 배너 표시 · 배지 카운트 · 탭 후 게시글 상세 이동까지 확인했습니다.

```
[Push] 알림 탭: COMMUNITY_COMMENT extras: {"postId":4,"actorId":1}
[Push] 알림 탭: COMMUNITY_POST_LIKE extras: {"postId":4,"actorId":1}
```

## 리뷰 포인트

**1. 실기기 실제 푸시로는 검증하지 못했습니다.** 개발 빌드로는 푸시가 전혀 도착하지 않습니다 — 팀 전체가 개발 빌드로 알림을 받아본 적이 없고, TestFlight 빌드만 정상 수신됩니다. 클라이언트·Firebase·IAM·네트워크를 모두 점검했지만 전부 정상이었고, **Firebase 콘솔에서 직접 보낸 테스트 메시지도 도착하지 않아** 백엔드 무관 이슈로 판단됩니다. Apple Developer 의 APNs 키 상태 또는 FCM 발송 응답 확인이 필요하며, 별도 이슈로 진행 중입니다.

**2. 따라서 다음 두 가지는 아직 미검증입니다.**
- `trigger.payload` 폴백 경로 — 시뮬레이터는 `content.data` 경로만 탑니다
- **실제 백엔드 페이로드 형태** — 테스트 페이로드는 코드가 기대하는 구조에 맞춰 역으로 구성한 것이라, `extras` 가 JSON 문자열인지 / 키가 `postId` 가 맞는지 확인이 필요합니다. 백엔드에 문의해둔 상태이고, TestFlight 검증 시 함께 확인됩니다

**3. `SEMOFEED_EMOJI` 라우팅은 의도적으로 붙이지 않았습니다.** 세모피드는 홈 탭 내부 뷰라 개별 글로 이동할 라우트가 없고, `?tab=feed` 로 목록만 열면 반응이 달린 글이 첫 페이지에 없을 때 사용자가 찾을 수 없습니다. 타입에는 포함시키고 사유를 주석으로 남겼습니다.

**4. 남은 별건** — `usePushNotification` 의 의존성 배열에 `router` 가 있어 화면 이동마다 `POST /api/fcm/tokens` 가 재호출됩니다. 이번 범위에서 제외했습니다.

## 체크리스트

- [x] 자동 생성 파일을 직접 수정하지 않았습니다
- [x] iOS 시뮬레이터에서 동작을 확인했습니다
- [x] API 스펙 변경 없음 (기존 `NotificationTestRequest` 타입 참조만 추가)
- [ ] 실기기 검증 — 개발 빌드 푸시 미수신으로 불가, TestFlight 에서 확인 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 푸시 알림 토큰 등록 과정이 개선되어 시뮬레이터에서도 알림 권한을 요청할 수 있습니다.
  * 개발 환경에서 APNs 알림 설정이 지원됩니다.
  * 알림을 통해 커뮤니티 게시글 좋아요 및 정상 도달한 트래킹 화면으로 이동할 수 있습니다.

* **개선 사항**
  * 모든 알림이 일관된 배너, 목록, 사운드 및 배지 설정으로 표시됩니다.
  * 지원되지 않는 알림 유형은 잘못된 화면으로 이동하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->