### PR TITLE
fix: 세모피드 프사가 없을 때 기본 프로필 아이콘이 안 보이던 문제 수정

### DIFF
--- a/features/home/components/feed-cell-detail.tsx
+++ b/features/home/components/feed-cell-detail.tsx
@@ -1,3 +1,4 @@
+import { AvatarIcon } from "@/components/icons/avatar-icon";
 import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
 import { XIcon } from "@/components/icons/x-icon";
 import { SemoFeedEmojiRequest, SemoFeedResponse } from "@/types/api.generated";
@@ -118,7 +119,9 @@ export function FeedCellDetail({
                       style={{ flex: 1 }}
                       contentFit="cover"
                     />
-                  ) : null}
+                  ) : (
+                    <AvatarIcon size={32} />
+                  )}
                 </View>
                 <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
                   {item.nickname ?? ""}


### PR DESCRIPTION
## Summary
- 세모피드 상세 화면에서 프로필 이미지가 없을 때 빈 원(placeholder)만 보이던 문제를 기본 프로필 아이콘(AvatarIcon)으로 대체

## Test plan
- [ ] 프사가 없는 세모피드 항목에서 기본 프로필 아이콘이 정상 노출되는지 확인
- [ ] 프사가 있는 경우 기존처럼 이미지가 정상 노출되는지 확인