### PR TITLE
fix: 닉네임/생년월일/코스명 입력창에서 텍스트가 세로 중앙에서 벗어나 아래로 처지던 문제 수정

### DIFF
--- a/features/mypage/components/birth-date-bottom-sheet.tsx
+++ b/features/mypage/components/birth-date-bottom-sheet.tsx
@@ -87,7 +87,7 @@ export function BirthDateBottomSheet({ visible, initialValue, onClose, onSave }:
                 placeholderTextColor="#8b92a6"
                 keyboardType="numbers-and-punctuation"
                 autoFocus
-                style={{ paddingVertical: 0, letterSpacing: -0.16 }}
+                style={{ letterSpacing: -0.16 }}
               />
             </View>
 

--- a/features/mypage/components/nickname-bottom-sheet.tsx
+++ b/features/mypage/components/nickname-bottom-sheet.tsx
@@ -86,7 +86,7 @@ export function NicknameBottomSheet({ visible, initialValue, onClose, onSave }: 
               onChangeText={setValue}
               maxLength={10}
               autoFocus
-              style={{ paddingVertical: 0, letterSpacing: -0.16 }}
+              style={{ letterSpacing: -0.16 }}
             />
             {value.length > 0 && (
               <TouchableOpacity

--- a/features/tracking/components/course-name-input-modal.tsx
+++ b/features/tracking/components/course-name-input-modal.tsx
@@ -82,7 +82,6 @@ export function CourseNameInputModal({
                 returnKeyType="done"
                 autoFocus
                 onSubmitEditing={() => onSubmit(value.trim())}
-                style={{ paddingVertical: 0 }}
               />
             </View>
 


### PR DESCRIPTION
## Summary
- 내 정보 화면의 닉네임/생년월일 바텀시트, 트래킹 코스명 입력 모달에서 텍스트가 세로 중앙 정렬되지 못하고 아래로 처지던 문제 수정
- 원인: 고정 높이 입력창 안에서 TextInput에 `paddingVertical: 0`을 강제로 덮어써 세로 중앙 정렬이 깨짐. 앱 내 정상 동작하는 다른 입력창(TextField 등)과 동일하게 해당 padding 오버라이드 제거

## Test plan
- [ ] 마이페이지 > 내 정보 > 닉네임 입력 시 텍스트가 세로 중앙에 정렬되는지 확인
- [ ] 마이페이지 > 내 정보 > 생년월일 입력 시 텍스트가 세로 중앙에 정렬되는지 확인
- [ ] 트래킹 > 코스명 입력 모달에서 텍스트가 세로 중앙에 정렬되는지 확인