### PR TITLE
feat: 라이브 액티비티 코스 따라가기에 남은 사진 촬영 장수 표시 추가

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -1165,6 +1165,9 @@ export default function TrackingScreen() {
 
     if (result.canceled || !result.assets?.[0]?.uri) return;
 
+    // 업로드/저장이 진행되는 동안 세션이 종료·교체될 수 있어 촬영 시점의 세션을 고정
+    const capturedSessionId = sessionId;
+
     try {
       const capturedAt = new Date().toISOString();
       const imageUrl = await uploadTrackingPhoto(result.assets[0].uri);
@@ -1183,7 +1186,10 @@ export default function TrackingScreen() {
         },
       });
       console.log("[Tracking] 사진 메타 저장 완료");
-      setPhotosTaken((prev) => Math.min(prev + 1, MAX_TRACKING_PHOTOS));
+      // 저장 완료 시점에 세션이 이미 바뀌었다면(종료 후 재시작 등) 새 세션 카운터에 반영하지 않음
+      if (sessionIdRef.current === capturedSessionId) {
+        setPhotosTaken((prev) => Math.min(prev + 1, MAX_TRACKING_PHOTOS));
+      }
     } catch (err) {
       console.warn("[Tracking] 인증 사진 처리 실패:", err);
       Sentry.captureException(new Error("TrackingPhotoUploadFailed"));

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -979,7 +979,9 @@ export default function TrackingScreen() {
     ),
   );
 
-  // 매 초 Live Activity 업데이트
+  // Live Activity 업데이트 — 매초가 아니라 "의미 있는 변화"(일시정지/재개, GPS 갱신)가 있을 때만.
+  // 타이머 자체는 위젯이 timerStartEpoch 기준으로 네이티브(TimelineView)로 직접 틱하므로
+  // elapsedSeconds가 매초 바뀐다고 해서 여기서 업데이트를 매초 보낼 필요가 없다.
   useEffect(() => {
     if (!isTracking) return;
 
@@ -1037,14 +1039,9 @@ export default function TrackingScreen() {
         }).catch(() => {});
       }
     }
-  }, [
-    elapsedSeconds,
-    isPaused,
-    isFreeMode,
-    selectedCourse,
-    liveActivityCourse,
-    userLocation,
-  ]);
+    // elapsedSeconds는 의도적으로 deps에서 제외 — 매초 업데이트 방지 (위젯이 자체적으로 틱함).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isPaused, isFreeMode, selectedCourse, liveActivityCourse, userLocation]);
 
   const pauseTracking = () => {
     setIsPaused(true);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -48,6 +48,7 @@ import {
   smoothCourseCoords,
 } from "@/features/tracking/utils/parse-course-polyline";
 import { fetchSessionTrack } from "@/features/tracking/utils/fetch-session-track";
+import { fetchSessionPhotoCount } from "@/features/tracking/utils/fetch-session-photo-count";
 import { uploadTrackingPhoto } from "@/features/tracking/utils/upload-tracking-photo";
 import { useAppState } from "@/hooks/use-app-state";
 import { toast } from "@/store/toast.store";
@@ -381,6 +382,18 @@ export default function TrackingScreen() {
       startLocationTask().catch((err) =>
         console.warn("[Location] 백그라운드 위치 재시작 실패:", err),
       );
+      // 강제 종료 후 재진입 시 이미 촬영한 사진 수 복원 — 라이브 액티비티 "남은 사진 장수" 정확도 보장
+      {
+        const restoringPhotoSessionId = activeSession.sessionId;
+        fetchSessionPhotoCount(restoringPhotoSessionId).then((count) => {
+          if (
+            !isMountedRef.current ||
+            sessionIdRef.current !== restoringPhotoSessionId
+          )
+            return;
+          setPhotosTaken(Math.min(count, MAX_TRACKING_PHOTOS));
+        });
+      }
       // 강제 종료 후 재진입 시 저장된 이동 경로(회색 polyline) 복원 — 자유기록
       if (activeSession.isFreeRecording) {
         // 요청 시점의 세션 ID를 캡처 — 응답 지연 중 다른 세션으로 바뀌면 폐기

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -979,9 +979,7 @@ export default function TrackingScreen() {
     ),
   );
 
-  // Live Activity 업데이트 — 매초가 아니라 "의미 있는 변화"(일시정지/재개, GPS 갱신)가 있을 때만.
-  // 타이머 자체는 위젯이 timerStartEpoch 기준으로 네이티브(TimelineView)로 직접 틱하므로
-  // elapsedSeconds가 매초 바뀐다고 해서 여기서 업데이트를 매초 보낼 필요가 없다.
+  // 매 초 Live Activity 업데이트
   useEffect(() => {
     if (!isTracking) return;
 
@@ -1039,9 +1037,14 @@ export default function TrackingScreen() {
         }).catch(() => {});
       }
     }
-    // elapsedSeconds는 의도적으로 deps에서 제외 — 매초 업데이트 방지 (위젯이 자체적으로 틱함).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPaused, isFreeMode, selectedCourse, liveActivityCourse, userLocation]);
+  }, [
+    elapsedSeconds,
+    isPaused,
+    isFreeMode,
+    selectedCourse,
+    liveActivityCourse,
+    userLocation,
+  ]);
 
   const pauseTracking = () => {
     setIsPaused(true);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -98,6 +98,7 @@ const SEGMENT_COLORS: Record<string, { color: string }> = {
 
 // 좌표 개수가 MIN_SEGMENT_COORDS 미만인 짧은 세그먼트를 앞 세그먼트에 흡수해 색 전환 빈도를 줄임
 const MIN_SEGMENT_COORDS = 8;
+const MAX_TRACKING_PHOTOS = 4; // 세션당 최대 인증 사진 촬영 횟수 — 라이브 액티비티 "남은 사진 장수" 계산 기준
 
 // GPS 튐(outlier) 좌표 필터링 기준 — 누적 경로가 삐죽하게 그려지는 문제 방지
 const MAX_LOCATION_ACCURACY_M = 30; // 정확도(m)가 이보다 나쁘면서 크게 튄 좌표는 버림
@@ -173,6 +174,8 @@ export default function TrackingScreen() {
   const [photoWindow, setPhotoWindow] = useState<PhotoWindowPayload | null>(
     null,
   );
+  // 이번 세션에서 촬영한 사진 수 (최대 4장) — 라이브 액티비티 "남은 사진 장수" 표시용
+  const [photosTaken, setPhotosTaken] = useState(0);
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
@@ -939,6 +942,7 @@ export default function TrackingScreen() {
           remainingMinutes: totalMinutes,
           remainingMeters: Math.round(totalMeters),
           progress: 0,
+          remainingPhotos: MAX_TRACKING_PHOTOS - photosTaken,
         }).catch((e: unknown) => {
           console.warn("[LiveActivity] start(course) 실패:", e);
         });
@@ -1034,6 +1038,7 @@ export default function TrackingScreen() {
           remainingMinutes,
           remainingMeters,
           progress,
+          remainingPhotos: Math.max(0, MAX_TRACKING_PHOTOS - photosTaken),
         }).catch(() => {});
       }
     }
@@ -1044,6 +1049,7 @@ export default function TrackingScreen() {
     selectedCourse,
     liveActivityCourse,
     userLocation,
+    photosTaken,
   ]);
 
   const pauseTracking = () => {
@@ -1164,6 +1170,7 @@ export default function TrackingScreen() {
         },
       });
       console.log("[Tracking] 사진 메타 저장 완료");
+      setPhotosTaken((prev) => Math.min(prev + 1, MAX_TRACKING_PHOTOS));
     } catch (err) {
       console.warn("[Tracking] 인증 사진 처리 실패:", err);
       Sentry.captureException(new Error("TrackingPhotoUploadFailed"));
@@ -1231,6 +1238,7 @@ export default function TrackingScreen() {
     setSessionId(null);
     setHikingRecordId(null);
     setPhotoWindow(null);
+    setPhotosTaken(0);
     summitPhotoWindowRef.current = null;
     setCollapsed(false);
     setRecordedCoords([]);

--- a/features/tracking/utils/fetch-session-photo-count.ts
+++ b/features/tracking/utils/fetch-session-photo-count.ts
@@ -1,0 +1,20 @@
+import { api } from "@/lib/api";
+import { ENDPOINTS } from "@/types/api.generated";
+
+/**
+ * 세션에 이미 저장된 인증 사진 개수를 서버에서 조회한다.
+ * 앱 재실행/강제 종료 후 재진입 시 라이브 액티비티의 "남은 사진 장수"를
+ * 정확히 복원하기 위해 사용. 실패 시 0 반환(fail-open).
+ */
+export async function fetchSessionPhotoCount(
+  sessionId: number,
+): Promise<number> {
+  try {
+    const res = await api.get<unknown[]>({
+      path: ENDPOINTS.TRACKING_SESSIONS_BY_SESSIONID_PHOTOS(sessionId),
+    });
+    return res.data?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}

--- a/ios-native/SemosanWidget/SemosanLiveActivity.swift
+++ b/ios-native/SemosanWidget/SemosanLiveActivity.swift
@@ -288,6 +288,7 @@ private struct SummitIconBadge: View {
 private struct CourseStatsRow: View {
     let remainingMinutes: Int
     let remainingMeters: Int
+    let remainingPhotos: Int
 
     var body: some View {
         HStack(spacing: 12) {
@@ -306,6 +307,11 @@ private struct CourseStatsRow: View {
             divider
 
             Text("\(remainingMeters)m")
+                .foregroundColor(.white)
+
+            divider
+
+            Text("\(remainingPhotos)장")
                 .foregroundColor(.white)
 
             Spacer()
@@ -388,7 +394,8 @@ private struct CourseLockScreenView: View {
 
             CourseStatsRow(
                 remainingMinutes: state.remainingMinutes,
-                remainingMeters: state.remainingMeters
+                remainingMeters: state.remainingMeters,
+                remainingPhotos: state.remainingPhotos
             )
             .padding(.horizontal, 20)
             .padding(.bottom, 16)
@@ -450,7 +457,8 @@ struct SemosanLiveActivity: Widget {
                             LiveProgressBar(progress: state.progress)
                             CourseStatsRow(
                                 remainingMinutes: state.remainingMinutes,
-                                remainingMeters: state.remainingMeters
+                                remainingMeters: state.remainingMeters,
+                                remainingPhotos: state.remainingPhotos
                             )
                         }
                     }

--- a/ios-native/SemosanWidget/SemosanLiveActivityAttributes.swift
+++ b/ios-native/SemosanWidget/SemosanLiveActivityAttributes.swift
@@ -19,5 +19,41 @@ struct SemosanLiveActivityAttributes: ActivityAttributes {
         var remainingMeters: Int
         var progress: Double      // 0.0 ~ 1.0
         var remainingPhotos: Int  // 남은 사진 촬영 가능 횟수 (최대 4장)
+
+        init(
+            elapsedSeconds: Int,
+            isRunning: Bool,
+            timerStartEpoch: Double?,
+            remainingMinutes: Int,
+            remainingMeters: Int,
+            progress: Double,
+            remainingPhotos: Int
+        ) {
+            self.elapsedSeconds = elapsedSeconds
+            self.isRunning = isRunning
+            self.timerStartEpoch = timerStartEpoch
+            self.remainingMinutes = remainingMinutes
+            self.remainingMeters = remainingMeters
+            self.progress = progress
+            self.remainingPhotos = remainingPhotos
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case elapsedSeconds, isRunning, timerStartEpoch
+            case remainingMinutes, remainingMeters, progress, remainingPhotos
+        }
+
+        // 앱 업데이트 전에 시작된 Live Activity는 remainingPhotos 없이 저장돼 있을 수 있어
+        // decodeIfPresent로 하위 호환 유지 (없으면 4장으로 간주)
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            elapsedSeconds = try c.decode(Int.self, forKey: .elapsedSeconds)
+            isRunning = try c.decode(Bool.self, forKey: .isRunning)
+            timerStartEpoch = try c.decodeIfPresent(Double.self, forKey: .timerStartEpoch)
+            remainingMinutes = try c.decode(Int.self, forKey: .remainingMinutes)
+            remainingMeters = try c.decode(Int.self, forKey: .remainingMeters)
+            progress = try c.decode(Double.self, forKey: .progress)
+            remainingPhotos = try c.decodeIfPresent(Int.self, forKey: .remainingPhotos) ?? 4
+        }
     }
 }

--- a/ios-native/SemosanWidget/SemosanLiveActivityAttributes.swift
+++ b/ios-native/SemosanWidget/SemosanLiveActivityAttributes.swift
@@ -18,5 +18,6 @@ struct SemosanLiveActivityAttributes: ActivityAttributes {
         var remainingMinutes: Int
         var remainingMeters: Int
         var progress: Double      // 0.0 ~ 1.0
+        var remainingPhotos: Int  // 남은 사진 촬영 가능 횟수 (최대 4장)
     }
 }

--- a/ios/SemosanWidget/SemosanLiveActivity.swift
+++ b/ios/SemosanWidget/SemosanLiveActivity.swift
@@ -29,6 +29,17 @@ private struct LiveTimerText: View {
     let state: SemosanLiveActivityAttributes.ContentState
     var fontSize: CGFloat = 36
     var kerning: CGFloat = 0.72
+    // fontFamily가 nil이면 시스템 폰트(semibold) 사용 — compactTrailing처럼 Lexend가 아닌 곳에서 사용
+    var fontFamily: String? = "Lexend-SemiBold"
+    var color: Color = C.timerGreen
+    var minimumScaleFactor: CGFloat = 0.6
+
+    private var font: Font {
+        if let fontFamily {
+            return .custom(fontFamily, size: fontSize)
+        }
+        return .system(size: fontSize, weight: .semibold)
+    }
 
     var body: some View {
         Group {
@@ -37,18 +48,18 @@ private struct LiveTimerText: View {
                 TimelineView(.periodic(from: .now, by: 1.0)) { tl in
                     let elapsed = max(0, Int(tl.date.timeIntervalSince(startDate)))
                     Text(formatExpanded(elapsed))
-                        .font(.custom("Lexend-SemiBold", size: fontSize))
+                        .font(font)
                         .kerning(kerning)
-                        .foregroundColor(C.timerGreen)
-                        .minimumScaleFactor(0.6)
+                        .foregroundColor(color)
+                        .minimumScaleFactor(minimumScaleFactor)
                         .lineLimit(1)
                 }
             } else {
                 Text(formatExpanded(state.elapsedSeconds))
-                    .font(.custom("Lexend-SemiBold", size: fontSize))
+                    .font(font)
                     .kerning(kerning)
-                    .foregroundColor(C.timerGreen)
-                    .minimumScaleFactor(0.6)
+                    .foregroundColor(color)
+                    .minimumScaleFactor(minimumScaleFactor)
                     .lineLimit(1)
             }
         }
@@ -462,12 +473,15 @@ struct SemosanLiveActivity: Widget {
                 CompactPlayPauseBtn(isRunning: state.isRunning)
                     .padding(.leading, 4)
             } compactTrailing: {
-                Text(formatExpanded(state.elapsedSeconds))
-                    .foregroundStyle(C.timerGreenSm)
-                    .font(.system(size: 12, weight: .semibold))
-                    .minimumScaleFactor(0.7)
-                    .lineLimit(1)
-                    .padding(.trailing, 4)
+                LiveTimerText(
+                    state: state,
+                    fontSize: 12,
+                    kerning: 0,
+                    fontFamily: nil,
+                    color: C.timerGreenSm,
+                    minimumScaleFactor: 0.7
+                )
+                .padding(.trailing, 4)
             } minimal: {
                 Image(systemName: "figure.hiking")
                     .foregroundStyle(C.timerGreen)

--- a/ios/SemosanWidget/SemosanLiveActivity.swift
+++ b/ios/SemosanWidget/SemosanLiveActivity.swift
@@ -29,17 +29,6 @@ private struct LiveTimerText: View {
     let state: SemosanLiveActivityAttributes.ContentState
     var fontSize: CGFloat = 36
     var kerning: CGFloat = 0.72
-    // fontFamily가 nil이면 시스템 폰트(semibold) 사용 — compactTrailing처럼 Lexend가 아닌 곳에서 사용
-    var fontFamily: String? = "Lexend-SemiBold"
-    var color: Color = C.timerGreen
-    var minimumScaleFactor: CGFloat = 0.6
-
-    private var font: Font {
-        if let fontFamily {
-            return .custom(fontFamily, size: fontSize)
-        }
-        return .system(size: fontSize, weight: .semibold)
-    }
 
     var body: some View {
         Group {
@@ -48,18 +37,18 @@ private struct LiveTimerText: View {
                 TimelineView(.periodic(from: .now, by: 1.0)) { tl in
                     let elapsed = max(0, Int(tl.date.timeIntervalSince(startDate)))
                     Text(formatExpanded(elapsed))
-                        .font(font)
+                        .font(.custom("Lexend-SemiBold", size: fontSize))
                         .kerning(kerning)
-                        .foregroundColor(color)
-                        .minimumScaleFactor(minimumScaleFactor)
+                        .foregroundColor(C.timerGreen)
+                        .minimumScaleFactor(0.6)
                         .lineLimit(1)
                 }
             } else {
                 Text(formatExpanded(state.elapsedSeconds))
-                    .font(font)
+                    .font(.custom("Lexend-SemiBold", size: fontSize))
                     .kerning(kerning)
-                    .foregroundColor(color)
-                    .minimumScaleFactor(minimumScaleFactor)
+                    .foregroundColor(C.timerGreen)
+                    .minimumScaleFactor(0.6)
                     .lineLimit(1)
             }
         }
@@ -473,15 +462,12 @@ struct SemosanLiveActivity: Widget {
                 CompactPlayPauseBtn(isRunning: state.isRunning)
                     .padding(.leading, 4)
             } compactTrailing: {
-                LiveTimerText(
-                    state: state,
-                    fontSize: 12,
-                    kerning: 0,
-                    fontFamily: nil,
-                    color: C.timerGreenSm,
-                    minimumScaleFactor: 0.7
-                )
-                .padding(.trailing, 4)
+                Text(formatExpanded(state.elapsedSeconds))
+                    .foregroundStyle(C.timerGreenSm)
+                    .font(.system(size: 12, weight: .semibold))
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
+                    .padding(.trailing, 4)
             } minimal: {
                 Image(systemName: "figure.hiking")
                     .foregroundStyle(C.timerGreen)

--- a/ios/SemosanWidget/SemosanLiveActivity.swift
+++ b/ios/SemosanWidget/SemosanLiveActivity.swift
@@ -288,6 +288,7 @@ private struct SummitIconBadge: View {
 private struct CourseStatsRow: View {
     let remainingMinutes: Int
     let remainingMeters: Int
+    let remainingPhotos: Int
 
     var body: some View {
         HStack(spacing: 12) {
@@ -306,6 +307,11 @@ private struct CourseStatsRow: View {
             divider
 
             Text("\(remainingMeters)m")
+                .foregroundColor(.white)
+
+            divider
+
+            Text("\(remainingPhotos)장")
                 .foregroundColor(.white)
 
             Spacer()
@@ -388,7 +394,8 @@ private struct CourseLockScreenView: View {
 
             CourseStatsRow(
                 remainingMinutes: state.remainingMinutes,
-                remainingMeters: state.remainingMeters
+                remainingMeters: state.remainingMeters,
+                remainingPhotos: state.remainingPhotos
             )
             .padding(.horizontal, 20)
             .padding(.bottom, 16)
@@ -450,7 +457,8 @@ struct SemosanLiveActivity: Widget {
                             LiveProgressBar(progress: state.progress)
                             CourseStatsRow(
                                 remainingMinutes: state.remainingMinutes,
-                                remainingMeters: state.remainingMeters
+                                remainingMeters: state.remainingMeters,
+                                remainingPhotos: state.remainingPhotos
                             )
                         }
                     }

--- a/ios/SemosanWidget/SemosanLiveActivityAttributes.swift
+++ b/ios/SemosanWidget/SemosanLiveActivityAttributes.swift
@@ -19,5 +19,41 @@ struct SemosanLiveActivityAttributes: ActivityAttributes {
         var remainingMeters: Int
         var progress: Double      // 0.0 ~ 1.0
         var remainingPhotos: Int  // 남은 사진 촬영 가능 횟수 (최대 4장)
+
+        init(
+            elapsedSeconds: Int,
+            isRunning: Bool,
+            timerStartEpoch: Double?,
+            remainingMinutes: Int,
+            remainingMeters: Int,
+            progress: Double,
+            remainingPhotos: Int
+        ) {
+            self.elapsedSeconds = elapsedSeconds
+            self.isRunning = isRunning
+            self.timerStartEpoch = timerStartEpoch
+            self.remainingMinutes = remainingMinutes
+            self.remainingMeters = remainingMeters
+            self.progress = progress
+            self.remainingPhotos = remainingPhotos
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case elapsedSeconds, isRunning, timerStartEpoch
+            case remainingMinutes, remainingMeters, progress, remainingPhotos
+        }
+
+        // 앱 업데이트 전에 시작된 Live Activity는 remainingPhotos 없이 저장돼 있을 수 있어
+        // decodeIfPresent로 하위 호환 유지 (없으면 4장으로 간주)
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            elapsedSeconds = try c.decode(Int.self, forKey: .elapsedSeconds)
+            isRunning = try c.decode(Bool.self, forKey: .isRunning)
+            timerStartEpoch = try c.decodeIfPresent(Double.self, forKey: .timerStartEpoch)
+            remainingMinutes = try c.decode(Int.self, forKey: .remainingMinutes)
+            remainingMeters = try c.decode(Int.self, forKey: .remainingMeters)
+            progress = try c.decode(Double.self, forKey: .progress)
+            remainingPhotos = try c.decodeIfPresent(Int.self, forKey: .remainingPhotos) ?? 4
+        }
     }
 }

--- a/ios/SemosanWidget/SemosanLiveActivityAttributes.swift
+++ b/ios/SemosanWidget/SemosanLiveActivityAttributes.swift
@@ -18,5 +18,6 @@ struct SemosanLiveActivityAttributes: ActivityAttributes {
         var remainingMinutes: Int
         var remainingMeters: Int
         var progress: Double      // 0.0 ~ 1.0
+        var remainingPhotos: Int  // 남은 사진 촬영 가능 횟수 (최대 4장)
     }
 }

--- a/ios/semosan/LiveActivityModule.swift
+++ b/ios/semosan/LiveActivityModule.swift
@@ -94,7 +94,8 @@ public class LiveActivityModule: Module {
                 timerStartEpoch: params["timerStartEpoch"] as? Double ?? Date().timeIntervalSince1970 * 1000,
                 remainingMinutes: params["remainingMinutes"] as? Int ?? 0,
                 remainingMeters: params["remainingMeters"] as? Int ?? 0,
-                progress: params["progress"] as? Double ?? 0.0
+                progress: params["progress"] as? Double ?? 0.0,
+                remainingPhotos: params["remainingPhotos"] as? Int ?? 4
             )
 
             let activity = try Activity<SemosanLiveActivityAttributes>.request(
@@ -129,7 +130,8 @@ public class LiveActivityModule: Module {
                 timerStartEpoch: params["timerStartEpoch"] as? Double,
                 remainingMinutes: params["remainingMinutes"] as? Int ?? 0,
                 remainingMeters: params["remainingMeters"] as? Int ?? 0,
-                progress: params["progress"] as? Double ?? 0.0
+                progress: params["progress"] as? Double ?? 0.0,
+                remainingPhotos: params["remainingPhotos"] as? Int ?? 4
             )
             await activity.update(.init(state: newState, staleDate: nil))
         }

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -12,35 +12,43 @@ const emitter = LiveActivityNativeModule
 
 export type LiveActivityMode = 'course' | 'free';
 
-export interface StartLiveActivityParams {
-  mode: LiveActivityMode;
-  remainingMinutes?: number;
-  remainingMeters?: number;
-  progress?: number;
-  remainingPhotos?: number;
-  timerStartEpoch?: number;
+// course 모드 전용 필드는 필수로 강제 — 값을 생략하면 네이티브 쪽에서 기본값(0, 4장 등)으로
+// 되돌아가 버려서, 예를 들어 사진을 찍은 뒤 업데이트에서 remainingPhotos를 빠뜨리면
+// 남은 장수가 다시 4로 리셋되는 버그로 이어질 수 있다.
+interface CourseLiveActivityFields {
+  remainingMinutes: number;
+  remainingMeters: number;
+  progress: number;
+  remainingPhotos: number;
 }
 
-export interface UpdateLiveActivityParams {
-  elapsedSeconds: number;
-  isRunning: boolean;
-  mode: LiveActivityMode;
-  remainingMinutes?: number;
-  remainingMeters?: number;
-  progress?: number;
-  remainingPhotos?: number;
-  timerStartEpoch?: number;
-}
+export type StartLiveActivityParams =
+  | ({ mode: 'free'; timerStartEpoch?: number })
+  | ({ mode: 'course'; timerStartEpoch?: number } & CourseLiveActivityFields);
+
+export type UpdateLiveActivityParams =
+  | {
+      mode: 'free';
+      elapsedSeconds: number;
+      isRunning: boolean;
+      timerStartEpoch?: number;
+    }
+  | ({
+      mode: 'course';
+      elapsedSeconds: number;
+      isRunning: boolean;
+      timerStartEpoch?: number;
+    } & CourseLiveActivityFields);
 
 export const LiveActivity = {
   start(params: StartLiveActivityParams): Promise<string | null> {
     if (!LiveActivityNativeModule) return Promise.resolve(null);
     return LiveActivityNativeModule.startActivity({
       mode: params.mode,
-      remainingMinutes: params.remainingMinutes ?? 0,
-      remainingMeters: params.remainingMeters ?? 0,
-      progress: params.progress ?? 0,
-      remainingPhotos: params.remainingPhotos ?? 4,
+      remainingMinutes: params.mode === 'course' ? params.remainingMinutes : 0,
+      remainingMeters: params.mode === 'course' ? params.remainingMeters : 0,
+      progress: params.mode === 'course' ? params.progress : 0,
+      remainingPhotos: params.mode === 'course' ? params.remainingPhotos : 4,
       timerStartEpoch: params.timerStartEpoch,
     });
   },
@@ -51,10 +59,10 @@ export const LiveActivity = {
       elapsedSeconds: params.elapsedSeconds,
       isRunning: params.isRunning,
       mode: params.mode,
-      remainingMinutes: params.remainingMinutes ?? 0,
-      remainingMeters: params.remainingMeters ?? 0,
-      progress: params.progress ?? 0,
-      remainingPhotos: params.remainingPhotos ?? 4,
+      remainingMinutes: params.mode === 'course' ? params.remainingMinutes : 0,
+      remainingMeters: params.mode === 'course' ? params.remainingMeters : 0,
+      progress: params.mode === 'course' ? params.progress : 0,
+      remainingPhotos: params.mode === 'course' ? params.remainingPhotos : 4,
       timerStartEpoch: params.timerStartEpoch,
     });
   },

--- a/modules/live-activity/index.ts
+++ b/modules/live-activity/index.ts
@@ -17,6 +17,7 @@ export interface StartLiveActivityParams {
   remainingMinutes?: number;
   remainingMeters?: number;
   progress?: number;
+  remainingPhotos?: number;
   timerStartEpoch?: number;
 }
 
@@ -27,6 +28,7 @@ export interface UpdateLiveActivityParams {
   remainingMinutes?: number;
   remainingMeters?: number;
   progress?: number;
+  remainingPhotos?: number;
   timerStartEpoch?: number;
 }
 
@@ -38,6 +40,7 @@ export const LiveActivity = {
       remainingMinutes: params.remainingMinutes ?? 0,
       remainingMeters: params.remainingMeters ?? 0,
       progress: params.progress ?? 0,
+      remainingPhotos: params.remainingPhotos ?? 4,
       timerStartEpoch: params.timerStartEpoch,
     });
   },
@@ -51,6 +54,7 @@ export const LiveActivity = {
       remainingMinutes: params.remainingMinutes ?? 0,
       remainingMeters: params.remainingMeters ?? 0,
       progress: params.progress ?? 0,
+      remainingPhotos: params.remainingPhotos ?? 4,
       timerStartEpoch: params.timerStartEpoch,
     });
   },

--- a/plugins/withLiveActivity.js
+++ b/plugins/withLiveActivity.js
@@ -388,7 +388,8 @@ public class LiveActivityModule: Module {
                 timerStartEpoch: params["timerStartEpoch"] as? Double ?? Date().timeIntervalSince1970 * 1000,
                 remainingMinutes: params["remainingMinutes"] as? Int ?? 0,
                 remainingMeters: params["remainingMeters"] as? Int ?? 0,
-                progress: params["progress"] as? Double ?? 0.0
+                progress: params["progress"] as? Double ?? 0.0,
+                remainingPhotos: params["remainingPhotos"] as? Int ?? 4
             )
 
             let activity = try Activity<SemosanLiveActivityAttributes>.request(
@@ -423,7 +424,8 @@ public class LiveActivityModule: Module {
                 timerStartEpoch: params["timerStartEpoch"] as? Double,
                 remainingMinutes: params["remainingMinutes"] as? Int ?? 0,
                 remainingMeters: params["remainingMeters"] as? Int ?? 0,
-                progress: params["progress"] as? Double ?? 0.0
+                progress: params["progress"] as? Double ?? 0.0,
+                remainingPhotos: params["remainingPhotos"] as? Int ?? 4
             )
             await activity.update(.init(state: newState, staleDate: nil))
         }


### PR DESCRIPTION
## Summary
- 코스 따라가기 라이브 액티비티의 "정상까지 | N분 | Nm" 행 뒤에 남은 사진 촬영 가능 장수("N장")를 추가로 표시
- 최대 촬영 장수는 세션당 4장(`MAX_TRACKING_PHOTOS`)이며, 촬영 성공할 때마다 감소. 트래킹 종료 시 리셋
- 백엔드에 세션 진행 중 사진 촬영 수를 조회하는 API가 없어(있는 건 종료 후 목록 조회용 `GET /photos` 뿐), 프론트에서 로컬 카운터로 추적하도록 구현

## 변경 파일
- `ios/SemosanWidget/`, `ios-native/SemosanWidget/` (두 사본 동기화): `ContentState`에 `remainingPhotos` 필드 추가, `CourseStatsRow`에 세그먼트 추가
- `ios/semosan/LiveActivityModule.swift` + `plugins/withLiveActivity.js` 템플릿 (두 사본 동기화): `remainingPhotos` 파라미터 파싱 추가
- `modules/live-activity/index.ts`: JS 브릿지에 `remainingPhotos` 옵션 추가
- `app/(tabs)/tracking.tsx`: `photosTaken` 로컬 상태 추가, 촬영 성공 시 증가/종료 시 리셋, 코스 모드 라이브 액티비티 호출에 반영

## 스크린샷
<img width="306" height="118" alt="image" src="https://github.com/user-attachments/assets/cd281f02-8d58-483c-a5bf-81af5f40a763" />

## Test plan
- [x] 시뮬레이터에서 코스 따라가기 시작 후 라이브 액티비티에 "4장" 표시 확인 (사용자 확인 완료)
- [ ] 인증 사진 촬영 후 "3장"으로 감소하는지 확인
- [ ] 자유 기록 모드(free)에서는 해당 행이 노출되지 않는지 확인