### PR TITLE
fix: 세모피드 프로필 기본 아이콘이 원 안에서 치우쳐 보이던 문제 수정

### DIFF
--- a/features/home/components/feed-cell-detail.tsx
+++ b/features/home/components/feed-cell-detail.tsx
@@ -1,3 +1,4 @@
+import { AvatarIcon } from "@/components/icons/avatar-icon";
 import { ChevronLeftIcon } from "@/components/icons/chevron-left-icon";
 import { XIcon } from "@/components/icons/x-icon";
 import { SemoFeedEmojiRequest, SemoFeedResponse } from "@/types/api.generated";
@@ -118,7 +119,9 @@ export function FeedCellDetail({
                       style={{ flex: 1 }}
                       contentFit="cover"
                     />
-                  ) : null}
+                  ) : (
+                    <AvatarIcon size={32} />
+                  )}
                 </View>
                 <Text className="text-label-normal-inverse typo-body-2-normal-semi-bold">
                   {item.nickname ?? ""}

--- a/features/home/components/feed-cell-detail.tsx
+++ b/features/home/components/feed-cell-detail.tsx
@@ -112,7 +112,7 @@ export function FeedCellDetail({
 
               {/* 프로필 */}
               <View className="mb-5 mt-5 flex-row items-center gap-2 px-1">
-                <View className="h-8 w-8 overflow-hidden rounded-full bg-fill-normal">
+                <View className="h-8 w-8 items-center justify-center overflow-hidden rounded-full bg-fill-normal">
                   {item.profileUrl ? (
                     <Image
                       source={{ uri: item.profileUrl }}


### PR DESCRIPTION
## Summary
- 세모피드 상세 화면에서 프로필 이미지가 없을 때 표시되는 기본 아이콘(AvatarIcon)이 원형 배경 안에서 중앙에 정렬되지 못하고 한쪽으로 치우쳐 보이던 문제 수정
- 감싸는 View에 `items-center justify-center`를 추가 (커뮤니티 화면의 동일 패턴인 `PostAvatar` 컴포넌트와 동일하게 맞춤)

## 스크린샷
<img width="360" height="62" alt="image" src="https://github.com/user-attachments/assets/44b710c9-1dbe-4fa3-94ec-f7c5550b594f" />

## Test plan
- [x] 프사가 없는 세모피드 항목에서 기본 프로필 아이콘이 원 안에서 정확히 중앙 정렬되는지 확인