### PR TITLE
fix: 앱 전체 인풋 박스에서 텍스트가 세로 중앙에서 벗어나 아래로 처지던 문제 수정

### DIFF
--- a/app/mountains/search.tsx
+++ b/app/mountains/search.tsx
@@ -64,6 +64,7 @@ export default function MountainSearchScreen(): React.JSX.Element {
             onSubmitEditing={handleSubmit}
             autoFocus
             returnKeyType="search"
+            style={{ lineHeight: 20 }}
           />
           <SearchIcon />
         </Pressable>

--- a/components/text-field.tsx
+++ b/components/text-field.tsx
@@ -78,6 +78,7 @@ export const TextField = forwardRef<TextInput, TextFieldProps>(
             onBlur={() => setIsFocused(false)}
             onEndEditing={onEndEditing}
             maxLength={maxLength}
+            style={{ lineHeight: 20 }}
           />
           {showClear ? (
             <Pressable onPressIn={handleClear}>

--- a/features/community/components/free-board-search-screen.tsx
+++ b/features/community/components/free-board-search-screen.tsx
@@ -60,6 +60,7 @@ export function FreeBoardSearchScreen(): React.JSX.Element {
             onSubmitEditing={() => setSubmittedKeyword(keyword)}
             returnKeyType="search"
             autoFocus
+            style={{ lineHeight: 20 }}
           />
           {isLoading && submittedKeyword.trim().length > 0 ? (
             <LoadingSpinner size={24} />

--- a/features/mountains/components/region-filter-content.tsx
+++ b/features/mountains/components/region-filter-content.tsx
@@ -103,6 +103,7 @@ export function RegionFilterContent({ initialSelections = [], onApply }: Props) 
             placeholderTextColor="#8b92a6"
             value={searchQuery}
             onChangeText={setSearchQuery}
+            style={{ lineHeight: 20 }}
           />
           <SearchIcon />
         </View>

--- a/features/mypage/components/birth-date-bottom-sheet.tsx
+++ b/features/mypage/components/birth-date-bottom-sheet.tsx
@@ -87,7 +87,7 @@ export function BirthDateBottomSheet({ visible, initialValue, onClose, onSave }:
                 placeholderTextColor="#8b92a6"
                 keyboardType="numbers-and-punctuation"
                 autoFocus
-                style={{ letterSpacing: -0.16 }}
+                style={{ letterSpacing: -0.16, lineHeight: 20 }}
               />
             </View>
 

--- a/features/mypage/components/nickname-bottom-sheet.tsx
+++ b/features/mypage/components/nickname-bottom-sheet.tsx
@@ -86,7 +86,7 @@ export function NicknameBottomSheet({ visible, initialValue, onClose, onSave }: 
               onChangeText={setValue}
               maxLength={10}
               autoFocus
-              style={{ letterSpacing: -0.16 }}
+              style={{ letterSpacing: -0.16, lineHeight: 20 }}
             />
             {value.length > 0 && (
               <TouchableOpacity

--- a/features/tracking/components/course-name-input-modal.tsx
+++ b/features/tracking/components/course-name-input-modal.tsx
@@ -82,6 +82,7 @@ export function CourseNameInputModal({
                 returnKeyType="done"
                 autoFocus
                 onSubmitEditing={() => onSubmit(value.trim())}
+                style={{ lineHeight: 20 }}
               />
             </View>
 


### PR DESCRIPTION
## Summary
- 앱 전반의 boxed TextInput(닉네임, 생년월일, 키/체중, 코스명, 지역 검색, 산 검색 등)에서 텍스트/placeholder가 박스 안에서 세로 중앙에 정렬되지 못하고 아래로 처지던 문제 수정
- 근본 원인: `typo-body-1-reading-regular`/`typo-body-1-normal-regular` 타이포 클래스의 line-height가 unitless 값(1.5~1.6)으로 정의되어 있는데, 고정 높이 박스 안 TextInput에서 이 값이 올바르게 계산되지 않아 텍스트가 처져 보임. 각 TextInput에 명시적 `lineHeight: 20`을 지정해 해결
- 이전에 시도했던 `paddingVertical: 0` 제거만으로는 근본 원인이 해결되지 않았던 것을 실제 기기 확인으로 검증함(#196에서 일부 조치했으나 재발)
- 온보딩 화면(닉네임/생년월일/키/체중)이 공통 `components/text-field.tsx`를 사용하는데, 이 컴포넌트 자체에 원래부터 override가 없어 지난 조사에서 "정상"으로 분류됐지만 실제로는 처음부터 문제가 있었음 — 이번에 해당 컴포넌트를 고쳐서 온보딩 화면 전체가 함께 해결됨

## 변경 파일
- `components/text-field.tsx` — 온보딩 닉네임/생년월일/키/체중 등에서 쓰는 공통 컴포넌트
- `features/mypage/components/nickname-bottom-sheet.tsx`
- `features/mypage/components/birth-date-bottom-sheet.tsx`
- `features/tracking/components/course-name-input-modal.tsx`
- `features/mountains/components/region-filter-content.tsx`
- `features/community/components/free-board-search-screen.tsx`
- `app/mountains/search.tsx`

## Test plan
- [x] 온보딩 닉네임/생년월일/키/체중 입력 시 텍스트가 세로 중앙 정렬되는지 확인 (실기기/시뮬레이터 확인 완료)
- [x] 마이페이지 닉네임/생년월일 바텀시트 확인 완료
- [x] 트래킹 코스명 입력, 지역 필터 검색, 자유게시판 검색, 산 검색 확인 완료