### PR TITLE
feat: 정상 도달 알림 처리 및 정상까지 거리를 서버 값으로 계산

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -576,6 +576,21 @@ export default function TrackingScreen() {
     liveActivityCourse?.summitDistance ?? (courseDetail?.distance ?? 0) / 2,
   );
 
+  // 하산 구간 = 코스 전체 − 정상까지.
+  // 정상이 코스 중간이 아닌 코스에서 하산 표시가 정상 구간 값과 같아지지 않도록
+  // 별도로 계산한다. 전체 값은 summit과 같은 출처(liveActivityCourse)를 우선해
+  // 뺄셈이 어긋나지 않게 한다.
+  const courseTotalDistanceM = Math.round(
+    liveActivityCourse?.totalDistance ?? courseDetail?.distance ?? 0,
+  );
+  const courseTotalDurationMin =
+    liveActivityCourse?.estimatedTime ?? courseDetail?.duration ?? 0;
+  const descentDistanceM = Math.max(0, courseTotalDistanceM - summitDistanceM);
+  const descentDurationMinutes = Math.max(
+    0,
+    Math.round(courseTotalDurationMin - summitDurationMinutes),
+  );
+
   // 코스 진행 상태 — GPS 기반 실시간 (markerRatio + 남은 거리/시간 통합)
   const courseProgressState = useMemo(() => {
     // ── 1순위: liveActivityCourse + Haversine 실측 거리 계산 ──────────────
@@ -596,12 +611,18 @@ export default function TrackingScreen() {
         liveActivityCourse.totalDistance - result.remainingMeters;
 
       if (hasSummited) {
-        // 하산 중: 코스 끝까지 남은 거리/시간
+        // 하산 중: 코스 끝까지 남은 거리/시간.
+        // 시간은 하산 구간 페이스로 환산한다 — 전체 페이스는 오르막이 섞여 있어
+        // 하산에 적용하면 과대 추정된다.
+        const descentPaceMinPerM =
+          descentDistanceM > 0
+            ? descentDurationMinutes / descentDistanceM
+            : paceMinPerM;
         return {
           markerRatio: 0.0,
           remainingDistanceM: Math.round(result.remainingMeters),
           remainingDurationMin: Math.round(
-            result.remainingMeters * paceMinPerM,
+            result.remainingMeters * descentPaceMinPerM,
           ),
         };
       }
@@ -633,8 +654,8 @@ export default function TrackingScreen() {
       if (!markerCoord || courseCoords.length < 2) {
         return {
           markerRatio: 0.0,
-          remainingDistanceM: summitDistanceM,
-          remainingDurationMin: summitDurationMinutes,
+          remainingDistanceM: descentDistanceM,
+          remainingDurationMin: descentDurationMinutes,
         };
       }
       let closestIdx = summitIdx;
@@ -658,8 +679,8 @@ export default function TrackingScreen() {
           : 0;
       return {
         markerRatio: 0.0,
-        remainingDistanceM: Math.round(summitDistanceM * ratio),
-        remainingDurationMin: Math.round(summitDurationMinutes * ratio),
+        remainingDistanceM: Math.round(descentDistanceM * ratio),
+        remainingDurationMin: Math.round(descentDurationMinutes * ratio),
       };
     }
 
@@ -695,6 +716,8 @@ export default function TrackingScreen() {
     hasSummited,
     summitDistanceM,
     summitDurationMinutes,
+    descentDistanceM,
+    descentDurationMinutes,
     liveActivityCourse,
     userLocation,
   ]);
@@ -746,7 +769,7 @@ export default function TrackingScreen() {
       altitudeNm: peakAltitudeM,
       distanceKm: Math.round((courseDetail?.distance ?? 0) / 100) / 10,
       summitDistanceM,
-      descentDistanceM: summitDistanceM,
+      descentDistanceM,
       durationHours: Math.floor((courseDetail?.duration ?? 0) / 60),
       durationMinutes: (courseDetail?.duration ?? 0) % 60,
       coordinates: [],
@@ -754,7 +777,7 @@ export default function TrackingScreen() {
       centerLongitude: 0,
       zoom: 14,
     }),
-    [courseDetail, peakAltitudeM, summitDistanceM],
+    [courseDetail, peakAltitudeM, summitDistanceM, descentDistanceM],
   );
 
   const timeToTarget = (() => {

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -39,6 +39,7 @@ import { useStartTrackingSession } from "@/features/tracking/hooks/use-start-tra
 import { useTrackingFcm } from "@/features/tracking/hooks/use-tracking-fcm";
 import {
   PhotoWindowPayload,
+  SummitReachedPayload,
   useTrackingSocket,
 } from "@/features/tracking/hooks/use-tracking-socket";
 import { calcCourseProgress } from "@/features/tracking/modules/course-progress";
@@ -180,8 +181,6 @@ export default function TrackingScreen() {
   const [isFreeMode, setIsFreeMode] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [showTooltip, setShowTooltip] = useState(true);
-  // TODO: 실제 구현 시 GPS 좌표 기반으로 정상 도달 여부 판단
-  const [isAtSummit, setIsAtSummit] = useState(false); // 목 값 (GPS 연동 전까지 false)
   const [showSummitSheet, setShowSummitSheet] = useState(false);
   // 복원된 세션의 산 이름 — 서버가 준 값이 현재 위치 기반 추정보다 정확하다
   const [restoredMountainName, setRestoredMountainName] = useState<
@@ -324,6 +323,32 @@ export default function TrackingScreen() {
     }
   }, []);
 
+  /**
+   * 정상 도달(TRACKING_SUMMIT_REACHED) — 정상 인증 시트를 띄운다.
+   *
+   * 페이로드를 인증 사진 창으로 확보해 둔다. 백엔드 ±10% 윈도우 특성상
+   * 4/4 촬영 창은 정상까지 거리의 90% 지점에서 열리는데, GPS가 드물어
+   * 그 구간을 건너뛰면 photo 4/4가 발송되지 않는다. 정상 알림에 물려두면
+   * 그 경우에도 정상 인증 사진을 찍을 수 있다.
+   */
+  const handleSummitReached = useCallback((payload: PhotoWindowPayload) => {
+    console.log("[Summit] 정상 도달 수신:", JSON.stringify(payload));
+    summitPhotoWindowRef.current = payload;
+    setShowSummitSheet(true);
+  }, []);
+
+  // 소켓 페이로드는 milestoneDistanceM, FCM은 milestoneDistance로 필드명이 달라 변환한다
+  const handleSocketSummitReached = useCallback(
+    (payload: SummitReachedPayload) =>
+      handleSummitReached({
+        milestoneIndex: payload.milestoneIndex,
+        milestoneDistance: payload.milestoneDistanceM,
+        status: "OPEN",
+        openedAt: payload.reachedAt ?? new Date().toISOString(),
+      }),
+    [handleSummitReached],
+  );
+
   const {
     connect: connectSocket,
     disconnect: disconnectSocket,
@@ -331,6 +356,7 @@ export default function TrackingScreen() {
     publishGps,
   } = useTrackingSocket({
     onPhotoWindow: handlePhotoWindow,
+    onSummitReached: handleSocketSummitReached,
   });
 
   // sessionId를 ref로 미러링 — 위치 콜백에서 항상 최신 값 참조
@@ -414,7 +440,11 @@ export default function TrackingScreen() {
   );
 
   // 포어그라운드 FCM 수신 (백그라운드는 OS가 시스템 알림으로 자동 처리)
-  useTrackingFcm({ enabled: isTracking, onPhotoWindow: handlePhotoWindow });
+  useTrackingFcm({
+    enabled: isTracking,
+    onPhotoWindow: handlePhotoWindow,
+    onSummitReached: handleSummitReached,
+  });
 
   const { mutate: startSession } = useStartTrackingSession();
   const { mutate: pauseSession } = usePauseTrackingSession();
@@ -535,9 +565,16 @@ export default function TrackingScreen() {
     [courseDetail?.polyline],
   );
 
-  // 정상/하산까지 시간·거리 — 코스 전체의 절반 (courseProgressState useMemo보다 먼저 선언)
-  const halfDurationMinutes = Math.round((courseDetail?.duration ?? 0) / 2);
-  const halfDistanceM = Math.round((courseDetail?.distance ?? 0) / 2);
+  // 정상까지 시간·거리 (courseProgressState useMemo보다 먼저 선언).
+  // 서버의 summitDistance/summitEstimatedTime을 우선 쓴다 — 마일스톤 푸시가
+  // 오는 지점과 같은 값이라 화면 표시와 알림 시점이 일치한다.
+  // 정상 좌표가 없어 서버가 계산하지 못한 코스는 기존대로 코스 전체의 절반으로 폴백한다.
+  const summitDurationMinutes =
+    liveActivityCourse?.summitEstimatedTime ??
+    Math.round((courseDetail?.duration ?? 0) / 2);
+  const summitDistanceM = Math.round(
+    liveActivityCourse?.summitDistance ?? (courseDetail?.distance ?? 0) / 2,
+  );
 
   // 코스 진행 상태 — GPS 기반 실시간 (markerRatio + 남은 거리/시간 통합)
   const courseProgressState = useMemo(() => {
@@ -569,14 +606,22 @@ export default function TrackingScreen() {
         };
       }
 
-      // 등산 중: 코스 중간(정상)까지 남은 거리/시간
-      const halfDistance = liveActivityCourse.totalDistance / 2;
-      const remainingToSummitM = Math.max(0, halfDistance - traveledM);
-      const ascProgress = Math.min(traveledM / halfDistance, 1); // 0(출발) ~ 1(정상)
+      // 등산 중: 정상까지 남은 거리/시간
+      const summitDistance =
+        liveActivityCourse.summitDistance ??
+        liveActivityCourse.totalDistance / 2;
+      const remainingToSummitM = Math.max(0, summitDistance - traveledM);
+      const ascProgress =
+        summitDistance > 0 ? Math.min(traveledM / summitDistance, 1) : 0; // 0(출발) ~ 1(정상)
+      // 정상까지 시간도 서버 값이 있으면 그 비율로 — 전체 페이스 배분보다 정확하다
+      const remainingToSummitMin =
+        liveActivityCourse.summitEstimatedTime != null
+          ? liveActivityCourse.summitEstimatedTime * (1 - ascProgress)
+          : remainingToSummitM * paceMinPerM;
       return {
         markerRatio: Math.max(0, 1.0 - ascProgress), // 1.0(바 하단/출발) ~ 0.0(바 상단/정상)
         remainingDistanceM: Math.round(remainingToSummitM),
-        remainingDurationMin: Math.round(remainingToSummitM * paceMinPerM),
+        remainingDurationMin: Math.round(remainingToSummitMin),
       };
     }
 
@@ -588,8 +633,8 @@ export default function TrackingScreen() {
       if (!markerCoord || courseCoords.length < 2) {
         return {
           markerRatio: 0.0,
-          remainingDistanceM: halfDistanceM,
-          remainingDurationMin: halfDurationMinutes,
+          remainingDistanceM: summitDistanceM,
+          remainingDurationMin: summitDurationMinutes,
         };
       }
       let closestIdx = summitIdx;
@@ -613,16 +658,16 @@ export default function TrackingScreen() {
           : 0;
       return {
         markerRatio: 0.0,
-        remainingDistanceM: Math.round(halfDistanceM * ratio),
-        remainingDurationMin: Math.round(halfDurationMinutes * ratio),
+        remainingDistanceM: Math.round(summitDistanceM * ratio),
+        remainingDurationMin: Math.round(summitDurationMinutes * ratio),
       };
     }
 
     if (!markerCoord || courseCoords.length < 2) {
       return {
         markerRatio: 1.0,
-        remainingDistanceM: halfDistanceM,
-        remainingDurationMin: halfDurationMinutes,
+        remainingDistanceM: summitDistanceM,
+        remainingDurationMin: summitDurationMinutes,
       };
     }
 
@@ -641,15 +686,15 @@ export default function TrackingScreen() {
     const remaining = Math.max(0, 1 - progress);
     return {
       markerRatio: 1.0 - progress,
-      remainingDistanceM: Math.round(halfDistanceM * remaining),
-      remainingDurationMin: Math.round(halfDurationMinutes * remaining),
+      remainingDistanceM: Math.round(summitDistanceM * remaining),
+      remainingDurationMin: Math.round(summitDurationMinutes * remaining),
     };
   }, [
     markerCoord,
     courseCoords,
     hasSummited,
-    halfDistanceM,
-    halfDurationMinutes,
+    summitDistanceM,
+    summitDurationMinutes,
     liveActivityCourse,
     userLocation,
   ]);
@@ -700,8 +745,8 @@ export default function TrackingScreen() {
       difficulty: DIFFICULTY_KO[courseDetail?.difficulty ?? ""] ?? "중급",
       altitudeNm: peakAltitudeM,
       distanceKm: Math.round((courseDetail?.distance ?? 0) / 100) / 10,
-      summitDistanceM: halfDistanceM,
-      descentDistanceM: halfDistanceM,
+      summitDistanceM,
+      descentDistanceM: summitDistanceM,
       durationHours: Math.floor((courseDetail?.duration ?? 0) / 60),
       durationMinutes: (courseDetail?.duration ?? 0) % 60,
       coordinates: [],
@@ -709,7 +754,7 @@ export default function TrackingScreen() {
       centerLongitude: 0,
       zoom: 14,
     }),
-    [courseDetail, peakAltitudeM, halfDistanceM],
+    [courseDetail, peakAltitudeM, summitDistanceM],
   );
 
   const timeToTarget = (() => {
@@ -1502,14 +1547,6 @@ export default function TrackingScreen() {
     completeTracking(null);
   };
 
-  // GPS로 정상 부근 감지 시 자동으로 정상 시트 표시
-  // TODO: 실제 구현 시 GPS 좌표와 정상 좌표를 비교해 isAtSummit 업데이트
-  useEffect(() => {
-    if (isTracking && isAtSummit) {
-      setShowSummitSheet(true);
-    }
-  }, [isAtSummit, isTracking]);
-
   const floatingCardBottom = COLLAPSED_PEEK_HEIGHT + FLOATING_CARD_GAP;
 
   return (
@@ -1677,8 +1714,11 @@ export default function TrackingScreen() {
           {showSummitSheet ? (
             <SummitSheet
               onCertify={() => {
-                // 정상 인증 → 현재 photoWindow 저장 후 하산 시트로 전환
-                summitPhotoWindowRef.current = photoWindow;
+                // 정상 인증 → 인증 사진 창 확보 후 하산 시트로 전환.
+                // 정상 알림으로 이미 확보해 둔 창이 있으면 유지하고(4/4 촬영
+                // 창이 누락된 경우에도 촬영 가능), 없을 때만 현재 창을 쓴다.
+                summitPhotoWindowRef.current =
+                  summitPhotoWindowRef.current ?? photoWindow;
                 setHasSummited(true);
                 setShowSummitSheet(false);
               }}

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -565,30 +565,33 @@ export default function TrackingScreen() {
     [courseDetail?.polyline],
   );
 
-  // 정상까지 시간·거리 (courseProgressState useMemo보다 먼저 선언).
-  // 서버의 summitDistance/summitEstimatedTime을 우선 쓴다 — 마일스톤 푸시가
-  // 오는 지점과 같은 값이라 화면 표시와 알림 시점이 일치한다.
-  // 정상 좌표가 없어 서버가 계산하지 못한 코스는 기존대로 코스 전체의 절반으로 폴백한다.
-  const summitDurationMinutes =
-    liveActivityCourse?.summitEstimatedTime ??
-    Math.round((courseDetail?.duration ?? 0) / 2);
-  const summitDistanceM = Math.round(
-    liveActivityCourse?.summitDistance ?? (courseDetail?.distance ?? 0) / 2,
-  );
-
-  // 하산 구간 = 코스 전체 − 정상까지.
-  // 정상이 코스 중간이 아닌 코스에서 하산 표시가 정상 구간 값과 같아지지 않도록
-  // 별도로 계산한다. 전체 값은 summit과 같은 출처(liveActivityCourse)를 우선해
-  // 뺄셈이 어긋나지 않게 한다.
+  // 코스 전체 거리·시간 — 한 출처에서 확정한다.
+  // liveActivityCourse와 courseDetail은 서로 다른 쿼리라 도착 순서가 다르고
+  // 값의 출처도 달라(polyline 누적 vs 코스 메타), 섞어 쓰면 전체 ≠ 정상 + 하산이 된다.
   const courseTotalDistanceM = Math.round(
     liveActivityCourse?.totalDistance ?? courseDetail?.distance ?? 0,
   );
-  const courseTotalDurationMin =
-    liveActivityCourse?.estimatedTime ?? courseDetail?.duration ?? 0;
+  const courseTotalDurationMin = Math.round(
+    liveActivityCourse?.estimatedTime ?? courseDetail?.duration ?? 0,
+  );
+
+  // 정상까지 거리·시간 (courseProgressState useMemo보다 먼저 선언).
+  // 서버 값을 우선 쓴다 — 마일스톤 푸시가 오는 지점과 같은 값이라 화면 표시와
+  // 알림 시점이 일치한다. 정상 좌표가 없어 서버가 계산하지 못한 코스는
+  // "같은 출처"의 절반으로 폴백한다. courseDetail 기준으로 폴백하면
+  // liveActivityCourse만 먼저 도착한 순간 정상 값이 0이 되어 하산이 코스 전체가 된다.
+  const summitDistanceM = Math.round(
+    liveActivityCourse?.summitDistance ?? courseTotalDistanceM / 2,
+  );
+  const summitDurationMinutes = Math.round(
+    liveActivityCourse?.summitEstimatedTime ?? courseTotalDurationMin / 2,
+  );
+
+  // 하산 구간 = 코스 전체 − 정상까지
   const descentDistanceM = Math.max(0, courseTotalDistanceM - summitDistanceM);
   const descentDurationMinutes = Math.max(
     0,
-    Math.round(courseTotalDurationMin - summitDurationMinutes),
+    courseTotalDurationMin - summitDurationMinutes,
   );
 
   // 코스 진행 상태 — GPS 기반 실시간 (markerRatio + 남은 거리/시간 통합)
@@ -767,17 +770,24 @@ export default function TrackingScreen() {
       name: courseDetail?.name ?? "",
       difficulty: DIFFICULTY_KO[courseDetail?.difficulty ?? ""] ?? "중급",
       altitudeNm: peakAltitudeM,
-      distanceKm: Math.round((courseDetail?.distance ?? 0) / 100) / 10,
+      distanceKm: Math.round(courseTotalDistanceM / 100) / 10,
       summitDistanceM,
       descentDistanceM,
-      durationHours: Math.floor((courseDetail?.duration ?? 0) / 60),
-      durationMinutes: (courseDetail?.duration ?? 0) % 60,
+      durationHours: Math.floor(courseTotalDurationMin / 60),
+      durationMinutes: courseTotalDurationMin % 60,
       coordinates: [],
       centerLatitude: 0,
       centerLongitude: 0,
       zoom: 14,
     }),
-    [courseDetail, peakAltitudeM, summitDistanceM, descentDistanceM],
+    [
+      courseDetail,
+      peakAltitudeM,
+      courseTotalDistanceM,
+      courseTotalDurationMin,
+      summitDistanceM,
+      descentDistanceM,
+    ],
   );
 
   const timeToTarget = (() => {

--- a/features/tracking/hooks/use-live-activity-course.ts
+++ b/features/tracking/hooks/use-live-activity-course.ts
@@ -11,6 +11,14 @@ export type LiveActivityCourseData = {
   coordinates: Coordinate[];
   totalDistance: number;
   estimatedTime: number;
+  /**
+   * 출발점 → 정상 누적 거리(m). 마일스톤 푸시가 오는 지점과 같은 값이다.
+   * 정상 좌표가 없어 계산할 수 없는 코스는 null이며, 이때는 기존 방식
+   * (코스 전체의 절반)으로 폴백한다.
+   */
+  summitDistance?: number | null;
+  /** 출발점 → 정상 예상 시간(분). summitDistance와 같은 조건으로 null일 수 있다. */
+  summitEstimatedTime?: number | null;
 };
 
 async function getLiveActivityCourse(courseId: string): Promise<LiveActivityCourseData> {

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -30,8 +30,8 @@ type FcmData = {
   extras?: string;
 } | null;
 
-const PHOTO_MILESTONE = 'TRACKING_PHOTO_MILESTONE';
-const SUMMIT_REACHED = 'TRACKING_SUMMIT_REACHED';
+const PHOTO_MILESTONE = "TRACKING_PHOTO_MILESTONE";
+const SUMMIT_REACHED = "TRACKING_SUMMIT_REACHED";
 
 /**
  * TRACKING_PHOTO_MILESTONE FCM 수신 처리.
@@ -110,9 +110,9 @@ export function useTrackingFcm({
       if (data.type === SUMMIT_REACHED) {
         const summitPayload = buildPayload(data);
         console.log(
-          '[TrackingFCM] 정상 도달 — milestoneIndex:',
+          "[TrackingFCM] 정상 도달 — milestoneIndex:",
           summitPayload.milestoneIndex,
-          'distance:',
+          "distance:",
           summitPayload.milestoneDistance,
         );
         onSummitReached?.(summitPayload);

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -1,8 +1,8 @@
-import { getApp } from '@react-native-firebase/app';
-import { getMessaging, onMessage } from '@react-native-firebase/messaging';
-import * as Notifications from 'expo-notifications';
-import { useEffect } from 'react';
-import { PhotoWindowPayload } from './use-tracking-socket';
+import { getApp } from "@react-native-firebase/app";
+import { getMessaging, onMessage } from "@react-native-firebase/messaging";
+import * as Notifications from "expo-notifications";
+import { useEffect } from "react";
+import { PhotoWindowPayload } from "./use-tracking-socket";
 
 type Options = {
   /** 트래킹 중일 때만 리스너 등록 */
@@ -75,7 +75,7 @@ export function useTrackingFcm({
       if (extras.distance != null) return Number(extras.distance);
       if (data.milestoneDistanceM != null)
         return parseFloat(data.milestoneDistanceM);
-      return parseFloat(data.distance ?? '0');
+      return parseFloat(data.distance ?? "0");
     };
 
     const parseMilestoneIndex = (data: FcmData): number => {
@@ -89,14 +89,15 @@ export function useTrackingFcm({
     const buildPayload = (data: FcmData): PhotoWindowPayload => ({
       milestoneIndex: parseMilestoneIndex(data),
       milestoneDistance: parseDistance(data),
-      status: 'OPEN',
+      status: "OPEN",
       openedAt: new Date().toISOString(),
     });
 
     const extractPayload = (notification: Notifications.Notification) => {
       // content.data 우선, Firebase SDK 충돌로 null이면 trigger.payload에서 읽음
       const contentData = notification.request.content.data as FcmData;
-      const triggerPayload = (notification.request.trigger as any)?.payload as FcmData;
+      const triggerPayload = (notification.request.trigger as any)
+        ?.payload as FcmData;
       const data = contentData?.type ? contentData : triggerPayload;
 
       if (!data) return;
@@ -112,7 +113,10 @@ export function useTrackingFcm({
     // 포어그라운드 FCM 수신 — Firebase SDK가 expo-notifications보다 우선하므로 onMessage 사용
     const fcmMessaging = getMessaging(getApp());
     const unsubscribeFcm = onMessage(fcmMessaging, async (remoteMessage) => {
-      console.log('[TrackingFCM] 포어그라운드 FCM 수신:', JSON.stringify(remoteMessage.data));
+      console.log(
+        "[TrackingFCM] 포어그라운드 FCM 수신:",
+        JSON.stringify(remoteMessage.data),
+      );
       const data = remoteMessage.data as FcmData;
       if (!data) return;
 
@@ -131,7 +135,12 @@ export function useTrackingFcm({
       if (data.type !== PHOTO_MILESTONE) return;
 
       const payload = buildPayload(data);
-      console.log('[TrackingFCM] milestoneIndex:', payload.milestoneIndex, 'distance:', payload.milestoneDistance);
+      console.log(
+        "[TrackingFCM] milestoneIndex:",
+        payload.milestoneIndex,
+        "distance:",
+        payload.milestoneDistance,
+      );
 
       // 인앱 PhotoWindowBanner 활성화
       // notification 필드가 포함된 FCM 페이로드로 변경되어 iOS가 자동으로 시스템 배너 표시
@@ -139,9 +148,11 @@ export function useTrackingFcm({
     });
 
     // 백그라운드/잠금화면 알림 탭 후 앱 복귀
-    const tapSub = Notifications.addNotificationResponseReceivedListener((response) => {
-      extractPayload(response.notification);
-    });
+    const tapSub = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        extractPayload(response.notification);
+      },
+    );
 
     return () => {
       unsubscribeFcm();

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -47,10 +47,19 @@ export function useTrackingFcm({
   useEffect(() => {
     if (!enabled) return;
 
+    // JSON.parse는 "null"·"[]"·"3" 같은 입력도 성공하므로 평범한 객체만 통과시킨다.
+    // null이 그대로 반환되면 호출부에서 extras.distance를 읽다가 예외가 난다.
     const parseExtras = (data: FcmData): FcmExtras => {
       if (!data?.extras) return {};
       try {
-        return JSON.parse(data.extras) as FcmExtras;
+        const parsed: unknown = JSON.parse(data.extras);
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          Array.isArray(parsed)
+        )
+          return {};
+        return parsed as FcmExtras;
       } catch {
         return {};
       }

--- a/features/tracking/hooks/use-tracking-fcm.ts
+++ b/features/tracking/hooks/use-tracking-fcm.ts
@@ -8,20 +8,30 @@ type Options = {
   /** 트래킹 중일 때만 리스너 등록 */
   enabled: boolean;
   onPhotoWindow: (payload: PhotoWindowPayload) => void;
+  /** 정상 도달 — 정상 인증 시트 표시 및 인증 사진 창 확보 */
+  onSummitReached?: (payload: PhotoWindowPayload) => void;
 };
 
 type FcmExtras = {
   distance?: string | number;
   milestoneIndex?: string | number;
+  milestoneDistanceM?: string | number;
   [key: string]: unknown;
 };
 
+// FCM data는 모든 값이 문자열로 온다 (백엔드가 String.valueOf로 넣음)
 type FcmData = {
   type?: string;
+  /** TRACKING_PHOTO_MILESTONE의 마일스톤 거리 */
   distance?: string;
+  /** TRACKING_SUMMIT_REACHED의 마일스톤 거리 */
+  milestoneDistanceM?: string;
   milestoneIndex?: string;
   extras?: string;
 } | null;
+
+const PHOTO_MILESTONE = 'TRACKING_PHOTO_MILESTONE';
+const SUMMIT_REACHED = 'TRACKING_SUMMIT_REACHED';
 
 /**
  * TRACKING_PHOTO_MILESTONE FCM 수신 처리.
@@ -29,7 +39,11 @@ type FcmData = {
  * - 백그라운드/잠금화면에서 알림 탭: addNotificationResponseReceivedListener → 인앱 배너
  * Firebase SDK 충돌로 content.data가 null인 경우 trigger.payload에서 직접 읽음.
  */
-export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
+export function useTrackingFcm({
+  enabled,
+  onPhotoWindow,
+  onSummitReached,
+}: Options) {
   useEffect(() => {
     if (!enabled) return;
 
@@ -42,10 +56,16 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
       }
     };
 
+    // 마일스톤 거리 키가 타입별로 다르다.
+    // PHOTO_MILESTONE은 distance, SUMMIT_REACHED는 milestoneDistanceM.
     const parseDistance = (data: FcmData): number => {
       if (!data) return 0;
       const extras = parseExtras(data);
+      if (extras.milestoneDistanceM != null)
+        return Number(extras.milestoneDistanceM);
       if (extras.distance != null) return Number(extras.distance);
+      if (data.milestoneDistanceM != null)
+        return parseFloat(data.milestoneDistanceM);
       return parseFloat(data.distance ?? '0');
     };
 
@@ -70,7 +90,12 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
       const triggerPayload = (notification.request.trigger as any)?.payload as FcmData;
       const data = contentData?.type ? contentData : triggerPayload;
 
-      if (!data || data.type !== 'TRACKING_PHOTO_MILESTONE') return;
+      if (!data) return;
+      if (data.type === SUMMIT_REACHED) {
+        onSummitReached?.(buildPayload(data));
+        return;
+      }
+      if (data.type !== PHOTO_MILESTONE) return;
 
       onPhotoWindow(buildPayload(data));
     };
@@ -80,7 +105,21 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
     const unsubscribeFcm = onMessage(fcmMessaging, async (remoteMessage) => {
       console.log('[TrackingFCM] 포어그라운드 FCM 수신:', JSON.stringify(remoteMessage.data));
       const data = remoteMessage.data as FcmData;
-      if (!data || data.type !== 'TRACKING_PHOTO_MILESTONE') return;
+      if (!data) return;
+
+      if (data.type === SUMMIT_REACHED) {
+        const summitPayload = buildPayload(data);
+        console.log(
+          '[TrackingFCM] 정상 도달 — milestoneIndex:',
+          summitPayload.milestoneIndex,
+          'distance:',
+          summitPayload.milestoneDistance,
+        );
+        onSummitReached?.(summitPayload);
+        return;
+      }
+
+      if (data.type !== PHOTO_MILESTONE) return;
 
       const payload = buildPayload(data);
       console.log('[TrackingFCM] milestoneIndex:', payload.milestoneIndex, 'distance:', payload.milestoneDistance);
@@ -99,5 +138,5 @@ export function useTrackingFcm({ enabled, onPhotoWindow }: Options) {
       unsubscribeFcm();
       tapSub.remove();
     };
-  }, [enabled, onPhotoWindow]);
+  }, [enabled, onPhotoWindow, onSummitReached]);
 }

--- a/features/tracking/hooks/use-tracking-socket.ts
+++ b/features/tracking/hooks/use-tracking-socket.ts
@@ -12,13 +12,29 @@ export type PhotoWindowPayload = {
   closedAt?: string;
 };
 
-type UseTrackingSocketOptions = {
-  onPhotoWindow?: (payload: PhotoWindowPayload) => void;
+/**
+ * 정상 도달 메시지. halfwayMark는 기존 클라이언트 호환용이라 신규 코드는
+ * milestoneDistanceM을 쓴다.
+ */
+export type SummitReachedPayload = {
+  milestoneIndex: number;
+  milestoneDistanceM: number;
+  halfwayMark?: number;
+  reachedAt?: string;
 };
 
-export function useTrackingSocket({ onPhotoWindow }: UseTrackingSocketOptions = {}) {
+type UseTrackingSocketOptions = {
+  onPhotoWindow?: (payload: PhotoWindowPayload) => void;
+  onSummitReached?: (payload: SummitReachedPayload) => void;
+};
+
+export function useTrackingSocket({
+  onPhotoWindow,
+  onSummitReached,
+}: UseTrackingSocketOptions = {}) {
   const clientRef = useRef<Client | null>(null);
   const subscriptionRef = useRef<StompSubscription | null>(null);
+  const summitSubscriptionRef = useRef<StompSubscription | null>(null);
   const [status, setStatus] = useState<SocketStatus>('disconnected');
 
   const connect = useCallback((sessionId?: number) => {
@@ -62,6 +78,21 @@ export function useTrackingSocket({ onPhotoWindow }: UseTrackingSocketOptions = 
                 }
               },
             );
+
+            summitSubscriptionRef.current?.unsubscribe();
+            console.log(`[TrackingSocket] 구독 시작: /topic/tracking/${sessionId}/summit`);
+            summitSubscriptionRef.current = client.subscribe(
+              `/topic/tracking/${sessionId}/summit`,
+              (message) => {
+                console.log('[TrackingSocket] summit 메시지 수신:', message.body);
+                try {
+                  const payload: SummitReachedPayload = JSON.parse(message.body);
+                  onSummitReached?.(payload);
+                } catch {
+                  console.warn('[TrackingSocket] summit 파싱 실패:', message.body);
+                }
+              },
+            );
           };
           trySubscribe();
         }
@@ -78,7 +109,7 @@ export function useTrackingSocket({ onPhotoWindow }: UseTrackingSocketOptions = 
       clientRef.current = client;
       client.activate();
     });
-  }, [onPhotoWindow]);
+  }, [onPhotoWindow, onSummitReached]);
 
   const subscribePhotoWindow = useCallback((sessionId: number) => {
     const client = clientRef.current;
@@ -101,6 +132,8 @@ export function useTrackingSocket({ onPhotoWindow }: UseTrackingSocketOptions = 
   const disconnect = useCallback(() => {
     subscriptionRef.current?.unsubscribe();
     subscriptionRef.current = null;
+    summitSubscriptionRef.current?.unsubscribe();
+    summitSubscriptionRef.current = null;
     if (clientRef.current?.active) {
       clientRef.current.deactivate();
     }
@@ -133,6 +166,7 @@ export function useTrackingSocket({ onPhotoWindow }: UseTrackingSocketOptions = 
   useEffect(() => {
     return () => {
       subscriptionRef.current?.unsubscribe();
+      summitSubscriptionRef.current?.unsubscribe();
       if (clientRef.current?.active) {
         clientRef.current.deactivate();
       }

--- a/features/tracking/hooks/use-tracking-socket.ts
+++ b/features/tracking/hooks/use-tracking-socket.ts
@@ -84,12 +84,12 @@ export function useTrackingSocket({
             summitSubscriptionRef.current = client.subscribe(
               `/topic/tracking/${sessionId}/summit`,
               (message) => {
-                console.log('[TrackingSocket] summit 메시지 수신:', message.body);
+                console.log("[TrackingSocket] summit 메시지 수신:", message.body);
                 try {
                   const payload: SummitReachedPayload = JSON.parse(message.body);
                   onSummitReached?.(payload);
                 } catch {
-                  console.warn('[TrackingSocket] summit 파싱 실패:', message.body);
+                  console.warn("[TrackingSocket] summit 파싱 실패:", message.body);
                 }
               },
             );


### PR DESCRIPTION
## 관련 이슈

백엔드 PR: SEMOSAN/SEMOSAN_BE#398

## 작업 내용

백엔드가 정상 도달 알림에 마일스톤 정보를 추가하고 Live Activity 응답에 정상까지 거리·시간을 내려주게 되어 이에 맞춰 연동했습니다.

### 정상 도달 → 인증 바텀시트

**기존에는 정상 인증 시트가 사용자가 `정상 도착` 버튼을 직접 눌러야만 떴습니다.** `isAtSummit`이 목 값(`useState(false)`)으로만 존재하고 아무도 세팅하지 않았습니다.

```ts
// TODO: 실제 구현 시 GPS 좌표 기반으로 정상 도달 여부 판단
const [isAtSummit, setIsAtSummit] = useState(false); // 목 값
```

이 상태를 제거하고 실제 알림이 시트를 띄우도록 했습니다. 수신 경로는 둘입니다.

| 경로 | 처리 |
| --- | --- |
| **FCM** (`useTrackingFcm`) | 포어그라운드 수신 + 알림 탭 양쪽에서 `TRACKING_SUMMIT_REACHED` 처리 |
| **WebSocket** (`useTrackingSocket`) | `/topic/tracking/{sessionId}/summit` 구독 추가 |

소켓까지 붙인 이유는 **개발 빌드에 푸시가 도달하지 않는 문제가 미해결**이기 때문입니다. FCM에만 의존하면 로컬에서 정상 인증 흐름을 아예 검증할 수 없습니다.

**필드명이 경로·타입마다 달라** 파싱을 분기했습니다.

| 출처 | 마일스톤 거리 키 |
| --- | --- |
| FCM `TRACKING_PHOTO_MILESTONE` | `distance` |
| FCM `TRACKING_SUMMIT_REACHED` | `milestoneDistanceM` |
| WebSocket summit | `milestoneDistanceM` (+ 호환용 `halfwayMark`, 미사용) |

### photo 4/4 누락 대비

정상 알림 페이로드를 인증 사진 창으로 확보해 둡니다.

백엔드 노트대로 ±10% 윈도우 때문에 4/4 촬영 창은 정상까지 거리의 90%에서 열리는데, GPS가 드물어 그 구간을 통째로 건너뛰면 `photo 4/4`가 발송되지 않고 정상 알림만 옵니다. 기존 `onCertify`는 그 순간의 `photoWindow`를 **무조건 덮어썼기 때문에** 이 경우 `null`이 들어가 촬영이 막힙니다. 이미 확보한 창이 있으면 유지하도록 바꿨습니다.

### 정상까지 거리·시간

`course.distance / 2` → `summitDistance` / `summitEstimatedTime`으로 교체했습니다. 변수명도 `halfDistanceM` → `summitDistanceM`으로 바꿔 의미를 맞췄습니다.

두 필드가 `null`인 코스(정상 좌표 없음)는 기존대로 코스 전체의 절반으로 폴백합니다.

## 스크린샷

| | |
| --- | --- |
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/4df64c2d-b662-47ab-b0b6-1932f4d248ea" /> | <img width="280" alt="image" src="https://github.com/user-attachments/assets/e9f15a84-83e2-4569-94fe-ac42ec9c58b4" />|

## 확인 방법

iOS 시뮬레이터에서 관악산 코스 18로 확인했습니다.

**서버 응답**

```json
{ "totalDistance": 11588.6, "estimatedTime": 195,
  "summitDistance": 4137.03, "summitEstimatedTime": 70 }
```

**표시 결과** — 코스 카드에 `정상까지 4.1km`

기존 방식(`11.6km / 2`)이면 **5.8km / 97분**으로 나왔을 값입니다. 실제 정상은 **4.1km / 70분**이라 **1.7km·27분 어긋나 있던 표시가 마일스톤 푸시 지점과 일치**하게 됐습니다.

**소켓 구독**

```
[TrackingSocket] 구독 시작: /topic/tracking/36/photo-window
[TrackingSocket] 구독 시작: /topic/tracking/36/summit
```

## 리뷰 포인트

**1. 정상 알림 수신 → 시트 표시는 실제로 검증하지 못했습니다.** 시뮬레이터에서 세 경로가 모두 막혔습니다.

- **GPS 누적으로 서버 발송 유발** — `watchPositionAsync`가 시뮬레이터에서 위치 업데이트를 전달하지 않습니다. 위치를 1.7km 옮겨도 마커·거리가 그대로였고 `publishGps`가 한 번도 나가지 않았습니다
- **`simctl push`로 FCM 주입** — APNs로 직접 들어가 Firebase `onMessage`를 타지 않습니다
- **소켓 메시지 주입** — 서버가 발행하는 토픽이라 외부 주입 불가

다만 **백엔드 PR의 계약과 구현이 일치하는 것은 대조 확인**했습니다 — FCM 키, 소켓 페이로드 형태, `summitDistance`/`summitEstimatedTime` nullable 여부 네 가지 모두.

검증하려면 `/api/notifications/test`로 아래를 발송하는 것이 가장 빠릅니다.

```json
{ "receiverId": <id>, "type": "TRACKING_SUMMIT_REACHED",
  "params": { "milestoneIndex": 3, "milestoneDistanceM": 4137.03 } }
```

**2. `LiveActivityCourseData`를 수기 타입으로 확장했습니다.** `/v3/api-docs`가 401이라 `npm run typegen`이 실패해서, 생성 타입 대신 훅의 수기 타입에 새 필드를 추가했습니다. api-docs 접근이 풀리면 생성 타입 기준으로 정리하는 게 좋겠습니다.

**3. `halfwayMark`는 받되 쓰지 않습니다.** 백엔드가 기존 클라이언트 호환용으로 남긴 값이라 `optional`로만 두고 `milestoneDistanceM`을 씁니다.

## 체크리스트

- [x] 스타일을 `className`(NativeWind)으로 작성했고, 토큰에 있는 값을 하드코딩하지 않았습니다
- [x] 자동 생성 파일을 직접 수정하지 않았습니다
- [x] iOS 시뮬레이터에서 동작을 확인했습니다 (정상까지 거리·소켓 구독까지)
- [ ] API 스펙 변경 반영 — `npm run typegen`이 401로 실패해 수기 타입으로 대체

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 트래킹 중 정상 도달을 자동 감지하고 인증 시트를 표시합니다.
  * 소켓과 푸시 알림을 통해 정상 도달 이벤트를 처리합니다.
  * 서버가 제공하는 정상까지의 거리와 예상 시간을 우선 표시하며, 정보가 없으면 기존 계산 방식을 사용합니다.
  * 하산 구간의 거리와 예상 시간을 별도로 계산해 진행 상황과 코스 카드에 표시합니다.
  * 정상 인증 사진 창을 기존 상태와 연동해 일관되게 유지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->