### PR TITLE
feat: 인증 사진 촬영 후 남은 장수 토스트 표시

### DIFF
--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -206,6 +206,9 @@ export default function TrackingScreen() {
   );
   // 이번 세션에서 촬영한 사진 수 (최대 4장) — 라이브 액티비티 "남은 사진 장수" 표시용
   const [photosTaken, setPhotosTaken] = useState(0);
+  // 업로드 완료 콜백에서 최신 촬영 수를 참조하기 위한 미러
+  const photosTakenRef = useRef(0);
+  photosTakenRef.current = photosTaken;
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
@@ -479,7 +482,9 @@ export default function TrackingScreen() {
             sessionIdRef.current !== restoringPhotoSessionId
           )
             return;
-          setPhotosTaken(Math.min(count, MAX_TRACKING_PHOTOS));
+          const restored = Math.min(count, MAX_TRACKING_PHOTOS);
+          photosTakenRef.current = restored;
+          setPhotosTaken(restored);
         });
       }
       // 강제 종료 후 재진입 시 저장된 이동 경로(회색 polyline) 복원 — 자유기록
@@ -1361,7 +1366,20 @@ export default function TrackingScreen() {
       // 저장 완료 시점에 세션이 이미 바뀌었다면(종료 후 재시작 등) 새 세션 카운터에 반영하지 않음.
       // 이때는 isFreeMode·산 이름도 이미 초기화된 상태라 분석 이벤트도 함께 건너뛴다.
       if (sessionIdRef.current === capturedSessionId) {
-        setPhotosTaken((prev) => Math.min(prev + 1, MAX_TRACKING_PHOTOS));
+        const nextPhotoCount = Math.min(
+          photosTakenRef.current + 1,
+          MAX_TRACKING_PHOTOS,
+        );
+        photosTakenRef.current = nextPhotoCount;
+        setPhotosTaken(nextPhotoCount);
+
+        const remainingPhotos = MAX_TRACKING_PHOTOS - nextPhotoCount;
+        toast.show(
+          remainingPhotos > 0
+            ? `${remainingPhotos}장 더 찍을 수 있어요!`
+            : "인증 사진을 모두 찍었어요!",
+        );
+
         logAnalyticsEvent("clive_photo_taken", {
           tracking_type: isFreeMode ? "free" : "course",
           mountain_name: sessionMountainName,
@@ -1485,6 +1503,7 @@ export default function TrackingScreen() {
     setHikingRecordId(null);
     setPhotoWindow(null);
     setPhotosTaken(0);
+    photosTakenRef.current = 0;
     summitPhotoWindowRef.current = null;
     setCollapsed(false);
     setRecordedCoords([]);

--- a/app/(tabs)/tracking.tsx
+++ b/app/(tabs)/tracking.tsx
@@ -206,9 +206,11 @@ export default function TrackingScreen() {
   );
   // 이번 세션에서 촬영한 사진 수 (최대 4장) — 라이브 액티비티 "남은 사진 장수" 표시용
   const [photosTaken, setPhotosTaken] = useState(0);
-  // 업로드 완료 콜백에서 최신 촬영 수를 참조하기 위한 미러
+  // 업로드 완료 콜백에서 최신 촬영 수를 참조하기 위한 미러.
+  // 렌더 중에는 쓰지 않는다 — React가 렌더를 버리거나 재실행할 수 있어
+  // 커밋되지 않은 값이 새어나갈 수 있다. setPhotosTaken을 호출하는 세 지점
+  // (세션 복원 / 촬영 성공 / 트래킹 종료)에서만 함께 갱신한다.
   const photosTakenRef = useRef(0);
-  photosTakenRef.current = photosTaken;
   // 정상 인증 시점의 photoWindow 저장 — 인증 후 photoWindow가 닫혀도 메타 업로드에 사용
   const summitPhotoWindowRef = useRef<PhotoWindowPayload | null>(null);
   const [showFreeRecordModal, setShowFreeRecordModal] = useState(false);
@@ -1325,6 +1327,16 @@ export default function TrackingScreen() {
       toast.show("인증 사진을 찍을 수 있는 시간이 지났어요.", {
         type: "error",
       });
+      return;
+    }
+
+    // 상한 검사를 촬영 전에 한다. 카운터는 저장 성공 후에 오르므로, 검사가
+    // 없으면 연속 촬영으로 4장을 넘겨 업로드할 수 있다.
+    if (photosTakenRef.current >= MAX_TRACKING_PHOTOS) {
+      toast.show(
+        `인증 사진은 ${MAX_TRACKING_PHOTOS}장까지만 찍을 수 있어요.`,
+        { type: "error" },
+      );
       return;
     }
 


### PR DESCRIPTION
세션당 최대 4장을 찍을 수 있는데 몇 장 남았는지 알 수 없어, 촬영 성공
시점에 남은 장수를 안내한다.

  1번째 → "3장 더 찍을 수 있어요!"
  2번째 → "2장 더 찍을 수 있어요!"
  3번째 → "1장 더 찍을 수 있어요!"
  4번째 → "인증 사진을 모두 찍었어요!"

photosTaken을 ref로 미러링해 업로드 완료 콜백에서 최신 값을 참조한다.
setPhotosTaken의 함수형 업데이터 안에서 토스트를 호출하면 렌더가 두 번
평가될 때 중복 노출될 수 있어 분리했다. 세션 복원·종료 시 ref도 함께
초기화한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 사진 업로드 완료 후에도 최신 촬영 수가 정확히 반영되도록 개선했습니다.
  * 세션 복원 및 초기화 시 촬영 수가 올바르게 유지되도록 수정했습니다.
  * 동일 세션에서 사진 촬영을 최대 4장으로 제한하고, 남은 촬영 가능 횟수를 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->