### PR TITLE
fix: 카카오톡 설치 기기에서도 웹뷰 로그인으로 폴백되던 문제 수정

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -144,6 +144,8 @@ const config = {
             "@react-native-kakao/core",
             {
               nativeAppKey: process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY,
+              ios: { handleKakaoOpenUrl: true },
+              android: { authCodeHandlerActivity: true },
             },
           ],
         ]

--- a/ios/semosan/AppDelegate.swift
+++ b/ios/semosan/AppDelegate.swift
@@ -2,6 +2,7 @@ import Expo
 import FirebaseCore
 import React
 import ReactAppDependencyProvider
+import RNCKakaoUser
 
 @UIApplicationMain
 public class AppDelegate: ExpoAppDelegate {
@@ -42,6 +43,7 @@ FirebaseApp.configure()
     open url: URL,
     options: [UIApplication.OpenURLOptionsKey: Any] = [:]
   ) -> Bool {
+    if RNCKakaoUserUtil.isKakaoTalkLoginUrl(url) { return RNCKakaoUserUtil.handleOpen(url) }
     return super.application(app, open: url, options: options) || RCTLinkingManager.application(app, open: url, options: options)
   }
 

--- a/ios/semosan/Info.plist
+++ b/ios/semosan/Info.plist
@@ -39,11 +39,25 @@
           <string>exp+semosan</string>
         </array>
       </dict>
+      <dict>
+        <key>CFBundleURLName</key>
+        <string>Kakao</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
+          <string>kakaoa3e7a28786d646fd2c68b8faf42529fa</string>
+        </array>
+      </dict>
     </array>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>ITSAppUsesNonExemptEncryption</key>
     <false/>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+      <string>kakaokompassauth</string>
+      <string>kakaolink</string>
+      <string>kakaoplus</string>
+    </array>
     <key>LSMinimumSystemVersion</key>
     <string>12.0</string>
     <key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- `@react-native-kakao/core` config 플러그인에 `nativeAppKey`만 넘기고 `ios`/`android` 옵션이 빠져 있어, 플러그인의 `withIos`/`withAndroid` mod가 아예 실행되지 않았음
- 그 결과 `Info.plist`에 카카오 URL scheme / `LSApplicationQueriesSchemes`가 없었고, `AppDelegate.swift`에도 카카오 로그인 콜백 URL 처리가 없어서 카카오톡 설치 여부와 무관하게 항상 웹뷰(카카오계정) 로그인으로 폴백되던 문제

## Changes
- `app.config.js`: 플러그인에 `ios: { handleKakaoOpenUrl: true }`, `android: { authCodeHandlerActivity: true }` 추가 (근본 수정 — 다음 prebuild부터 android도 자동 반영)
- `ios/semosan/Info.plist`: `kakao{NATIVE_APP_KEY}` URL scheme, `LSApplicationQueriesSchemes`(`kakaokompassauth`, `kakaolink`, `kakaoplus`) 추가
- `ios/semosan/AppDelegate.swift`: `application(_:open:options:)`에 `RNCKakaoUserUtil` 카카오 로그인 URL 처리 추가

`ios/`가 위젯 타겟 때문에 git에 커밋되어 있어, 전체 `expo prebuild` 재실행 대신 플러그인이 생성했을 내용을 그대로 수동 반영했습니다.

## Test plan
- [x] 카카오톡 설치된 iOS 실기기에서 로그인 시 카카오톡 앱으로 전환되어 1초 로그인 되는지 확인
- [x] 카카오톡 미설치 기기에서는 기존처럼 웹뷰 로그인이 정상 동작하는지 확인
