### PR TITLE
fix: 운동 안 함 선택 시 루틴 질문 없이 바로 회원가입 완료

### DIFF
--- a/features/onboarding/components/onboarding-exercise-detail-screen.tsx
+++ b/features/onboarding/components/onboarding-exercise-detail-screen.tsx
@@ -7,13 +7,8 @@ import {
   ExerciseFrequency,
   FREQUENCY_OPTIONS,
 } from "@/features/onboarding/constants/exercise";
+import { useCompleteOnboarding } from "@/features/onboarding/hooks/use-complete-onboarding";
 import { useOnboardingStore } from "@/features/onboarding/store/onboarding-store";
-import { useSubmitOnboardingFromStore } from "@/features/onboarding/store/use-submit-onboarding-from-store";
-import { ApiError } from "@/lib/api";
-import { tokenStorage } from "@/lib/auth/tokenStorage";
-import { authState } from "@/store/auth.store";
-import { toast } from "@/store/toast.store";
-import { router } from "expo-router";
 import { useState } from "react";
 import { ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -26,7 +21,7 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
   const setExerciseFrequency = useOnboardingStore(
     (s) => s.setExerciseFrequency,
   );
-  const { submit, isPending } = useSubmitOnboardingFromStore();
+  const { complete, isPending } = useCompleteOnboarding();
 
   const [selectedDuration, setSelectedDuration] =
     useState<ExerciseDuration | null>(null);
@@ -37,23 +32,7 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
     if (!selectedDuration || !selectedFrequency) return;
     setExerciseDuration(selectedDuration);
     setExerciseFrequency(selectedFrequency);
-    try {
-      await submit();
-      router.replace("/(tabs)");
-    } catch (e) {
-      if (e instanceof ApiError && e.statusCode === 409) {
-        const saved = await tokenStorage.setOnboardingPending(false);
-        if (!saved) {
-          toast.show("잠시후 다시 시도해주십시오.");
-          return;
-        }
-        authState.setAuthenticated();
-        toast.show("이미 등록된 사용자입니다.");
-        router.replace("/(tabs)");
-      } else {
-        toast.show("잠시후 다시 시도해주십시오.");
-      }
-    }
+    await complete();
   }
 
   const exerciseLabel = EXERCISE_LABELS[exerciseType];

--- a/features/onboarding/components/onboarding-exercise-screen.tsx
+++ b/features/onboarding/components/onboarding-exercise-screen.tsx
@@ -4,6 +4,7 @@ import {
   EXERCISE_OPTIONS,
   ExerciseType,
 } from "@/features/onboarding/constants/exercise";
+import { useCompleteOnboarding } from "@/features/onboarding/hooks/use-complete-onboarding";
 import { useOnboardingStore } from "@/features/onboarding/store/onboarding-store";
 import { router } from "expo-router";
 import { useState } from "react";
@@ -13,11 +14,19 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 export function OnboardingExerciseScreen(): React.JSX.Element {
   const insets = useSafeAreaInsets();
   const setExerciseType = useOnboardingStore((s) => s.setExerciseType);
+  const { complete, isPending } = useCompleteOnboarding();
   const [selected, setSelected] = useState<ExerciseType | null>(null);
 
-  function handleNext(): void {
+  async function handleNext(): Promise<void> {
     if (!selected) return;
     setExerciseType(selected);
+
+    // 운동 안 함 선택 시 루틴 질문 없이 바로 회원가입 완료
+    if (selected === "NONE") {
+      await complete();
+      return;
+    }
+
     router.push("/onboarding/exercise-detail");
   }
 
@@ -54,7 +63,11 @@ export function OnboardingExerciseScreen(): React.JSX.Element {
 
       {selected !== null && (
         <View className="px-5 pb-4 pt-3">
-          <LongButton label="다음" onPress={handleNext} />
+          <LongButton
+            label="다음"
+            onPress={handleNext}
+            loading={selected === "NONE" && isPending}
+          />
         </View>
       )}
     </View>

--- a/features/onboarding/hooks/use-complete-onboarding.ts
+++ b/features/onboarding/hooks/use-complete-onboarding.ts
@@ -1,0 +1,32 @@
+import { useSubmitOnboardingFromStore } from "@/features/onboarding/store/use-submit-onboarding-from-store";
+import { ApiError } from "@/lib/api";
+import { tokenStorage } from "@/lib/auth/tokenStorage";
+import { authState } from "@/store/auth.store";
+import { toast } from "@/store/toast.store";
+import { router } from "expo-router";
+
+export function useCompleteOnboarding() {
+  const { submit, isPending } = useSubmitOnboardingFromStore();
+
+  async function complete(): Promise<void> {
+    try {
+      await submit();
+      router.replace("/(tabs)");
+    } catch (e) {
+      if (e instanceof ApiError && e.statusCode === 409) {
+        const saved = await tokenStorage.setOnboardingPending(false);
+        if (!saved) {
+          toast.show("잠시후 다시 시도해주십시오.");
+          return;
+        }
+        authState.setAuthenticated();
+        toast.show("이미 등록된 사용자입니다.");
+        router.replace("/(tabs)");
+      } else {
+        toast.show("잠시후 다시 시도해주십시오.");
+      }
+    }
+  }
+
+  return { complete, isPending };
+}


### PR DESCRIPTION
## Summary
- 온보딩 운동 선택 화면에서 "운동 안 함"을 고르면 루틴(운동 시간/빈도) 질문 페이지로 넘어가지 않고, 바로 온보딩을 제출해 회원가입을 완료하도록 변경
- exercise 화면과 exercise-detail 화면에서 중복되던 "제출 → 409 처리 → 탭 화면 이동" 로직을 `useCompleteOnboarding` 훅으로 추출해 재사용

## Changes
- `features/onboarding/hooks/use-complete-onboarding.ts` (신규): 온보딩 제출 + 이미 등록된 사용자(409) 처리 + `/(tabs)` 이동 공통 로직
- `features/onboarding/components/onboarding-exercise-screen.tsx`: "운동 안 함" 선택 시 `exercise-detail`로 push하지 않고 바로 `complete()` 호출, 버튼 로딩 상태 표시
- `features/onboarding/components/onboarding-exercise-detail-screen.tsx`: 중복 로직을 공통 훅으로 교체 (동작 변화 없음)

`exerciseDuration`/`exerciseFrequency`는 API 타입상 optional이라 "운동 안 함" 케이스에서 값 없이 제출해도 문제없음을 확인했습니다.

## Test plan
- [ ] 온보딩에서 "운동 안 함" 선택 → 바로 회원가입 완료되고 `(tabs)` 화면으로 이동하는지 확인
- [ ] 다른 운동 선택 시 기존처럼 루틴 질문 페이지(exercise-detail)로 이동하는지 확인
- [ ] exercise-detail에서 "시작하기" 완료 흐름이 기존과 동일하게 동작하는지 확인 (409 케이스 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)