### PR TITLE
fix: 새로고침 시 로딩 스피너가 무한으로 도는 문제 수정

### DIFF
--- a/hooks/use-online-manager.ts
+++ b/hooks/use-online-manager.ts
@@ -8,11 +8,10 @@ export function useOnlineManager() {
     // React Query already supports on reconnect auto refetch in web browser
     if (Platform.OS !== "web") {
       return NetInfo.addEventListener((state) => {
-        onlineManager.setOnline(
-          state.isConnected != null &&
-            state.isConnected &&
-            Boolean(state.isInternetReachable),
-        );
+        // isInternetReachable은 reachability 확인 전 null을 반환하는 경우가 잦아
+        // 이를 함께 걸면 실제로는 연결돼 있는데도 오프라인으로 오판해 쿼리가
+        // paused 상태로 멈춘 채 풀리지 않는 문제가 있었다. isConnected만 사용.
+        onlineManager.setOnline(state.isConnected ?? false);
       });
     }
   }, []);


### PR DESCRIPTION
## Summary
- 커뮤니티 등에서 아래로 당겨서 새로고침(pull-to-refresh)하면 로딩 스피너가 사라지지 않고 계속 도는 문제 수정
- 근본 원인: `hooks/use-online-manager.ts`에서 `onlineManager.setOnline()` 판단에 `isInternetReachable`을 함께 걸고 있었는데, 이 값은 NetInfo가 reachability 확인을 마치기 전(특히 와이파이 연결 직후) `null`을 자주 반환함. `Boolean(null)`은 `false`라서 실제로는 인터넷이 정상인데도 앱 전체가 "오프라인"으로 오판됨
- 오프라인으로 판단되면 React Query(`networkMode: 'online'`, 기본값)가 진행 중이던 fetch를 paused 상태로 멈추고, `isFetching`/`isRefetching`이 계속 `true`로 남아 스피너가 멈추지 않음 — NetInfo가 다시 `isInternetReachable: true` 이벤트를 보내주지 않으면 영영 안 풀림
- 커뮤니티 화면만이 아니라 앱 전체 쿼리/새로고침에 영향을 주는 전역 버그였음

## Changes
- `hooks/use-online-manager.ts`: `onlineManager.setOnline()` 판단을 `isConnected`만 사용하도록 변경 (TanStack Query 공식 React Native 가이드 권장 방식, `isInternetReachable`은 신뢰도가 낮아 제외)

## Test plan
- [x] 커뮤니티 화면에서 pull-to-refresh 후 스피너가 정상적으로 사라지는지 확인