### PR TITLE
fix: 주변 맛집 카드에서 식당 이름이 사진 폭을 넘어가던 문제 수정

### DIFF
--- a/features/mountains-detail/components/restaurant-tab.tsx
+++ b/features/mountains-detail/components/restaurant-tab.tsx
@@ -51,11 +51,17 @@ export function RestaurantTab() {
                 ) : (
                   <View className="h-[116px] w-[188px] rounded-[10px] bg-fill-stronger" />
                 )}
-                <View className="gap-0.5">
-                  <Text className="text-label-normal typo-body-1-normal-semi-bold">
+                <View className="w-[188px] gap-0.5">
+                  <Text
+                    numberOfLines={1}
+                    className="text-label-normal typo-body-1-normal-semi-bold"
+                  >
                     {item.name}
                   </Text>
-                  <Text className="text-label-subtler typo-caption-1-medium">
+                  <Text
+                    numberOfLines={1}
+                    className="text-label-subtler typo-caption-1-medium"
+                  >
                     {item.category}
                   </Text>
                 </View>


### PR DESCRIPTION
## Summary
- 산 상세 화면의 "주변 맛집" 탭에서 식당 이름이 길면 사진 폭을 넘어 옆 카드까지 침범하던 문제 수정
- 이름/카테고리 텍스트에 너비 제한과 줄임 처리가 없어서 발생

## Changes
- `features/mountains-detail/components/restaurant-tab.tsx`: 텍스트 영역을 사진과 동일한 `188px`로 고정하고, 이름/카테고리 모두 `numberOfLines={1}`로 한 줄 초과 시 말줄임표 처리

## Test plan
- [x] iOS 시뮬레이터에서 도봉산 상세 → 주변 맛집 탭 확인 — 긴 식당 이름("리본레시피 저탄고지 식단 방학본점")이 "리본레시피 저탄고지 식단..."으로 말줄임표 처리되고 카드 폭이 사진과 일치하는 것 확인
- [x] 다양한 길이의 이름/카테고리에서 레이아웃 깨짐 없는지 추가 확인