### PR TITLE
fix: 온보딩 운동 질문의 답변 목록이 서로 바뀐 문제 수정

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -10,7 +10,7 @@ const hasKakaoNativeAppKey = !!process.env.EXPO_PUBLIC_KAKAO_NATIVE_APP_KEY;
 const config = {
   name: "semosan",
   slug: "semosan",
-  version: "1.1.1",
+  version: "1.2.0",
   orientation: "portrait",
   icon: "./assets/images/app-icon.png",
   scheme: "semosan",

--- a/features/onboarding/components/onboarding-exercise-detail-screen.tsx
+++ b/features/onboarding/components/onboarding-exercise-detail-screen.tsx
@@ -65,17 +65,17 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
         </View>
 
         {/* 섹션 1: 운동 시간 — 빈도 선택 후 위에 노출 */}
-        {selectedDuration !== null && (
+        {selectedFrequency !== null && (
           <View className="mt-8 gap-[10px]">
             <Text className="text-label-normal typo-headline-1-semi-bold">
               운동 시간은 어떻게 되시나요?
             </Text>
-            {FREQUENCY_OPTIONS.map((option) => (
+            {DURATION_OPTIONS.map((option) => (
               <OptionButton
                 key={option.value}
                 label={option.label}
-                selected={selectedFrequency === option.value}
-                onPress={() => setSelectedFrequency(option.value)}
+                selected={selectedDuration === option.value}
+                onPress={() => setSelectedDuration(option.value)}
               />
             ))}
           </View>
@@ -86,12 +86,12 @@ export function OnboardingExerciseDetailScreen(): React.JSX.Element {
           <Text className="text-label-normal typo-headline-1-semi-bold">
             운동 빈도는 어떻게 되시나요?
           </Text>
-          {DURATION_OPTIONS.map((option) => (
+          {FREQUENCY_OPTIONS.map((option) => (
             <OptionButton
               key={option.value}
               label={option.label}
-              selected={selectedDuration === option.value}
-              onPress={() => setSelectedDuration(option.value)}
+              selected={selectedFrequency === option.value}
+              onPress={() => setSelectedFrequency(option.value)}
             />
           ))}
         </View>


### PR DESCRIPTION
"운동 시간은 어떻게 되시나요?"에 빈도 보기(거의 매일, 주 3~4회…)가,
"운동 빈도는 어떻게 되시나요?"에 시간 보기(4시간 이상, 2~4시간…)가
나오고 있었다. 저장되는 값도 반대라 exerciseDuration에 빈도가,
exerciseFrequency에 시간이 들어갔다.

각 섹션이 자기 질문에 맞는 보기와 상태를 쓰도록 바로잡는다.
섹션 노출 조건도 함께 맞춘다 — 항상 보이는 빈도 섹션을 고르면
시간 섹션이 위에 나타난다(기존 동작 유지).

버전을 1.2.0으로 올린다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 온보딩 운동 설정에서 운동 빈도와 운동 시간 선택 항목이 올바르게 표시되고 매핑됩니다.
  * 운동 빈도는 항상 표시되며, 운동 시간은 운동 빈도 선택 후 표시됩니다.

* **기타**
  * 앱 버전이 1.2.0으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->