### PR TITLE
chore: iOS 마케팅 버전을 1.2.0으로 올림

### DIFF
--- a/ios/semosan.xcodeproj/project.pbxproj
+++ b/ios/semosan.xcodeproj/project.pbxproj
@@ -534,7 +534,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -568,7 +568,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.2.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
app.config.js의 version만 1.2.0으로 올렸지만 반영되지 않았다.
ios/ 디렉토리가 있는 bare 프로젝트라 EAS Build가 app.config.js가 아니라 네이티브 프로젝트의 값을 쓴다.

  Specified value for "ios.bundleIdentifier" in app.config.js is ignored
  because an ios directory was detected in the project.

Xcode 프로젝트의 MARKETING_VERSION(Debug/Release 2곳)을 1.2.0으로 올린다. Info.plist의 CFBundleShortVersionString은 $(MARKETING_VERSION)을 참조하므로 함께 반영된다.

빌드 번호는 eas.json의 appVersionSource: "remote" + autoIncrement로 EAS가 계속 관리한다.