### PR TITLE
fix: 앱 재시작 시 포토 리포트 편집/세모피드 공개 상태가 사라지던 문제 수정

### DIFF
--- a/app/record/[id].tsx
+++ b/app/record/[id].tsx
@@ -26,6 +26,10 @@ import { useCourseDetail } from "@/features/tracking/hooks/use-course-detail";
 import { parseCoursePolyline } from "@/features/tracking/utils/parse-course-polyline";
 import { getCenterCoordinate } from "@/utils/get-center-coordinate";
 import { getPhotoReportState, setPhotoReportState } from "@/features/photo-report/photo-report-state";
+import {
+  getRecordSemoFeedState,
+  setRecordSemoFeedState,
+} from "@/features/home/record-semofeed-storage";
 import { useClivePhotos } from "@/features/tracking/hooks/use-clive-photos";
 import { uploadImage } from "@/hooks/use-upload-image";
 import { api } from "@/lib/api";
@@ -217,21 +221,47 @@ export default function RecordScreen() {
       id: createdFeedId,
       isPublic,
     });
+    if (sessionId != null) {
+      setRecordSemoFeedState(sessionId, tab, { id: createdFeedId, isPublic });
+    }
     return createdFeedId;
   };
 
   useFocusEffect(
     useCallback(() => {
-      const saved = getPhotoReportState();
-      // 같은 세션의 상태만 복원 — 다른 기록의 사진이 유입되지 않도록
-      if (saved.sessionId === sessionId && saved.photoSource !== null) {
-        setPhotoReportSource(saved.photoSource);
-      }
-      if (saved.sessionId === sessionId) {
-        setPhotoReportTemplate(saved.templateIndex);
-      }
+      let cancelled = false;
+      getPhotoReportState().then((saved) => {
+        if (cancelled) return;
+        // 같은 세션의 상태만 복원 — 다른 기록의 사진이 유입되지 않도록
+        if (saved.sessionId === sessionId && saved.photoSource !== null) {
+          setPhotoReportSource(saved.photoSource);
+        }
+        if (saved.sessionId === sessionId) {
+          setPhotoReportTemplate(saved.templateIndex);
+        }
+      });
+      return () => {
+        cancelled = true;
+      };
     }, [sessionId]),
   );
+
+  // 세모피드 게시/공개 상태 조회 API가 없어, 이 기기에 저장해둔 상태를 복원
+  useEffect(() => {
+    if (sessionId == null) return;
+    let cancelled = false;
+    (["클라이브", "포토 리포트"] as RecordTab[]).forEach((tab) => {
+      getRecordSemoFeedState(sessionId, tab).then((saved) => {
+        if (cancelled || !saved) return;
+        setSemoFeedIdByTab((prev) => ({ ...prev, [tab]: saved.id }));
+        setIsPublicByTab((prev) => ({ ...prev, [tab]: saved.isPublic }));
+        queryClient.setQueryData(["record-semofeed", sessionId, tab], saved);
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, queryClient]);
 
   // 경로 로드 후 카메라 fit
   useEffect(() => {
@@ -304,6 +334,12 @@ export default function RecordScreen() {
         id: semoFeedId,
         isPublic: nextPublic,
       });
+      if (sessionId != null) {
+        setRecordSemoFeedState(sessionId, activeTab, {
+          id: semoFeedId,
+          isPublic: nextPublic,
+        });
+      }
       queryClient.invalidateQueries({ queryKey: [ENDPOINTS.SEMOFEED] });
 
       if (nextPublic) {
@@ -759,9 +795,9 @@ export default function RecordScreen() {
                   { position: "absolute", top: 16, right: 16 },
                 ]}
                 activeOpacity={0.7}
-                onPress={() => {
+                onPress={async () => {
                   // 현재 표시 중인 사진/템플릿을 상태에 저장 → 편집 화면에서 이어받음
-                  setPhotoReportState({
+                  await setPhotoReportState({
                     sessionId,
                     photoSource: photoReportSource,
                     templateIndex: photoReportTemplate,

--- a/app/record/photo-report-edit.tsx
+++ b/app/record/photo-report-edit.tsx
@@ -66,23 +66,28 @@ export default function PhotoReportEditScreen() {
 
   const { top, bottom } = useSafeAreaInsets();
 
-  // 이전 화면에서 저장한 사진/템플릿 상태로 초기화 (같은 세션일 때만 복원)
-  const savedState = getPhotoReportState();
-  const isSameSession = savedState.sessionId === parsedSessionId;
-  const [selectedTemplate, setSelectedTemplate] = useState(isSameSession ? (savedState.templateIndex ?? 0) : 0);
-  const [photos, setPhotos] = useState<Photo[]>(() => {
-    const src = isSameSession ? savedState.photoSource : null;
-    if (src != null) {
-      const key = typeof src === "number" ? String(src) : src.uri;
-      return [{ key, source: src }];
-    }
-    return [];
-  });
-  const [selectedPhoto, setSelectedPhoto] = useState<number | null>(
-    isSameSession && savedState.photoSource != null ? 0 : null,
-  );
+  const [selectedTemplate, setSelectedTemplate] = useState(0);
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [selectedPhoto, setSelectedPhoto] = useState<number | null>(null);
   const [showExitDialog, setShowExitDialog] = useState(false);
   const scrollRef = useRef<ScrollView>(null);
+
+  // 이전 화면에서 저장한 사진/템플릿 상태로 복원 (같은 세션일 때만)
+  useEffect(() => {
+    getPhotoReportState().then((savedState) => {
+      if (savedState.sessionId !== parsedSessionId) return;
+      setSelectedTemplate(savedState.templateIndex ?? 0);
+      const src = savedState.photoSource;
+      if (src == null) return;
+      const key = typeof src === "number" ? String(src) : src.uri;
+      setPhotos((prev) =>
+        prev.some((p) => p.key === key)
+          ? prev
+          : [{ key, source: src }, ...prev],
+      );
+      setSelectedPhoto(0);
+    });
+  }, [parsedSessionId]);
 
   useEffect(() => {
     if (trackingPhotos.length > 0) {
@@ -256,9 +261,9 @@ export default function PhotoReportEditScreen() {
       <View style={[styles.bottomBar, { paddingBottom: bottom || 16 }]}>
         <TouchableOpacity
           style={styles.doneBtn}
-          onPress={() => {
+          onPress={async () => {
             const photo = selectedPhoto !== null ? photos[selectedPhoto] : null;
-            setPhotoReportState({
+            await setPhotoReportState({
               sessionId: parsedSessionId,
               photoSource: photo ? photo.source : null,
               templateIndex: selectedTemplate,

--- a/features/home/record-semofeed-storage.ts
+++ b/features/home/record-semofeed-storage.ts
@@ -1,0 +1,30 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+type RecordSemoFeedState = { id: number; isPublic: boolean };
+
+function storageKey(sessionId: number, tab: string): string {
+  return `@record_semofeed:${sessionId}:${tab}`;
+}
+
+// 백엔드에 기록별 세모피드 게시 여부를 조회할 API가 없어, 이 기기에서
+// 게시/공개 전환한 상태를 로컬에 저장해 앱 재시작 후에도 복원한다.
+export async function getRecordSemoFeedState(
+  sessionId: number,
+  tab: string,
+): Promise<RecordSemoFeedState | null> {
+  const json = await AsyncStorage.getItem(storageKey(sessionId, tab));
+  if (!json) return null;
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+export async function setRecordSemoFeedState(
+  sessionId: number,
+  tab: string,
+  state: RecordSemoFeedState,
+): Promise<void> {
+  await AsyncStorage.setItem(storageKey(sessionId, tab), JSON.stringify(state));
+}

--- a/features/photo-report/photo-report-state.ts
+++ b/features/photo-report/photo-report-state.ts
@@ -1,19 +1,34 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
 type PhotoReportState = {
   sessionId: number | null;
   photoSource: number | { uri: string } | null;
   templateIndex: number;
 };
 
-let state: PhotoReportState = {
+const STORAGE_KEY = "@photo_report_state";
+const INITIAL_STATE: PhotoReportState = {
   sessionId: null,
   photoSource: null,
   templateIndex: 0,
 };
 
-export function getPhotoReportState(): PhotoReportState {
-  return { ...state };
+// 앱을 종료했다가 다시 들어와도 편집 중이던 포토 리포트(사진/템플릿 선택)를
+// 복원할 수 있도록 인메모리가 아닌 AsyncStorage에 저장한다.
+export async function getPhotoReportState(): Promise<PhotoReportState> {
+  const json = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!json) return INITIAL_STATE;
+  try {
+    return { ...INITIAL_STATE, ...JSON.parse(json) };
+  } catch {
+    return INITIAL_STATE;
+  }
 }
 
-export function setPhotoReportState(updates: Partial<PhotoReportState>) {
-  state = { ...state, ...updates };
+export async function setPhotoReportState(
+  updates: Partial<PhotoReportState>,
+): Promise<void> {
+  const current = await getPhotoReportState();
+  const next = { ...current, ...updates };
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
 }


### PR DESCRIPTION
## Summary
- 포토 리포트에서 사진/템플릿을 편집하거나 세모피드 공개 여부를 토글한 뒤, 앱을 종료했다가 다시 들어오면 그 상태가 전부 초기화되던 문제 수정
- 원인: 두 상태 모두 인메모리(JS 모듈 변수 / React Query 캐시)에만 있었고, 영구 저장소에 쓰이지 않았음
  - 포토 리포트 사진·템플릿 선택: `photo-report-state.ts`가 일반 모듈 변수였음
  - 세모피드 게시 id/공개 여부: `["record-semofeed", ...]` 쿼리 키에 실제 서버 조회(`queryFn`) 없이 로컬에서 `setQueryData`로만 채워지던 캐시였음 — 서버 상태 자체는 정상이어도 앱 재시작 후 다시 불러올 방법이 없었음

## Changes
- `features/photo-report/photo-report-state.ts`: 인메모리 → AsyncStorage 기반으로 전환
- `features/home/record-semofeed-storage.ts` (신규): 기록별 세모피드 id/공개여부를 AsyncStorage에 저장·조회
- `app/record/[id].tsx`, `app/record/photo-report-edit.tsx`: 위 저장소 연동, 관련 호출부 async 처리

## 한계 (백엔드 협의 필요)
같은 기기에서 앱만 재시작하는 흔한 케이스는 해결되지만, **다른 기기/재설치 시에는 여전히 복원되지 않음**. `GET /api/hiking-records/{id}` 응답과 `SemoFeedResponse` 어디에도 둘을 연결하는 필드가 없어서, 서버에 실제로 이미 게시된 세모피드가 있는지 조회할 API 자체가 없기 때문. 근본 해결에는 백엔드 API 추가가 필요함.

## Test plan
- [ ] 포토 리포트 사진/템플릿 편집 → 완료 → 앱 종료 후 재진입 시 편집 상태 복원되는지 확인
- [ ] 세모피드 공개 전환 → 앱 종료 후 재진입 시 공개 상태 유지되는지 확인
- [ ] 클라이브/포토 리포트 탭 각각 독립적으로 복원되는지 확인